### PR TITLE
Potential fix for code scanning alert no. 5: Mismatching new/free or malloc/delete

### DIFF
--- a/Compression/LZP/C_LZP.cpp
+++ b/Compression/LZP/C_LZP.cpp
@@ -117,7 +117,7 @@ int LZPDecode(BYTE* In,UINT Size,BYTE* Out,int MinLen,int HashSize,int Barrier,i
         }
         k=lzpH(i=lzpC(Out),Out,HashMask);
     } while (In < InEnd);
-    delete HTable;                          return (Out-OutStart);
+    free(HTable);                           return (Out-OutStart);
 }
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/DavidLee18/DArc/security/code-scanning/5](https://github.com/DavidLee18/DArc/security/code-scanning/5)

In general, memory allocated with `malloc` must be released with `free`, and memory allocated with `new` must be released with `delete` (or `delete[]` for arrays). Here, `HTable` is allocated with `malloc` in the `LZP_INIT` macro, so every function that uses `LZP_INIT` must pair that allocation with `free(HTable);`.

The single best fix without changing existing functionality is to replace `delete HTable;` at the end of `LZPDecode` with `free(HTable);`, mirroring what is already done in `LZPEncode`. No other code changes are required: `stdlib.h` is already included earlier (for the rotate intrinsics) and provides the prototype for `free`. The change is localized to the `LZPDecode` function in `Compression/LZP/C_LZP.cpp`, specifically the line currently reading `delete HTable;                          return (Out-OutStart);`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
