### PR TITLE
Potential fix for code scanning alert no. 9: Mismatching new/free or malloc/delete

### DIFF
--- a/Compression/LZMA/C_BCJ.cpp
+++ b/Compression/LZMA/C_BCJ.cpp
@@ -23,8 +23,8 @@ int bcj_x86_de_compress( CALLBACK_FUNC *callback, void *auxdata)
     // Перенесём необработанный остаток данных в начало буфера
     if (RemainderSize>0)                memmove(Buf,Buf+OutSize,RemainderSize);
   }
-Error: delete Buf; return x;            // произошла ошибка при чтении/записи
-Ok:    delete Buf; return FREEARC_OK;   // всё в порядке
+Error: free(Buf); return x;            // произошла ошибка при чтении/записи
+Ok:    free(Buf); return FREEARC_OK;   // всё в порядке
 }
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/DavidLee18/DArc/security/code-scanning/9](https://github.com/DavidLee18/DArc/security/code-scanning/9)

In general, memory allocated with `malloc` must be released with `free`, and memory allocated with `new`/`new[]` must be released with `delete`/`delete[]`. The fix here is to make the allocation–deallocation pair consistent.

The best minimal fix, without changing functionality, is to keep using `malloc` for `Buf` and replace both `delete Buf` calls (in the `Error:` and `Ok:` labels) with `free(Buf)`. This preserves the existing control flow and lifetime of `Buf`, but uses the correct deallocator for the allocation method already in use. No additional headers are needed because `malloc` is already used, implying the appropriate C header is included elsewhere (we are not allowed to modify imports here). All changes are confined to `Compression/LZMA/C_BCJ.cpp` within the provided snippet.

Concretely:
- In `bcj_x86_de_compress`, at the two places where `delete Buf;` appears (lines 26 and 27), replace them with `free(Buf);`.
- Leave the allocation line (`malloc`) and all other logic unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
