### PR TITLE
Potential fix for code scanning alert no. 2: Call to `memset` may be deleted

### DIFF
--- a/Compression/GRZip/ST4.c
+++ b/Compression/GRZip/ST4.c
@@ -44,6 +44,14 @@
 
 #ifndef FREEARC_DECOMPRESS_ONLY
 
+/* Securely zero memory to prevent the compiler from optimizing the clear away. */
+static void secure_memzero(void *v, size_t n)
+{
+  volatile unsigned char *p = (volatile unsigned char *)v;
+  while (n--)
+    *p++ = 0;
+}
+
 sint32 GRZip_ST4_Encode(uint8 * Input, sint32 Size, uint8 * Output)
 {
   sint32    FBP,i;
@@ -128,7 +136,7 @@ sint32 GRZip_ST4_Decode(uint8 * Input, sint32 Size, sint32 FBP)
       T[c]++;
     }
 
-  memset(LastSeen,0,ST_MaxByte*sizeof(sint32));
+  secure_memzero(LastSeen, ST_MaxByte*sizeof(sint32));
 
   for (CStart=0,i=0;i<Size;i++)
   {


### PR DESCRIPTION
Potential fix for [https://github.com/DavidLee18/DArc/security/code-scanning/2](https://github.com/DavidLee18/DArc/security/code-scanning/2)

In general, to prevent a security-critical buffer clear from being optimized away, you must use a “secure” clearing function that compilers are required not to delete, such as `memset_s` from C11’s Annex K or a platform‑specific equivalent. These functions ensure the memory write has observable side effects from the optimizer’s point of view.

In this file, the only flagged call is `memset(LastSeen,0,ST_MaxByte*sizeof(sint32));` at line 131. To fix it without changing behavior, we can introduce a small wrapper function, e.g. `secure_memzero`, that uses a volatile pointer to force the writes to be considered side-effects, and then replace the `memset` with a call to this wrapper. This approach avoids relying on Annex K (`memset_s`), which is not universally available, and does not require changing build flags. The wrapper will be defined in the same file above `GRZip_ST4_Encode`, use only standard types, and not require additional headers beyond what is already included. The rest of the function logic and existing uses of `LastSeen` remain unchanged.

Concretely:
- Add a `static void secure_memzero(void *v, size_t n)` function near the top of `Compression/GRZip/ST4.c`. Inside, cast the pointer to `volatile unsigned char *` and zero the bytes in a loop.
- Replace the `memset(LastSeen,0,ST_MaxByte*sizeof(sint32));` call at line 131 with `secure_memzero(LastSeen, ST_MaxByte * sizeof(sint32));`.
- No other code or imports need to be changed, since `size_t` is already available from standard headers transitively included by the project (and if not, it will typically be via `libGRZip.h`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
