### PR TITLE
Potential fix for code scanning alert no. 7: Mismatching new/free or malloc/delete

### DIFF
--- a/Compression/PPMD/SubAlloc.hpp
+++ b/Compression/PPMD/SubAlloc.hpp
@@ -59,7 +59,7 @@ DWORD _STDCALL GetUsedMemory()
 }
 void _STDCALL StopSubAllocator() {
     if ( SubAllocatorSize ) {
-        SubAllocatorSize=0;                 delete[] HeapStart;
+        SubAllocatorSize=0;                 free(HeapStart);
     }
 }
 BOOL _STDCALL StartSubAllocator(UINT t)


### PR DESCRIPTION
Potential fix for [https://github.com/DavidLee18/DArc/security/code-scanning/7](https://github.com/DavidLee18/DArc/security/code-scanning/7)

In general, memory allocated with `malloc`, `calloc`, or `realloc` must be released with `free`, and memory allocated with `new`/`new[]` must be released with `delete`/`delete[]`. Mixing these families leads to undefined behavior.

For this specific case, the best minimal fix is to change the deallocation in `StopSubAllocator` from `delete[] HeapStart;` to `free(HeapStart);`, since `HeapStart` is allocated with `malloc(t)` in `StartSubAllocator`. This preserves all existing semantics while correcting the mismatch. No other behavior needs to change: `SubAllocatorSize` should still be reset to 0, and `HeapStart` is simply freed.

Concretely:
- In `Compression/PPMD/SubAlloc.hpp`, inside the `StopSubAllocator` function (around lines 60–64), replace `delete[] HeapStart;` with `free(HeapStart);`.
- Ensure that `<cstdlib>` or `<stdlib.h>` is available somewhere in the compilation unit so `free` is declared. Since we cannot see or modify other files, and standard headers are typically already included in this project, we will not add new includes here to avoid unnecessary changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
