### PR TITLE
Potential fix for code scanning alert no. 6: Mismatching new/free or malloc/delete

### DIFF
--- a/Compression/LZP/C_LZP.cpp
+++ b/Compression/LZP/C_LZP.cpp
@@ -90,7 +90,7 @@ MATCH_NOT_FOUND:
         }
         k=lzpH(i=lzpC(In),In,HashMask);
     } while (In<InEnd && Out<OutEnd);
-    delete HTable;
+    free(HTable);
     if (Out >= OutEnd)       return 0;
     memmove(Out,OutEnd,OutStart+Size-OutEnd);
     return Size-(OutEnd-Out);


### PR DESCRIPTION
Potential fix for [https://github.com/DavidLee18/DArc/security/code-scanning/6](https://github.com/DavidLee18/DArc/security/code-scanning/6)

In general, to fix a `malloc/delete` mismatch you must pair `malloc` with `free` and `new`/`new[]` with `delete`/`delete[]`. Here, `HTable` is obtained with `malloc`, so the correct way to release it is `free(HTable);` rather than `delete HTable;`.

The minimal, behavior-preserving fix is therefore to change the single deallocation in `LZPEncode` from `delete HTable;` to `free(HTable);`. We should not change the allocation site (within the `LZP_INIT` macro) to `new` because that macro may be used in other contexts (e.g., decoding function not shown), and switching to `new` would then require auditing all deallocation sites. The project already includes `<stdlib.h>` near the top of this file (for the Windows intrinsic rotate), which provides the prototype for `free`, so no additional includes are needed.

Concretely: in `Compression/LZP/C_LZP.cpp`, inside `LZPEncode`, replace line 93 (`delete HTable;`) with `free(HTable);`. No other logic or declarations need to be modified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
