### PR TITLE
Port DArc to MicroHs: pipeline concurrency fixes + arc a -mstoring working

### DIFF
--- a/Arc.hs
+++ b/Arc.hs
@@ -1,3 +1,252 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e82fed5ee5370e566e1727127d3084056b326b8b0ec47ed39ccb4b91cbc3c7d9
-size 16400
+{-# LANGUAGE CPP #-}
+----------------------------------------------------------------------------------------------------
+---- Основной модуль программы.                                                                 ----
+---- Вызывает parseCmdline из модуля Cmdline для разбора командной строки и выполняет каждую    ----
+----   полученную команду.                                                                      ----
+---- Если команда должна обработать несколько архивов, то findArchives дублирует её            ----
+----   для каждого из них.                                                                      ----
+---- Затем каждая команда сводится к выполнению одной из следующих задач:                       ----
+---- * изменение архива  с помощью  runArchiveCreate   из модуля ArcCreate   (команды a/f/m/u/j/d/ch/c/k/rr)
+---- * распаковка архива         -  runArchiveExtract  -         ArcExtract  (команды t/e/x)    ----
+---- * получение листинга архива -  runArchiveList     -         ArcList     (команды l/v)      ----
+---- * восстановление архива     -  runArchiveRecovery -         ArcRecover  (команда r)        ----
+---- которым передаются аргументы в соответствии со спецификой конкретной выполняемой команды.  ----
+----                                                                                            ----
+---- Эти процедуры в свою очередь прямо или косвенно обращаются к модулям:                      ----
+----   ArhiveFileList   - для работы со списками архивируемых файлов                            ----
+----   ArhiveDirectory  - для чтения/записи оглавления архива                                   ----
+----   ArhiveStructure  - для работы со структурой архива                                       ----
+----   ByteStream       - для превращения каталога архива в последовательность байтов           ----
+----   Compression      - для вызова алгоритмов упаковки, распаковки и вычисления CRC           ----
+----   UI               - для информирования пользователя о ходе выполняемых работ :)           ----
+----   Errors           - для сигнализации о возникших ошибках и записи в логфайл               ----
+----   FileInfo         - для поиска файлов на диске и получения информации о них               ----
+----   Files            - для всех операций с файлами на диске и именами файлов                 ----
+----   Process          - для разделения алгоритма на параллельные взаимодействующие процессы   ----
+----   Utils            - для всех остальных вспомогательных функций                            ----
+----------------------------------------------------------------------------------------------------
+module Main where
+
+import Prelude hiding (catch)
+import Control.Concurrent
+import Control.Exception
+#ifdef __GLASGOW_HASKELL__
+import GHC.Conc (setUncaughtExceptionHandler, getNumCapabilities, setNumCapabilities, getNumProcessors)
+#endif
+import Control.Monad
+import Data.List
+import System.Mem
+import System.IO
+
+import Utils
+import Process
+import Errors
+import Files
+import FileInfo
+import Charsets
+import Options
+import Cmdline
+import UI
+import ArcCreate
+import ArcExtract
+import ArcRecover
+#ifdef FREEARC_GUI
+import FileManager
+#endif
+
+
+-- |Главная функция программы
+main         =  (doMain =<< myGetArgs) >> shutdown "" aEXIT_CODE_SUCCESS
+-- |Дублирующая главная функция для интерактивной отладки
+arc cmdline  =  doMain (words cmdline)
+
+-- |Превратить командную строку в набор команд и выполнить их
+doMain args  = do
+#ifdef FREEARC_GUI
+  bg $ do                           -- выполняем в новом треде, не являющемся bound thread
+#endif
+#ifdef __GLASGOW_HASKELL__
+  setUncaughtExceptionHandler handler
+  nprocs <- getNumProcessors
+  ncaps  <- getNumCapabilities
+  when (ncaps < nprocs) $ setNumCapabilities nprocs
+#endif
+  setCtrlBreakHandler $ do          -- Организуем обработку ^Break
+  ensureCtrlBreak "resetConsoleTitle" resetConsoleTitle $ do
+  luaLevel "Program" [("command", args)] $ do
+#ifdef FREEARC_GUI
+  if length args < 2                -- При вызове программы без аргументов или с одним аргументом (именем каталога/архива)
+    then myGUI run args             --   запускаем полноценный Archive Manager
+    else do                         --   а иначе - просто отрабатываем команды (де)архивации
+#endif
+  uiStartProgram                    -- Открыть UI
+  commands <- parseCmdline args     -- Превратить командную строку в список команд на выполнение
+  mapM_ run commands                -- Выполнить каждую полученную команду
+  uiDoneProgram                     -- Закрыть UI
+
+ where
+   handler (ex :: SomeException)  =
+#ifdef FREEARC_GUI
+    mapM_ doNothing $
+#else
+    registerError$ GENERAL_ERROR$
+#endif
+      maybe (maybe [show ex] (\(ErrorCall s) -> [s]) (fromException ex))
+            (\Deadlock -> ["0011 No threads to run: infinite loop or deadlock?"])
+            (fromException ex :: Maybe Deadlock)
+
+
+-- |Диспетчеризует команду и организует её повторение для каждого подходящего архива
+run command@Command
+                { cmd_name            = cmd
+                , cmd_setup_command   = setup_command
+                , opt_scan_subdirs    = scan_subdirs
+                } = do
+  performGC       -- почистить мусор после обработки предыдущих команд
+  setup_command   -- выполнить настройки, необходимые перед началом выполнения команды
+  luaLevel "Command" [("command", cmd)] $ do
+  case cmd of
+    "create" -> findArchives  False           runAdd     command
+    "a"      -> findArchives  False           runAdd     command
+    "f"      -> findArchives  False           runAdd     command
+    "m"      -> findArchives  False           runAdd     command
+    "mf"     -> findArchives  False           runAdd     command
+    "u"      -> findArchives  False           runAdd     command
+    "j"      -> findArchives  False           runJoin    command
+    "cw"     -> findArchives  False           runCw      command
+    "ch"     -> findArchives  scan_subdirs    runCopy    command
+    's':_    -> findArchives  scan_subdirs    runCopy    command
+    "c"      -> findArchives  scan_subdirs    runCopy    command
+    "k"      -> findArchives  scan_subdirs    runCopy    command
+    'r':'r':_-> findArchives  scan_subdirs    runCopy    command
+    "r"      -> findArchives  scan_subdirs    runRecover command
+    "d"      -> findArchives  scan_subdirs    runDelete  command
+    "e"      -> findArchives  scan_subdirs    runExtract command
+    "x"      -> findArchives  scan_subdirs    runExtract command
+    "t"      -> findArchives  scan_subdirs    runTest    command
+    "l"      -> findArchives  scan_subdirs    runList    command
+    "lb"     -> findArchives  scan_subdirs    runList    command
+    "lt"     -> findArchives  scan_subdirs    runList    command
+    "v"      -> findArchives  scan_subdirs    runList    command
+    _ -> registerError$ UNKNOWN_CMD cmd aLL_COMMANDS
+
+
+-- |Ищет архивы, подходящие под маску arcspec, и выполняет заданную команду на каждом из них
+findArchives scan_subdirs   -- искать архивы и в подкаталогах?
+              run_command    -- процедура, которую нужно запустить на каждом найденном архиве
+              command@Command {cmd_arcspec = arcspec} = do
+  uiStartCommand command   -- Отметим начало выполнения команды
+  arclist <- if scan_subdirs || is_wildcard arcspec
+               then find_files scan_subdirs arcspec >>== map diskName
+               else return [arcspec]
+  results <- foreach arclist $ \arcname -> do
+    performGC   -- почистить мусор после обработки предыдущих архивов
+    luaLevel "Archive" [("arcname", arcname)] $ do
+    -- Если указана опция -ad, то добавить к базовому каталогу на диске имя архива (без расширения)
+    let add_dir  =  opt_add_dir command  &&&  (</> takeBaseName arcname)
+    run_command command { cmd_arcspec      = error "findArchives:cmd_arcspec undefined"  -- cmd_arcspec нам больше не понадобится.
+                        , cmd_arclist      = arclist
+                        , cmd_arcname      = arcname
+                        , opt_disk_basedir = add_dir (opt_disk_basedir command)
+                        }
+  uiDoneCommand command results   -- доложить о результатах выполнения команды над всеми архивами
+
+
+-- |Команды добавления в архив: create, a, f, m, u
+runAdd cmd = do
+  msg <- i18n"0246 Found %1 files"
+  let diskfiles =  find_and_filter_files (cmd_filespecs cmd) (uiScanning msg) find_criteria
+      find_criteria  =  FileFind{ ff_ep             = opt_add_exclude_path cmd
+                                , ff_scan_subdirs   = opt_scan_subdirs     cmd
+                                , ff_include_dirs   = opt_include_dirs     cmd
+                                , ff_no_nst_filters = opt_no_nst_filters   cmd
+                                , ff_filter_f       = addFileFilter      cmd
+                                , ff_group_f        = opt_find_group       cmd.$Just
+                                , ff_arc_basedir    = opt_arc_basedir      cmd
+                                , ff_disk_basedir   = opt_disk_basedir     cmd}
+  runArchiveAdd cmd{ cmd_diskfiles      = diskfiles     -- файлы, которые нужно добавить с диска
+                   , cmd_archive_filter = const True }  -- фильтр отбора файлов из открываемых архивов
+
+
+-- |Команда слияния архивов: j
+runJoin cmd@Command { cmd_filespecs = filespecs
+                       , opt_noarcext  = noarcext
+                       } = do
+  msg <- i18n"0247 Found %1 archives"
+  let arcspecs  =  map (addArcExtension noarcext) filespecs   -- добавим к именам расширение по умолчанию (".arc")
+      arcnames  =  map diskName ==<< find_and_filter_files arcspecs (uiScanning msg) find_criteria
+      find_criteria  =  FileFind{ ff_ep             = opt_add_exclude_path cmd
+                                , ff_scan_subdirs   = opt_scan_subdirs     cmd
+                                , ff_include_dirs   = Just False
+                                , ff_no_nst_filters = opt_no_nst_filters   cmd
+                                , ff_filter_f       = addFileFilter      cmd
+                                , ff_group_f        = Nothing
+                                , ff_arc_basedir    = ""
+                                , ff_disk_basedir   = opt_disk_basedir     cmd}
+  runArchiveAdd cmd{ cmd_added_arcnames = arcnames      -- дополнительные входные архивы
+                   , cmd_archive_filter = const True }  -- фильтр отбора файлов из открываемых архивов
+
+
+-- |Команды копирования архива с внесением изменений: ch, c, k. s, rr
+runCopy    = runArchiveAdd                    . setArcFilter fullFileFilter
+-- |Команда удаления из архива: d
+runDelete  = runArchiveAdd                    . setArcFilter ((not.) . fullFileFilter)
+-- |Команды извлечения из архива: e, x
+runExtract = runArchiveExtract pretestArchive . setArcFilter (test_dirs extractFileFilter)
+-- |Команда тестирования архива: t
+runTest    = runArchiveExtract pretestArchive . setArcFilter (test_dirs fullFileFilter)
+-- |Команды получения листинга архива: l, v
+runList    = runArchiveList pretestArchive    . setArcFilter (test_dirs fullFileFilter)
+-- |Команда записи архивного комментария в файл: cw
+runCw      = runCommentWrite
+-- |Команда восстановления архива: r
+runRecover = runArchiveRecovery
+
+-- |Just shortcut
+runArchiveAdd  =  runArchiveCreate pretestArchive writeRecoveryBlocks
+
+{-# NOINLINE findArchives #-}
+{-# NOINLINE runAdd #-}
+{-# NOINLINE runJoin #-}
+{-# NOINLINE runCopy #-}
+{-# NOINLINE runDelete #-}
+{-# NOINLINE runExtract #-}
+{-# NOINLINE runTest #-}
+{-# NOINLINE runList #-}
+
+
+----------------------------------------------------------------------------------------------------
+---- Критерии отбора файлов, подлежащих обработке, для различных типов команд ----------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Установить в cmd предикат выбора из архива обрабатываемых файлов
+setArcFilter filter cmd  =  cmd {cmd_archive_filter = filter cmd}
+
+-- |Отобрать файлы в соответствии с фильтром opt_file_filter, за исключением
+-- обрабатываемых этой командой архивов и временных файлов, создаваемых при архивации
+addFileFilter cmd      =  all_functions [opt_file_filter cmd, not . overwriteF cmd]
+
+-- |Отобрать файлы в соответствии с фильтром fullFileFilter, за исключением
+-- обрабатываемых этой командой архивов и временных файлов, создаваемых при архивации
+extractFileFilter cmd  =  all_functions [fullFileFilter cmd, not . overwriteF cmd]
+
+-- |Отбирает среди файлов, маски которых указаны в командной строке,
+-- соответствующие фильтру opt_file_filter
+fullFileFilter cmd  =  all_functions
+                           [  match_filespecs (opt_match_with cmd) (cmd_filespecs cmd) . fiFilteredName
+                           ,  opt_file_filter cmd
+                           ]
+
+-- |Отбирает обрабатываемые архивы и временные файлы, создаваемые при архивации,
+-- а также файлы, которые могут их перезаписать при распаковке
+overwriteF cmd  =  in_arclist_or_temparc . fiDiskName
+  where in_arclist_or_temparc filename =
+            fpFullname filename `elem` cmd_arclist cmd
+            || all_functions [(temparcPrefix `isPrefixOf`), (temparcSuffix `isSuffixOf`)]
+                             (fpBasename filename)
+
+-- |Добавить в фильтр отбора файлов `filter_f` отбор каталогов в соответствии с опциями команды `cmd`
+test_dirs filter_f cmd fi  =  if fiIsDir fi
+                                then opt_x_include_dirs cmd
+                                else filter_f cmd fi
+

--- a/ArcCreate.hs
+++ b/ArcCreate.hs
@@ -1,3 +1,365 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e37a6f7fae639a6892fe8ef33d92ffba0161b83475fd1555446730066dfd02e0
-size 26060
+{-# LANGUAGE CPP #-}
+----------------------------------------------------------------------------------------------------
+---- Создание и изменение архивов.                                                              ----
+---- Здесь отрабатываются все команды создания и модификации архивов:                           ----
+----   create/a/f/m/u/ch/c/d/k/s/rr/j                                                           ----
+---- Процедура runArchiveCreate создаёт список файлов, которые должны попасть в выходной архив, ----
+----   затем запускает процессы создания структуры выходного архива, чтения входных файлов,     ----
+----   упаковки и записи данных в выходной архив.                                               ----
+---- Эти процессы описаны в ArcvProcessRead.hs и ArcvProcessCompress.hs                         ----
+----------------------------------------------------------------------------------------------------
+module ArcCreate where
+
+import Prelude hiding (catch)
+import Control.Concurrent
+import Control.Exception
+import Control.Monad
+import Data.IORef
+import Data.List
+import System.Mem
+import System.IO
+
+
+
+
+import Utils
+import Files
+import Charsets            (i18n)
+import Process
+import Errors
+import ByteStream
+import FileInfo
+import Options
+import UI
+import ArhiveStructure
+import ArhiveDirectory
+import ArhiveFileList
+import ArcExtract
+import ArcvProcessRead
+import ArcvProcessExtract
+import ArcvProcessCompress
+
+
+-- |Обобщённая команда создания/изменения архива
+runArchiveCreate pretestArchive
+                 writeRecoveryBlocks
+                 command@Command {             -- данные о выполняемой команде:
+      cmd_name            = cmd                  --   название команды
+    , cmd_arcname         = arcname              --   основной архив, который подвергается обновлению
+    , cmd_archive_filter  = archive_filter       --   предикат выбора обрабатываемых файлов из архивов
+    , cmd_added_arcnames  = find_added_arcnames  --   дополнительные входные архивы
+    , cmd_diskfiles       = find_diskfiles       --   файлы, которые нужно добавить с диска
+    , opt_arccmt_str      = arccmt_str           --   новый комментарий к архиву, или
+    , opt_arccmt_file     = arccmt_file          --   файл, из которого читается новый комментарий к архиву
+    , opt_data_compressor = compressor           --   алгоритм сжатия
+    } = do
+  opt_testMalloc command &&& testMalloc  -- напечатать карту памяти
+  -- для суперэкономии памяти: find_files |> buffer 100_000 |> write_to_archive
+
+  -- Создаём sfx-архив сразу с расширением EXE, если только мы не должны обновить уже существующий архив
+  arcname <- do archiveExists <- fileExist arcname
+                if cmd=="create" || not archiveExists
+                  then return$ cmdChangeSfxExt command arcname
+                  else return arcname
+  command <- return command {cmd_arcname = arcname}
+
+  -- Команда "create" всегда создаёт архив с нуля
+  when (cmd=="create")$  ignoreErrors$ fileRemove arcname
+  -- Сообщить пользователю о начале обработки архива и запросить пароль архивации, если необходимо
+  uiStartArchive command =<< limit_compressor command compressor   -- ограничить компрессор объёмом памяти и значением -lc
+  command <- (command.$ opt_cook_passwords) command ask_passwords  -- подготовить пароли в команде к использованию
+  debugLog "Started"
+
+  -- Прочитать служебную информацию основного (обновляемого) архива, включая каталоги.
+  -- Выйти, если архив залочен или содержит recovery info и повреждён.
+  -- Если мы создаём новый архив, то подставить вместо старого "фантом".
+  let abort_on_locked_archive archive footer = do
+          when (ftLocked footer) $
+              registerError$ GENERAL_ERROR ["0310 can't modify archive locked with -k"]
+          pretestArchive command archive footer
+  --
+  uiStage "0249 Reading archive directory"
+  updatingArchive <- fileExist arcname
+  main_archive    <- if updatingArchive
+                       then archiveReadInfo command "" "" archive_filter abort_on_locked_archive arcname
+                       else return phantomArc
+  debugLogList "There are %1 files in archive being updated" (arcDirectory main_archive)
+
+  -- Найти на диске добавляемые архивы (для команды "j") и прочитать их служебную информацию.
+  -- Выйти, если любой из этих архивов содержит recovery info и повреждён.
+  uiStartScanning
+  added_arcnames <- find_added_arcnames
+  debugLogList "Found %1 archives to add" added_arcnames
+  added_archives  <- foreach added_arcnames (archiveReadInfo command "" "" archive_filter (pretestArchive command))
+  debugLogList "There are %1 files in archives to add" (concatMap arcDirectory added_archives)
+  let input_archives = main_archive:added_archives      -- список всех входных архивов
+      closeInputArchives = for input_archives arcClose  -- операция закрытия всех входных архивов
+
+  -- Получить комментарий к создаваемому архиву путём комбинации старых или вводом от пользователя
+  arcComment <- getArcComment arccmt_str arccmt_file input_archives (opt_parseFile command)
+
+  -- Найти добавляемые файлы на диске и отсортировать их список
+  uiStartScanning
+  diskfiles <- find_diskfiles
+  debugLogList "Found %1 files" diskfiles
+  uiStage "0250 Sorting filelist"
+  sorted_diskfiles <- (opt_reorder command &&& reorder) (sortFiles command diskfiles)
+  debugLogList "Sorted %1 files" sorted_diskfiles
+  uiStartScanning  -- очистим счётчик для стадии анализа содержимого файлов
+
+  -- Получить список файлов, которые должны попасть в выходной архив, путём объединения.
+  -- списка файлов из обновляемого архива, списка файлов из добавляемых (командой "j")
+  -- к нему архивов, и файлов с диска. Предварительно эти списки зачищаются от дубликатов.
+  files_to_archive <- joinLists main_archive added_archives sorted_diskfiles command
+  debugLogList "Joined filelists, %1 files" files_to_archive
+
+  if null files_to_archive                    -- Если выходной архив не содержит ни одного файла
+    then do registerWarning NOFILES           -- то сообщить об этом пользователю
+            closeInputArchives                --    закрыть входные архивы
+            ignoreErrors$ fileRemove arcname  --    удалить архив, если он существовал перед операцией (например, в случае команды "arc d archive *")
+            return (1,0,0,0)
+    else do
+
+  -- Враппер, выполняющий постпроцессинг (-d[f], -ac) только если при тестировании созданного архива не было ни одного warning'а
+  postProcessWrapper command $ \postProcess_processDir deleteFiles -> do
+
+  -- Ссылка для возврата результатов работы команды в вызывающую процедуру
+  results <- ref (error "runArchiveCreate:results undefined")
+
+  -- Сохранить mtime архива для опции -tk
+  old_arc_exist <- fileExist arcname
+  arc_time <- if old_arc_exist  then getFileDateTime arcname  else return (error "runArchiveCreate:arc_time undefined")
+
+  -- Для реализации опции -tl мы должны получать списки всех записываемых в архив файлов и найти самый свежий из них.
+  --   Для этого в create_archive_structure_PROCESS передаётся процедура `find_last_time`.
+  --   Ей передают по частям список файлов, записываемых в архив, и она отслеживает самый свежий из них.
+  --   Этой датой будет проштампован архив после окончания архивации.
+  last_time <- ref aMINIMAL_POSSIBLE_DATETIME
+  let find_last_time dir  =  last_time .= (\time -> maximum$ time : map (fiTime . fwFileInfo) dir)
+  let processDir dir      =  do when (opt_time_to_last command) (find_last_time dir)
+                                postProcess_processDir dir  -- враппер постпроцессинга тоже должен получить список успешно сархивированных файлов
+
+  -- Сообщить пользователю о начале упаковки данных
+  uiStartProcessing (map cfFileInfo files_to_archive) 0 0
+  performGC   -- Почистить мусор чтобы освободить как можно больше памяти для алгоритмов сжатия данных
+
+  -- Сначала мы записываем содержимое создаваемого архива во временный файл и лишь затем, при успехе архивации - переименовываем его
+  tempfileWrapper arcname command deleteFiles pretestArchive $ \temp_arcname -> ensureCtrlBreak "closeInputArchives" closeInputArchives $ do   -- Закроем входные архивы по завершении архивации
+    bracketCtrlBreak "archiveClose:ArcCreate" (archiveCreateRW temp_arcname) archiveClose $ \archive -> do
+      writeSFX (opt_sfx command) archive main_archive    -- Начнём создание архива с записи SFX-модуля
+      -- Создание архива - последовательность отдельных процессов, передающих данные друг другу:
+      --   процесса разработки структуры архива и чтения упаковываемых данных
+      --   процесса упаковки и записи сжатых данных в архивный файл
+      -- Между ними создаётся очередь неограниченной длины (|>>>), что позволяет осуществлять read-ahead сжимаемых данных
+      let read_files          =  createArchiveAtructureAndReadFilesProcess command archive main_archive files_to_archive processDir arcComment writeRecoveryBlocks results
+          compress_AND_write  =  compress_AND_write_to_archive_PROCESS archive command
+      backdoor <- newEmptyMVar   -- Этот канал используется для возвращения информации о созданных блоках архива
+      runP (read_files backdoor |>>> compress_AND_write backdoor)
+      --debugLog "Archive written"
+
+  when (opt_keep_time command && old_arc_exist) $ do   -- Если использована опция -tk и это было обновление существующего архива
+    setFileDateTime arcname arc_time                   --   то восстановить mtime архива
+  when (opt_time_to_last command) $ do                 -- Если использована опция -tl
+    setFileDateTime arcname =<< val last_time          --   то установить время&дату модификации архива на время&дату модификации самого свежего файла в нём
+  renameArchiveAsSFX arcname command                   -- Переименуем архив, если в него был добавлен или из него убран SFX-модуль
+  val results                                          -- Возвратим статистику выполнения команды
+
+
+----------------------------------------------------------------------------------------------------
+---- Использование временного файла при создании архива --------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Префикс и суффикс имён создаваемых временных файлов
+temparcPrefix = "$$temparc$$"
+temparcSuffix = ".tmp"
+
+-- |Выполнить `action` с именем временного файла и затем переименовать его
+tempfileWrapper filename command deleteFiles pretestArchive action  =  find 0 >>= doit
+  where -- Найти свободное имя для временного файла
+        find n = do let tempname = (opt_workdir command ||| takeDirectory filename)
+                                   </> (temparcPrefix++show n++temparcSuffix)
+                    found <- fileExist tempname
+                    case found of
+                        True  | n==999    -> registerError$ GENERAL_ERROR ["0311 can't create temporary file"]
+                              | otherwise -> find (n+1)
+                        False             -> return tempname
+
+        -- Выполнить действие, используя временное имя файла, протестировать и затем переименовать окончательный архив
+        doit tempname = do old_file <- fileExist filename      -- Мы выполняем обновление существующего архива?
+                           handleCtrlBreak "fileRemove tempname" (ignoreErrors$ fileRemove tempname) $ do
+                             -- Выполнить архивацию
+                             action tempname
+                             -- Если указана опция "-t", то протестируем только что созданный архив
+                             when (opt_test command) $ test_archive tempname (opt_keep_broken command)
+                           handleCtrlBreak "Keeping temporary archive" (condPrintLineLn "n"$ "Keeping temporary archive "++tempname) $ do
+                             -- Удалить сархивированные файлы, если использована опция -d
+                             deleteFiles
+                             -- Заменить старый архив новым
+                             if old_file
+                                 then fileRemove filename   -- Хорошо бы проверять, что это всё ещё тот самый файл
+                                 else whenM (fileExist filename) $ do  -- Если файл с именем выходного архива создали за время архивации, то сообщить об ошибке
+                                          registerError$ GENERAL_ERROR ["0312 output archive already exists, keeping temporary file %1", tempname]
+                             fileRename tempname filename
+                                 `catch` (\(_::SomeException)-> do
+                                                  condPrintLineLn "n"$ "Copying temporary archive "++tempname++" to "++filename
+                                                  fileCopy tempname filename
+                                                  fileRemove tempname)
+                           -- Если указаны опции "-t" и "-w", то ещё раз протестируем окончательный архив
+                           when (opt_test command && opt_workdir command/="") $ test_archive filename (opt_keep_broken command || opt_delete_files command /= NO_DELETE)
+
+        -- Протестировать архив и выйти, удалив его, если при этом возникли проблемы
+        test_archive arcname keep_broken_archive = do
+            w <- count_warnings $ testArchive command arcname pretestArchive
+            -- Продолжать работу только при отсутствии warning'ов
+            when (w/=0) $ do
+                unless keep_broken_archive (ignoreErrors$ fileRemove arcname)
+                registerError$ GENERAL_ERROR$ if keep_broken_archive
+                                                 then ["0313 archive broken, keeping temporary file %1", arcname]
+                                                 else ["0314 archive broken, deleting"]
+
+
+----------------------------------------------------------------------------------------------------
+---- Постпроцессинг, выполняемый только если архивация прошла успешно ------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Постпроцессинг, выполняемый только если архивация прошла успешно:
+--    удалить успешно сархивированные файлы, если задана опция -d[f]
+--    сбросить у них атрибуты Archive, если задана опция -ac
+postProcessWrapper command archiving = do
+  doFinally uiDoneArchive2 $ do
+  (if opt_delete_files command /= NO_DELETE
+      || opt_clear_archive_bit command then
+     (do files2delete <- ref []
+         dirs2delete <- ref []
+         let processDir filelist0
+               = do let filelist
+                          = map fwFileInfo $ filter isFileOnDisk filelist0
+                        (dirs, files) = partition fiIsDir filelist
+                    evalList files `seq` (files2delete ++= files)
+                    evalList dirs `seq` (dirs2delete ++= dirs)
+             deleteFiles
+               = when (opt_delete_files command /= NO_DELETE)
+                   $ do condPrintLineLn "n" "Deleting successfully archived files"
+                        files <- val files2delete
+                        forM_ files
+                          $ \ fi
+                              -> whenM (checkThatFileWasNotChanged fi)
+                                   $ do ignoreErrors . fileRemove . fpFullname . fiDiskName $ fi
+                        when (opt_delete_files command == DEL_FILES_AND_DIRS)
+                          $ do dirs <- val dirs2delete
+                               for
+                                 (reverse dirs) (ignoreErrors . dirRemove . fpFullname . fiDiskName)
+         result <- archiving processDir deleteFiles
+         when (opt_clear_archive_bit command)
+           $ do condPrintLineLn
+                  "n" "Clearing Archive attribute of successfully archived files"
+                files <- val files2delete
+                for files
+                  $ \ fi
+                      -> whenM (checkThatFileWasNotChanged fi)
+                           $ do clearArchiveBit . fpFullname . fiDiskName $ fi
+         return result)
+  else
+     archiving (\ dir -> return ()) (return ()))
+
+-- |Проверить, что файл не изменился с момента архивации
+checkThatFileWasNotChanged fi = fileWithStatus "checkThatFileWasNotChanged" (fpFullname . fiDiskName$ fi) $ \p_stat -> do
+    size <- stat_size  p_stat
+    time <- stat_mtime p_stat
+    return (size==fiSize fi  &&  time==fiTime fi)
+
+
+----------------------------------------------------------------------------------------------------
+---- Вспомогательные операции ----------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Получить комментарий выходного архива из файла, указанного опцией -z,
+-- или конкатенацией комментариев входных архивов, и вывести его на экран
+getArcComment arccmt_str arccmt_file input_archives parseFile = do
+  -- Используем комментарий, заданный в командной строке, если есть
+  if arccmt_str>""  then do uiPrintArcComment arccmt_str
+                            return arccmt_str
+    else do
+  let old_comment = joinWith "\n\n" $ deleteIf null $ map arcComment input_archives
+  -- В зависимости от значения опции "-z":
+  case arccmt_file of
+  -- Ввести комментарий с stdin
+    ""   -> uiInputArcComment old_comment
+  -- Удалить старый комментарий
+    "-"  -> return ""
+  -- Скопировать существующий комментарий (по умолчанию):
+    "--" -> do uiPrintArcComment old_comment
+               return old_comment
+  -- Прочитать новый комментарий из указанного файла:
+    _    -> do newcmt <- parseFile 'c' arccmt_file >>== joinWith "\n"
+               uiPrintArcComment newcmt
+               return newcmt
+
+-- |Записать SFX-модуль в начало создаваемого архива
+writeSFX sfxname archive old_archive = do
+  let oldArchive = arcArchive old_archive
+      oldSFXSize = ftSFXSize (arcFooter old_archive)
+  case sfxname of                                      -- В зависимости от значения опции "-sfx":
+    "-"      -> return ()                              --   удалить старый sfx-модуль
+    "--"     -> unless (arcPhantom old_archive) $ do   --   скопировать sfx из исходного архива (по умолчанию)
+                  archiveCopyData oldArchive 0 oldSFXSize archive
+    filename -> bracket (archiveOpen sfxname              --   прочитать модуль sfx из указанного файла
+                          `catch` (\(e::SomeException) -> registerError$ GENERAL_ERROR ["0315 can't open SFX module %1", sfxname]))
+                        archiveClose
+                        (\sfxfile -> do size <- archiveGetSize sfxfile
+                                        archiveCopyData sfxfile 0 size archive)
+
+-- |Новое имя архива в соответствии с тем, что мы добавили или наоборот убрали из него SFX-модуль
+cmdChangeSfxExt command  =  changeSfxExt (opt_noarcext command) (opt_sfx command)
+
+changeSfxExt opt_noarcext opt_sfx arcname =
+  case (opt_noarcext, opt_sfx) of
+--  Отключено, поскольку мешало конвертировать в SFX архивы изнутри GUI
+--  (True, _)     -> arcname                -- Не менять расширение, если указана опция --noarcext
+    (_   , "--")  -> arcname                --   или не указана опция "-sfx"
+                                            -- При "-sfx-" расширение меняется на ".arc"
+    (_   , "-")   -> if takeExtension arcname == aDEFAULT_SFX_EXTENSION
+                       then replaceExtension arcname aDEFAULT_ARC_EXTENSION
+                       else arcname
+                                            -- При "-sfx..." расширение меняется на ".exe"
+    _             -> if takeExtension arcname == aDEFAULT_ARC_EXTENSION
+                       then replaceExtension arcname aDEFAULT_SFX_EXTENSION
+                       else arcname
+
+-- |Переименовать архив в соответствии с его SFX-именем
+renameArchiveAsSFX arcname command = do
+  let newname = cmdChangeSfxExt command arcname
+  when (newname/=arcname) $ do
+    condPrintLineLn "n"$ "Renaming "++arcname++" to "++newname
+    fileRename arcname newname
+
+
+
+
+
+
+
+
+
+-- |Протестировать только что созданный архив, находящийся в файле по имени `temp_arcname`
+testArchive command temp_arcname pretestArchive = do
+  let test_command = command{ cmd_name           = "t"           -- Тестируем
+                            , cmd_arcname        = temp_arcname  -- в созданном архиве
+                            , opt_arc_basedir    = ""            -- все файлы
+                            , opt_disk_basedir   = ""            -- ...
+                            , cmd_archive_filter = const True    -- ...
+                            , cmd_subcommand     = True          -- Это подкоманда (тестирование внутри упаковки)
+                            , opt_pretest        = 1             -- не стоит проводить тестирование перед тестированием, но recovery info проверить надо :)
+                            }
+  uiStartSubCommand command test_command
+  results <- runArchiveExtract pretestArchive test_command
+  uiDoneSubCommand command test_command [results]
+
+
+
+
+
+
+
+
+

--- a/ArcExtract.hs
+++ b/ArcExtract.hs
@@ -1,3 +1,280 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0806fddd35e7cc03517f178f201ded12b98d1f7973205920cbaca77992b028b1
-size 16335
+----------------------------------------------------------------------------------------------------
+---- Реализация команд распаковки и получения листинга архива                                   ----
+----------------------------------------------------------------------------------------------------
+module ArcExtract ( runArchiveExtract
+                  , runArchiveList
+                  , runCommentWrite
+                  , formatDateTime
+                  ) where
+
+import Prelude hiding (catch)
+import Control.Exception
+import Control.Monad
+import Data.List
+import Foreign.C.Types
+import Foreign.C.String
+import Foreign.Marshal.Alloc
+import Numeric
+import System.IO.Unsafe
+import System.Posix.Internals
+
+import Process
+import Utils
+import Files
+import FileInfo
+import Charsets            (i18n)
+import Errors
+import Compression         (aINIT_CRC, updateCRC, finishCRC, join_compressor)
+import Options
+import UI
+import ArhiveStructure
+import ArhiveDirectory
+import ArcvProcessExtract
+
+-- |Обобщённая команда распаковки архива
+runArchiveExtract pretestArchive
+                  command@Command{ cmd_arcname        = arcname
+                                 , cmd_archive_filter = archive_filter
+                                 , opt_arc_basedir    = arc_basedir
+                                 , opt_disk_basedir   = disk_basedir
+                                 , opt_arccmt_file    = arccmt_file
+                                 , opt_unParseFile    = unParseFile
+                                 } = do
+    -- Суперэкономия памяти: find_archives -> buffer 10_000 -> read_dir -> buffer 10_000 -> arcExtract
+  doFinally uiDoneArchive2 $ do
+  uiStartArchive command []  -- сообщить пользователю о начале обработки очередного архива
+  uiStage "0249 Reading archive directory"
+  command <- (command.$ opt_cook_passwords) command ask_passwords  -- подготовить пароли в команде к использованию
+  let openArchive = archiveReadInfo command arc_basedir disk_basedir archive_filter (pretestArchive command)
+  bracketCtrlBreak "arcClose:ArcExtract" (openArchive arcname) arcClose$ \archive -> do
+    uiPrintArcComment (arcComment archive)            -- Напечатать комментарий
+    when (arccmt_file/="-" && arccmt_file/="--") $    -- и записать его в файл, указанный опцией -z
+      unParseFile 'c' arccmt_file (arcComment archive)
+    arcExtract command archive
+  uiDoneArchive  -- напечатать и вернуть в вызывающую процедуру статистику выполнения команды
+
+-- |Распаковка архива
+arcExtract command arcinfo = do
+  -- Процедура, используемая для обработки каждого файла
+  let process_file = case cmd_name command of
+                       "t"  -> test_file
+                       _    -> extractFile (fpFullname . fiDiskName) command
+  -- Отобразить в UI общий объём распаковываемых файлов и объём уже распакованного каталога архива
+  uiStartProcessing (map cfFileInfo (arcDirectory arcinfo))  (arcDataBytes arcinfo)  (arcDataCBytes arcinfo)
+  uiStartDirectory
+  uiUnpackedBytes   (arcDirBytes  arcinfo)
+  uiCompressedBytes (arcDirCBytes arcinfo)
+  uiStartFiles 0
+  -- Создадим процесс для распаковки файлов и гарантируем его корректное завершение
+  bracket (runAsyncP$ decompress_PROCESS command (uiCompressedBytes.i))
+          ( \decompress_pipe -> do sendP decompress_pipe Nothing; joinP decompress_pipe)
+          $ \decompress_pipe -> do
+  -- Распаковать каждый распаковываемый файл и выругаться на нераспаковываемые
+  let (filesToSkip, filesToExtract)  =  partition isCompressedFake (arcDirectory arcinfo)
+  forM_ filesToExtract (process_file decompress_pipe)   -- runP$ enum_files |> decompress |> write_files
+  unless (null filesToSkip)$  registerWarning$ SKIPPED_FAKE_FILES (length filesToSkip)
+
+-- |Тестирование одного файла из архива
+test_file decompress_pipe compressed_file = do
+  uiStartFile (cfFileInfo compressed_file)
+  runDecompress decompress_pipe compressed_file (\buf size -> return ())
+  return ()
+
+-- |Распаковка одного файла из архива
+extractFile filename_func command decompress_pipe compressed_file = do
+  let fileinfo  = cfFileInfo compressed_file
+      filename  = filename_func fileinfo
+  if fiIsDir fileinfo
+    then do uiStartFile fileinfo
+            createDirectoryHierarchy filename
+    else do
+  -- Продолжить при условии, что этот файл позволено распаковать
+  whenM (canBeExtracted command filename fileinfo)$ do
+    uiStartFile fileinfo
+    buildPathTo filename
+    outfile  <- fileCreate filename
+    let closeOutfile ok = do   -- Процедура, выполняемая после распаковки файла или при выходе по ^Break
+          fileClose outfile                              -- to do: если используется fileSetSize, то изменить размер файла в соответствии с количеством реально распакованных байт
+          if ok || opt_keep_broken command
+            then do setFileDateTimeAttr filename fileinfo   -- Распаковано успешно или нужно сохранять даже файлы, распакованные с ошибками
+                    when (opt_clear_archive_bit command) $ clearArchiveBit filename            -- Опция -ac - очистить атрибут Archive после распаковки
+            else fileRemove filename                     -- Удалить файл, распакованный с ошибками
+    do  --fileSetSize outfile (fiSize fileinfo)  -- Приличная ОС при этом выделит на диске место для файла одним куском
+        handleCtrlBreak "closeOutfile" (closeOutfile False) $ do
+          ok <- runDecompress decompress_pipe compressed_file (fileWriteBuf outfile)
+          closeOutfile ok
+
+
+-- |Эта функция определяет - можно ли извлечь файл из архива?
+-- Ответ зависит от 1) использованных опций (-u/-f/-sync)
+--                  2) наличия на диске предыдущего файла
+--                  3) того, какой из файлов свежее - на диске или в архиве
+--                  4) значения опций "-o" и "y"
+--                  5) ответа пользователя на запрос о перезаписи файла
+--
+canBeExtracted cmd filename arcfile = do
+  diskfile_exist <- fileExist filename
+  if not diskfile_exist                         -- Если файл на диске не существует
+    then return (opt_update_type cmd /= 'f')    -- то извлечь файл из архива можно во всех случаях, кроме '-f'
+    else do
+  fileWithStatus "getFileInfo" filename $ \p_stat -> do
+  diskFileIsDir  <-  stat_mode  p_stat  >>==  s_isdir
+  diskFileTime   <-  stat_mtime p_stat
+  diskFileSize   <-  if diskFileIsDir then return 0
+                                      else stat_size p_stat
+  let arcfile_newer  =  fiTime arcfile > diskFileTime   -- файл в архиве свежее, чем на диске?
+  let overwrite = case opt_update_type cmd of
+                    'f' -> arcfile_newer
+                    'u' -> arcfile_newer
+                    's' -> error "--sync can't be used on extract"
+                    'a' -> True
+  if not overwrite  then return False  else do
+  askOverwrite filename diskFileSize diskFileTime arcfile (opt_overwrite cmd) arcfile_newer
+
+
+{-# NOINLINE runDecompress #-}
+-- |Распаковка файла из архива с проверкой CRC
+runDecompress decompress_pipe compressed_file write_data = do
+  crc <- ref aINIT_CRC                        -- Инициализируем значение CRC
+  let writer buf len = do
+        uiUnpackedBytes  (i len)              -- Информируем пользователя о ходе распаковки
+        uiUpdateProgressIndicator (i len)     -- -.-
+        crc          .<- updateCRC buf len    -- Обновим CRC содержимым буфера
+        write_data       buf len              -- Запишем данные в файл
+        send_backP       decompress_pipe ()   -- И возвратим использованный буфер
+  decompress_file decompress_pipe compressed_file writer
+  acrc  <-  val crc >>== finishCRC            -- Вычислим окончательное значение CRC
+  when (cfCRC compressed_file /= acrc) $ registerWarning$ BAD_CRC (fpFullname$ fiStoredName$ cfFileInfo compressed_file)
+  return (cfCRC compressed_file == acrc)      -- Возвратить True, если всё ок
+
+
+----------------------------------------------------------------------------------------------------
+---- Запись комментария к архиву в файл (команда "cw")                                          ----
+----------------------------------------------------------------------------------------------------
+
+-- |Реализация команды "cw" - запись комментария к архиву в файл
+runCommentWrite command@Command{ cmd_filespecs   = filespecs
+                               , cmd_arcname     = arcname
+                               , opt_unParseFile = unParseFile
+                               } = do
+  doFinally uiDoneArchive2 $ do
+  when (length filespecs /= 1) $
+    registerError$ CMDLINE_SYNTAX "cw archive outfile"
+  let [outfile] = filespecs
+  command <- (command.$ opt_cook_passwords) command ask_passwords  -- подготовить пароли в команде к использованию
+  printLineLn$ "Writing archive comment of "++arcname++" to "++outfile
+  bracket (archiveReadFooter command arcname) (archiveClose.fst) $ \(_,footer) -> unParseFile 'c' outfile (ftComment footer)
+  return (0,0,0,0)
+
+
+----------------------------------------------------------------------------------------------------
+---- Печать листинга архива:                                                                    ----
+----    - для пользователя (команда "l")                                                        ----
+----    - для создания файл-листов (команда "lb")                                               ----
+----    - для других программ (команда "v")                                                     ----
+---------------------------------------------------------------------------------------------------
+
+-- |Обобщённая команда получения листинга архива
+runArchiveList pretestArchive
+               command@Command{ cmd_arclist        = arclist
+                              , cmd_arcname        = arcname
+                              , opt_arc_basedir    = arc_basedir
+                              , cmd_archive_filter = archive_filter
+                              } = do
+  command <- (command.$ opt_cook_passwords) command ask_passwords  -- подготовить пароли в команде к использованию
+  bracket (archiveReadInfo command arc_basedir "" archive_filter (pretestArchive command) arcname) arcClose $
+      archiveList command (null$ tail arclist)
+
+-- |Листинг архива
+archiveList command@Command{ cmd_name = cmd, cmd_arcname = arcname }
+            show_empty
+            arc@ArchiveInfo{ arcDirectory = directory } = do
+  let files = length directory
+      bytes = sum$ map (fiSize . cfFileInfo) directory
+  when (files>0 || show_empty) $ do
+    doFinally uiDoneArchive2 $ do
+    uiStartArchive command [] -- Сообщить пользователю о начале обработки очередного архива
+    let list line1 line2 list_func linelast = do
+                uiPrintArcComment (arcComment arc)
+                myPutStrLn line1
+                myPutStrLn line2
+                compsize <- list_func
+                myPutStrLn linelast
+                myPutStr$   show3 files ++ " files, " ++ show3 bytes ++ " bytes, " ++ show3 compsize ++ " compressed"
+    case cmd of
+      "l" -> list "Date/time                  Size Filename"
+                  "----------------------------------------"
+                  (myMapM terseList directory)
+                  "----------------------------------------"
+
+      "v" -> list "Date/time              Attr            Size          Packed      CRC Filename"
+                  "-----------------------------------------------------------------------------"
+                  (myMapM verboseList directory)
+                  "-----------------------------------------------------------------------------"
+
+      "lb"-> myPutStr$ joinWith "\n"$ map filename directory
+
+      "lt"-> list "              Pos            Size      Compressed   Files Method"
+                  "-----------------------------------------------------------------------------"
+                  (do mapM_ dataBlockList (arcDataBlocks arc)
+                      return (sum$ map blCompSize (arcDataBlocks arc)))
+                  "-----------------------------------------------------------------------------"
+  return (1, files, bytes, -1)
+
+
+-- |Имя файла
+filename = fpFullname . fiStoredName . cfFileInfo
+
+-- |Добавляет к командам листинга информацию о сжатых размерах солид-блоков
+myMapM f = go 0 True undefined
+ where
+  go total first lastSolidBlock [] = return total
+  go total first lastSolidBlock (file:rest) = do
+    let solidBlock = cfArcBlock file
+    let compsize = if first  ||  blPos solidBlock /= blPos lastSolidBlock
+                     then blCompSize solidBlock
+                     else 0
+    f file compsize
+    (go $! total+compsize) False solidBlock rest
+
+
+-- |Однострочный простой листинг файла
+terseList direntry compsize = do
+  let fi = cfFileInfo direntry
+  myPutStrLn$        formatDateTime (fiTime fi)
+           ++ " " ++ right_justify 11 (if fiIsDir fi then "-dir-" else show3$ fiSize fi)
+                  ++ (if cfIsEncrypted direntry  then "*"  else " ")
+                  ++ filename direntry
+
+-- |Однострочный подробный листинг файла
+verboseList direntry compsize = do
+  let fi = cfFileInfo direntry
+  myPutStrLn$        formatDateTime (fiTime fi)
+           ++ " " ++ (if fiIsDir fi  then ".D....."  else ".......")
+           ++ " " ++ right_justify 15 (show$ fiSize fi)
+           ++ " " ++ right_justify 15 (show compsize)
+           ++ " " ++ left_fill  '0' 8 (showHex (cfCRC direntry) "")
+                  ++ (if cfIsEncrypted direntry  then "*"  else " ")
+                  ++ filename direntry
+
+{-
+-- |Многострочный технический листинг файла
+technical_list direntry = do
+  let fi = (cfFileInfo direntry)
+  timestr <- formatDateTime (fiTime fi)
+  myPutStrLn$ ""
+  myPutStrLn$ "Filename: "  ++ (fpFullname$ fiStoredName fi)
+  myPutStrLn$ "Size: "      ++ (show$ fiSize fi)
+  myPutStrLn$ "Date/time: " ++ timestr
+  myPutStrLn$ "CRC: "       ++ showHex (cfCRC direntry) ""
+  myPutStrLn$ "Type: "      ++ if (fiIsDir fi) then "directory" else "file"
+-}
+
+-- |Описание солид-блока
+dataBlockList bl = myPutStrLn$        (if blIsEncrypted bl  then "*"  else " ")
+         ++ " " ++ right_justify 15 (show3$ blPos      bl)
+         ++ " " ++ right_justify 15 (show3$ blOrigSize bl)
+         ++ " " ++ right_justify 15 (show3$ blCompSize bl)
+         ++ " " ++ right_justify  7 (show3$ blFiles    bl)
+         ++ " " ++ join_compressor (blCompressor bl)
+

--- a/ArcRecover.hs
+++ b/ArcRecover.hs
@@ -1,3 +1,485 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2dee9ee88d3fc8c034e7458c254c4d2e5a328cf6d035af63b9cb61d784d6800c
-size 36204
+----------------------------------------------------------------------------------------------------
+---- Защита и восстановление архивов.                                                           ----
+---- Реализация функциональности опции -rr и команды r.                                         ----
+---- Процедура writeRecoveryBlocks записывает в конец архива recovery info,                     ----
+----   необходимую для восстановления сбойных участков в архиве.                                ----
+---- Процедура pretestArchive проверяет, исправлен ли архив, используя recovery info            ----
+----   и/или тестируя содержимое архива                                                         ----
+---- Процедура runArchiveRecovery восстанавливает архив, используя recovery info.               ----
+----------------------------------------------------------------------------------------------------
+{-# LANGUAGE BlockArguments #-}
+module ArcRecover where
+
+import Prelude hiding (catch)
+import Control.Exception
+import Control.Monad
+import Data.Char
+import Data.List
+import Data.Maybe
+import Foreign.Ptr
+import Foreign.C.Types (CChar)
+import Foreign.Marshal
+import Foreign.Marshal.Pool
+import Foreign.Storable
+
+import Utils
+import Files
+import Charsets          (linesCRLF)
+import Errors
+import ByteStream
+import Compression
+import Options
+import UI
+import ArhiveStructure
+import ArhiveDirectory
+import ArcvProcessRead   (writeControlBlock)
+import ArcCreate         (testArchive, writeSFX)
+
+-- |Версии recovery info, которые мы умеем использовать
+aRecVersions = words "0.36 0.39"
+
+-- |Версия recovery info, которую мы записываем в архив, зависит от количества recovery sectors
+aRecVersion 0 = "0.39"
+aRecVersion _ = "0.36"
+
+{-
+recovery info записывается в архив следующим образом:
+
+1. После выбора размера recovery сектора (может быть 512/1k/2k/4k/... байт)
+   весь архив разбивается на сектора этого размера. Для каждого из них
+   подсчитывается CRC32, затем сохраняемая в recovery info.
+2. Одновременно с этим создаётся N recovery секторов, и каждый сектор архива
+   (с номером i) отображается на (i `mod` N)-ый сектор recovery. Все сектора архива,
+   отображённые на один recovery сектор, xor'ятся между собой, и в recovery info
+   записывается результирующий сектор. Таким образом, recovery info включает в
+   себя N recovery секторов, каждый из которых содержит "обобщённую" информацию о
+   соответствующих ему секторах архива.
+
+Проверка целостности архива сводится к подсчёту CRC секторов архива. CRC,
+отличное от оригинального (сохранённого в recovery info), означает, что этот
+сектор содержит сбои.
+
+Восстановление архива возможно, если на один recovery сектор приходится не
+более одного сбойного сектора архива. В этом случае правильное содержимое
+сбойного сектора вычисляется xor'еньем содержимого recovery сектора и всех
+остальных секторов архива, соответствующих этому recovery сектору.
+-}
+
+----------------------------------------------------------------------------------------------------
+---- Запись recovery информации в конец архива -----------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Размер одного RECOVERY сектора в RAR (используется только для разбора опции -rr в RAR-совместимом виде)
+aRarRecSectorSize = 512
+
+-- |Записать в архив блок RECOVERY
+writeRecoveryBlocks archive oldarc init_pos command params bufOps = do
+  rrPos <- archiveGetPos archive   -- Позиция начала recovery info в архиве
+  let -- Размер архива и 1% от него
+      arcsize      = rrPos - init_pos
+      arcsize_1p   = arcsize `divRoundUp` 100
+      -- Используемый по умолчанию объём recovery info зависит от размера архива
+      recommended_rr
+        | arcsize<3*10^5 = "4%"
+        | arcsize<2*10^6 = "2%"
+        | otherwise = "1%"
+      -- Старая настройка объёма recovery info, сохранённая в самом архиве
+      old_recovery = ftRecovery (arcFooter oldarc)
+      -- Новая настройка объёма recovery info, определяемая опцией -rr и старой настройки
+      recovery = case opt_recovery command of
+                   "-"     -> ""                                -- -rr-: отключить добавление к архиву recovery info
+                   "--"    -> old_recovery                      -- по умолчанию: использовать прежнюю настройку опции, занесённую в сам архив
+                   ""      -> old_recovery ||| recommended_rr   -- -rr: использовать прежнюю настройку или рекомендуемый объём, если раньше recovery info в архив не добавлялась
+                   "+"     -> old_recovery ||| recommended_rr   -- -rr+: то же самое
+                   "0.1%"  -> "0*4096"                          -- -rr0.1%: минимальный размер RR для восстановления только через internet
+                   "0.01%" -> "0*65536"                         -- -rr0.01%: ещё меньшая RR
+                   r       -> r                                 -- -rr...: добавить в архив указанный объём recovery info
+  -- Сразу выйти, если звёзды показали, что никакой recovery info добавлять и не нужно
+  if recovery==""  then return ([],"")  else do
+      -- Расшифруем запись опции -rr в виде recovery_amount;sector_size или rec_sectors*sector_size,
+      -- запоминая размер recovery сектора и/или их количество, если эти величины заданы явно
+  let (recovery_amount, explicit_rec_size, explicit_sector_size) = case () of
+        _ | ';' `elem` recovery -> let (r,ss)  = split2 ';' recovery .$ mapSnd (i.parseSize) in
+                                   (r,  Nothing,       Just ss)
+          | '*' `elem` recovery -> let (ns,ss) = split2 '*' recovery .$ mapFstSnd (i.parseSize) in
+                                   ("", Just (ns*ss),  Just ss)
+          | otherwise           -> (recovery, Nothing, Nothing)
+      -- Пересчитаем размер recovery info в байты
+      wanted_rec_size = (case parseNumber recovery_amount 's' of
+                             (num,'b') -> num                        -- уже задан в байтах
+                             (num,'s') -> num*aRarRecSectorSize   -- задан в секторах по 512 байт
+                             (num,'%') -> arcsize_1p * num           -- задан в процентах
+                             (num,'p') -> arcsize_1p * num           -- -.-
+                        -- ... но должен быть не больше половины объёма ОЗУ 8-)
+                        ) `minI` (getPhysicalMemory `div` 2)
+      -- Размер recovery сектора зависит того, сколько процентов от размера архива занимает
+      -- recovery info - чем она больше, тем меньший размер сектора можно сделать,
+      -- не опасаясь, что crc секторов архива будут занимать слишком большую часть recovery info.
+      -- Уменьшение размера recovery сектора увеличивает количество секторов, на которые
+      -- разбивается архив, и следовательно уменьшает вероятность их пересечения на общем
+      -- recovery секторе, то есть увеличивает шансы на восстановление архива.
+      -- При маленьком относительном объёме recovery info (в частности, при большом размере архива),
+      -- размер recovery сектора, наоборот, растёт до бесконечности.
+      -- Зависимость "объём recovery info -> размер сектора" следующая: 4% -> 512, 2% -> 1024, 1% -> 2048...
+      sector_size :: Integer
+      sector_size =  explicit_sector_size `defaultVal`
+                     case wanted_rec_size of
+                       0 -> 4096  -- При задании -rr0% запоминаются только CRC 4-килобайтных секторов, что составит 0.1% от размера архива
+                       _ -> (2^lb (40*arcsize `div` wanted_rec_size)) `atLeast` 512
+      -- Размер уже существующей части архива в секторах
+      arc_sectors :: Integer
+      arc_sectors = i$ arcsize `divRoundUp` sector_size
+      -- Сколько байт займёт запись CRC этих секторов
+      crcs_size0 :: Integer
+      crcs_size0  = arc_sectors * toInteger (sizeOf (undefined::CRC))
+      -- Реальный размер блока recovery
+      rec_size :: Integer
+      rec_size    = explicit_rec_size `defaultVal`
+                    max wanted_rec_size (crcs_size0+0*sector_size)  -- Блок recovery должен вмещать как минимум CRC секторов архива плюс 0 recovery-секторов
+      -- Количество recovery секторов и их общий объём
+      rec_sectors :: Integer
+      rec_sectors = (rec_size - crcs_size0) `divRoundUp` sector_size
+      rec_sectors_size :: Integer
+      rec_sectors_size = rec_sectors*sector_size
+      -- Окончательный размер буфера CRC, включающий CRC самих recovery секторов
+      crcs_size :: Integer
+      crcs_size   = crcs_size0 + rec_sectors * toInteger (sizeOf (undefined::CRC))
+
+  -- Все параметры определены, теперь - реальная работа
+  condPrintLineLn "r"$ "Protecting archive with "++show3 rec_sectors++" recovery sectors ("++showMemory (i rec_sectors*i sector_size::Integer)++")..."
+  uiStage              "0386 Protecting archive from damages"
+  withPool $ \pool -> do
+  sectors    <- (pooledMallocBytes pool (i rec_sectors_size) :: IO (Ptr CChar));   memset sectors 0 (i rec_sectors_size)
+  buf        <- (pooledMallocBytes pool (i sector_size) :: IO (Ptr CChar))
+  crcbuf     <- (pooledMallocBytes pool (i crcs_size+1) :: IO (Ptr CChar))
+  crc_stream <- ByteStream.createMemBuf crcbuf (fromEnum (crcs_size+1))
+  -- Начинаем i не с нуля для того, чтобы последний сектор в архиве отобразился на последний сектор
+  -- в recovery info (это позволяет гарантировать восстановление архива при сбое в любых rec_sectors
+  -- последовательных секторах, включая порчу последовательности секторов, приходящихся
+  -- на конец данных и начало recovery info архива)
+  i' <- ref ((-arc_sectors) `mod` rec_sectors)
+  -- Цикл по секторам уже записанной части архива, вычисляющий CRC каждого из них,
+  -- и xor-ящий каждый сектор в соответствующий ему сектор recovery info
+  archiveSeek archive init_pos
+  uiWithProgressIndicator command arcsize $ do
+    doChunks arcsize sector_size $ \(bytes :: Int) -> do
+      uiUpdateProgressIndicator (i bytes)
+      failOnTerminated
+      len <- archiveReadBuf archive buf bytes
+      crc <- calcCRC buf bytes
+      ByteStream.write crc_stream crc
+      when (rec_sectors>0) $ do
+        idx <- val i';  i' =: (idx+1) `mod` rec_sectors
+        let idxI = fromEnum idx
+        let ssI = fromEnum sector_size
+        memxor (sectors `plusPtr` (idxI * ssI)) buf bytes
+  -- Записать CRC самих recovery секторов
+  forM_ [0..rec_sectors-1] $ \i -> do
+    let iI = fromEnum i
+    let ssI2 = fromEnum sector_size
+    crc <- calcCRC (sectors `plusPtr` (iI * ssI2)) sector_size
+    ByteStream.write crc_stream crc
+  -- Записать два отдельных блока recovery - с xor-секторами и с CRC блоков архива.
+  -- Во второй блок также включается служебная информация, описывающая структуру recovery info
+  -- (номер версии, размер и адрес начала в архиве защищаемой информации,
+  --  количество секторов и размер сектора в каждом "отделении", на которые разбита recovery info).
+  -- При этом для восстановления данных достаточно целостности только второго, меньшего блока
+  -- (запоротые recovery сектора из первого блока просто фактически не будут использоваться,
+  --  поскольку CRC секторов данных, "восстановленных" с их участием, просто будет неправильным).
+  archiveSeek archive rrPos
+  r0 <- writeControlBlock RECOVERY_BLOCK aNO_COMPRESSION params $ do
+          archiveWriteRecoveryBlock (Nothing::Maybe Int) sectors (fromEnum rec_sectors_size) bufOps
+  curpos <- archiveGetPos archive
+  let addinfo = (aRecVersion rec_sectors, arcsize::Integer, curpos-init_pos::Integer, [(toInteger sector_size, toInteger rec_sectors)])
+  r1 <- writeControlBlock RECOVERY_BLOCK aNO_COMPRESSION params $ do
+          archiveWriteRecoveryBlock (Just addinfo) crcbuf (fromEnum crcs_size) bufOps
+  return ([r0,r1],recovery)
+
+
+-- |Чтение заголовка recovery info, описывающего все её параметры
+readControlInfo crc_stream crcs_block = do
+  ByteStream.rewindMemory crc_stream
+  -- Второй recovery блок помимо CRC секторов архива также содержит мета-информацию.
+  -- Для защиты от её неправильной интепретации она начинается с номера версии программы,
+  -- совместимой с этим форматом мета-информации
+  version <- ByteStream.read crc_stream
+  if version `notElem` aRecVersions  then return$ Left version  else do
+  -- Прочитаем заголовок второго recovery блока, содержащий все необходимые данные
+  -- об этой recovery информации - начальный адрес защищённых данных (закодирован как
+  -- смещение (offset) от начала второго recovery блока до начала защищённых данных),
+  -- размер защищённых данных (arcsize), и наконец размер и количество recovery секторов
+  -- в каждом "отделении" recovery информации
+  (arcsize::Integer, offset::Integer) <- ByteStream.read crc_stream
+  let init_pos = blPos crcs_block - offset
+  (sector_size,rec_sectors):_ <- ByteStream.read crc_stream >>== mapFsts fromInteger >>== mapSnds fromInteger
+  return$ Right (init_pos, arcsize, sector_size, rec_sectors)
+
+
+----------------------------------------------------------------------------------------------------
+---- Проверка архива при помощи recovery информации ------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Проверка целостности архива, содержащего recovery информацию,
+-- и аварийный выход, если архив содержит сбои
+pretestArchive command archive footer = do
+  when (opt_pretest command>0) $ do
+    result <- withPool$ scanArchive command archive footer False
+    case result of
+      Just (_, sector_size, bad_crcs)  |  bad_sectors <- genericLength bad_crcs, bad_sectors>0
+              -> registerError$ BROKEN_ARCHIVE (archiveName archive) ["0352 found %1 errors (%2)", show3 bad_sectors, showMemory (bad_sectors*sector_size)]
+      Just _  -> condPrintLineLn "r" "Archive integrity OK"
+      _       -> return ()
+    -- Полное тестирование архива только при -pt3 или при -pt2 и отсутствии recovery информации в архиве
+    when (opt_pretest command==3 || (opt_pretest command==2 && isNothing result)) $ do
+      w <- count_warnings $ do
+               testArchive command (cmd_arcname command) doNothing3
+      -- Продолжать работу только при отсутствии warning'ов
+      when (w>0) $ do
+        registerError$ BROKEN_ARCHIVE (archiveName archive) ["0353 there were %1 warnings due archive testing", show w]
+
+
+-- |Просканировать архив и возвратить список сбойных секторов
+-- (определяются сравнением CRC каждого сектора с его CRC, сохранённым во втором recovery блоке)
+scanArchive command archive footer recovery pool = do
+  -- Найдём recovery блоки в архиве. Нынешняя версия может обработать только одну пару recovery блоков
+  let recovery_blocks  =  filter ((RECOVERY_BLOCK==) . blType) (ftBlocks footer)
+  if length recovery_blocks < 2  then return Nothing  else do
+  let sectors_block:crcs_block:_ = recovery_blocks
+  when (length recovery_blocks > 2) $ do
+      registerWarning$ GENERAL_ERROR ["0344 only first of %1 recovery records can be processed by this program version. Please use newer versions to process the rest", show (length recovery_blocks `div` 2)]
+
+  -- Прочитаем RECOVERY блоки (сектора+crcs)
+  sectors <- if recovery  then archiveBlockReadUnchecked pool sectors_block
+                          else return$ error "scanArchive:sectors undefined"
+  (crcbuf, crcsize) <- archiveBlockReadAll pool (error "encrypted recovery block") crcs_block
+  crc_stream <- ByteStream.openMemory crcbuf crcsize
+
+  -- Прочитаем заголовок crc_stream, содержащий все необходимые данные об этой recovery информации
+  info <- readControlInfo crc_stream crcs_block
+  case info of
+    Left version -> do registerWarning$ GENERAL_ERROR ["0345 you need FreeArc %1 or above to process this recovery info", version]
+                       return Nothing
+    Right (init_pos, arcsize, sector_size, rec_sectors) -> do
+      -- От-xor-рить секторы архива с соответствующими секторами RECOVERY блока.
+      -- Занести в bad_crcs список секторов архива, чьи CRC не совпадают с контрольными.
+      condPrintLineLn "r"$ show3 rec_sectors++" recovery sectors ("++showMemory (i rec_sectors*i sector_size::Integer)++") present"
+      condPrintLineLn "r" "Scanning archive for damages..."
+      uiStage              "0385 Scanning archive for damages"
+      archiveSeek archive init_pos
+      buf <- pooledMallocBytes pool sector_size
+      -- Размер защищённой части архива в секторах
+      let arc_sectors = i$ arcsize `divRoundUp` sector_size
+      -- i начинается не с нуля потому что (см. в writeRecoveryBlocks)
+      i' <- ref ((-arc_sectors) `mod` rec_sectors);  n' <- ref 0
+      bad_crcs <- withList $ \bad_crcs -> do
+        -- Цикл по секторам архива с отображением индикатора прогресса
+        uiWithProgressIndicator command arcsize $ do
+          doChunks arcsize sector_size $ \(bytes :: Int) -> do
+            uiUpdateProgressIndicator (i bytes)
+            failOnTerminated
+            len <- archiveReadBuf archive buf bytes
+            -- Xor'им сектора, соответствующие одному recovery сектору, чтобы получить данные для восстановления сбойного сектора
+            when (recovery && rec_sectors>0) $ do
+              idx <- val i';  i' =: (idx+1) `mod` rec_sectors
+              let idxI4 = fromEnum idx
+              let ssI4 = fromEnum sector_size
+              memxor (sectors `plusPtr` (idxI4 * ssI4)) buf bytes
+            -- Сохраняем номера сбойных секторов (чьи CRC не совпадают с контрольным)
+            n <- val n';  n `seq` (n' =: n+1)
+            crc          <- calcCRC buf bytes
+            original_crc <- ByteStream.read crc_stream
+            when (crc/=original_crc) $ do
+              bad_crcs <<= n
+      return$ Just ((crcs_block,crc_stream,sectors,buf), sector_size, bad_crcs)
+
+
+----------------------------------------------------------------------------------------------------
+---- Восстановление архива с помощью recovery информации -------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Команда восстановления запорченного архива
+runArchiveRecovery command@Command{ cmd_filespecs       = filespecs
+                                  , cmd_arcname         = arcname
+                                  , opt_original        = opt_original
+                                  , opt_save_bad_ranges = opt_save_bad_ranges
+                                  } = do
+  doFinally uiDoneArchive2 $ do
+  uiStartArchive command []
+  let arcname_fixed = arcname `replaceBaseName` ("fixed."++takeBaseName arcname)
+  whenM (fileExist arcname_fixed) $ do
+    registerError$ GENERAL_ERROR ["0346 file %1 already exists", arcname_fixed]
+  command <- (command.$ opt_cook_passwords) command ask_passwords  -- подготовить пароли в команде к использованию
+  withPool $ \pool -> do   -- используем пул памяти, чтобы автоматически освободить выделенные буферы при выходе
+  bracketCtrlBreak "archiveClose1:ArcRecover" (archiveReadFooter command arcname) (archiveClose.fst) $ \(archive,footer) -> do
+    -- Первый этап - сканирование архива и составление списка сбойных секторов
+    result <- scanArchive command archive footer True pool
+    if isNothing result
+        then registerError$ GENERAL_ERROR ["0347 archive can't be recovered - recovery data absent or corrupt"]
+        else do
+    -- Переходим к восстановлению данных
+    let Just ((crcs_block,crc_stream,sectors,buf),_,bad_crcs) = result
+    if null bad_crcs  then condPrintLine "n" "Archive ok, no need to restore it!"  else do
+    -- Прочитаем заголовок crc_stream, содержащий все необходимые данные об этой recovery информации
+    Right (init_pos, arcsize, sector_size, rec_sectors) <- readControlInfo crc_stream crcs_block
+
+    -- Составить список секторов, которые мы сможем восстановить, и тех, которые претендуют
+    -- на один и тот же recovery сектор и потому не могут быть восстановлены
+    let (recoverable,bad)  =  case rec_sectors of
+           0 -> ([], bad_crcs)      -- если RR не содержит recovery sectors, то ни один сектор архива не может быть восстановлен с их помощью :D
+           _ -> bad_crcs .$ sort_and_groupOn (`mod` rec_sectors)   -- сгруппировать вместе те сбойные сектора, которые приходятся на один сектор RECOVERY
+                         .$ partition (null.tail)                  -- отделить группы, где только один элемент (сектор, который удастся однозначно восстановить), от других
+                         .$ mapFst concat .$ mapSnd concat
+        bad_sectors = genericLength bad
+        recoverable_sectors = genericLength recoverable
+
+    -- Эта процедура записывает в файл список запорченных диапазонов байт в архиве
+    let arcPos sector = sector*sector_size+init_pos
+    let save_bad_ranges bad_sectors = do
+          when (opt_save_bad_ranges>"") $ do
+            let byte_range sector = show start++"-"++show end
+                                      where start = arcPos sector
+                                            end   = start+sector_size-1
+            filePutBinary opt_save_bad_ranges (joinWith "," $ map byte_range bad_sectors)
+
+    -- Если мы ничего не можем восстановить - нам остаётся только застрелиться :)
+    originalName <- originalURL opt_original arcname
+    when (null recoverable && originalName=="") $ do
+      save_bad_ranges bad
+      registerError$ GENERAL_ERROR ["0348 %1 unrecoverable errors (%2) found, can't restore anything!",
+                                    show3 bad_sectors, showMemory (bad_sectors*sector_size)]
+
+    -- Скопируем файл, подставляя правильное содержимое вместо сбойных секторов из списка recoverable (bad сектора восстановить невозможно из-за отсутствия однозначности)
+    condPrintLineLn "n"$ show3 recoverable_sectors++" recoverable errors ("++showMemory (recoverable_sectors*sector_size)++") "
+                         ++(bad &&& "and "++show3 bad_sectors++" unrecoverable errors ("++showMemory (bad_sectors*sector_size)++") ")
+                         ++"found"
+    archiveFullSize <- archiveGetSize archive
+    condPrintLineLn "n"$ "Recovering "++showMem archiveFullSize++" archive..."
+    uiStage              "0387 Recovering archive"
+    errors' <- ref bad
+    -- Переходим к созданию архива с восстановленными данными
+    handleCtrlBreak  "fileRemove arcname_fixed" (ignoreErrors$ fileRemove arcname_fixed) $ do
+    bracketCtrlBreak "archiveClose2:ArcRecover" (archiveCreateRW arcname_fixed) archiveClose $ \new_archive -> do
+    withJIT (fileOpen =<< originalURL originalName arcname) fileClose $ \original' -> do   -- Лениво откроем файл, откуда можно загрузить корректные данные
+    writeSFX (opt_sfx command) new_archive (dirlessArchive archive footer)   -- Начнём создание архива с записи SFX-модуля
+    archiveSeek archive init_pos
+    -- Размер защищённой части архива в секторах
+    let arc_sectors = i$ arcsize `divRoundUp` sector_size
+    -- i начинается не с нуля потому что (см. в writeRecoveryBlocks)
+    i' <- ref ((-arc_sectors) `mod` rec_sectors);  n' <- ref 0
+    originalErr <- init_once
+
+    -- Цикл по секторам восстанавливаемого архива с отображением индикатора прогресса
+    uiWithProgressIndicator command arcsize $ do
+      doChunks arcsize sector_size $ \(bytes :: Int) -> do
+        uiUpdateProgressIndicator (i bytes)
+        failOnTerminated
+        idx <- val i';  when (rec_sectors>0) $  do idx `seq` (i' =: (idx+1) `mod` rec_sectors)
+        n <- val n';  n' =: n+1
+        len <- archiveReadBuf archive buf bytes
+        original_crc <- ByteStream.read crc_stream
+
+        -- Если это один из восстанавливаемых секторов, то восстановим его содержимое,
+        -- отксорив его с контрольным сектором, который сейчас содержит как раз
+        -- необходимые для восстановления данные
+        when (n `elem` recoverable) $ do
+          let idxI2 = fromEnum idx
+          let ssI3 = fromEnum sector_size
+          let do_xor = memxor buf (sectors `plusPtr` (idxI2 * ssI3)) bytes
+          do_xor
+          -- Если CRC и после этого не совпало (это возможно при ошибке в самом контрольном секторе),
+          -- то восстановим исходное содержимое сектора и запомним,
+          -- что в архиве остались невосстановленные сектора
+          crc <- calcCRC buf bytes
+          when (crc/=original_crc) $ do
+            do_xor;  errors' .= (n:)
+
+        -- Если это сбойный сектор, невосстановимый с помощью имеющейся информации,
+        -- то просто выкачаем его заново (если указано --original)
+        errors <- val errors'
+        when (originalName>"" && n `elem` errors) $ do
+          -- Прежде всего проверим, что original-файл удалось открыть
+          eitherM_ (try$ valJIT original' :: IO (Either SomeException File))
+            ( \exception -> once originalErr$ registerWarning$ GENERAL_ERROR ["0349 can't open original at %1", originalName])
+            $ \original  -> do
+          -- Теперь проверим, что его размер совпадает с восстанавливаемым архивом
+          dwnl_size <- fileGetSize original
+          if dwnl_size /= archiveFullSize
+            then once originalErr$ registerWarning$ GENERAL_ERROR
+                      ["0350 %1 has size %2 so it can't be used to recover %3 having size %4",
+                       originalName, show3 dwnl_size, arcname, show3 archiveFullSize]
+            else do
+          -- Читаем из original сбойный сектор
+          allocaBytes bytes $ \temp -> do
+          fileSeek    original (arcPos n)
+          fileReadBuf original temp bytes
+          -- Если прочитанный сектор имеет верную CRC - заменим им сектор, прочитанный из исходного архива
+          crc <- calcCRC temp bytes
+          when (crc==original_crc) $ do
+            copyBytes buf temp bytes
+            errors' .= delete n
+
+        -- Записать [восстановленный] сектор в новый архив
+        archiveWriteBuf new_archive buf bytes
+
+    -- Скопировать блоки recovery (а точнее, вообще весь остаток старого архивного файла после защищённых данных)
+    pos <- archiveGetPos archive
+    archiveCopyData archive pos (archiveFullSize-pos) new_archive
+
+    condPrintLineLn "n"$ "Recovered archive saved to "++arcname_fixed
+    errors <- val errors'
+    save_bad_ranges errors
+    when (errors>[]) $ do
+      let errnum = genericLength errors
+      registerWarning$ GENERAL_ERROR ["0351 %1 errors (%2) remain unrecovered", show3 errnum, showMemory (errnum*sector_size)]
+  return (1,0,0,0)
+
+
+
+-- |Вычислить URL оригинала, исходя из содержимого опции --original и имени архива
+originalURL opt_original arcname =
+  case opt_original of
+    "--"         -> return ""              -- отключено
+    '?':command  -> run_command command    -- URL возвращается выполнением команды `command arcname`
+    ""           -> auto_url               -- URL определяется автоматически из files.bbs/descript.ion
+    url          -> return url             -- URL указан явно
+ where
+
+  -- Выполнить команду и вернуть её вывод в качестве URL
+    run_command command  =  runProgram (command++" "++arcname)
+                          >>== head.linesCRLF
+
+  -- Автоматически подбираемый URL по описанию архива в files.bbs/descript.ion
+    auto_url = mapMaybeM try_descr (words "files.bbs descript.ion") >>== catMaybes >>== listToMaybe >>== fromMaybe ""
+
+  -- Поискать URL архива в файле описаний descr
+    try_descr descr = do
+      let descrname = takeDirectory arcname </> descr
+          basename  = takeFileName  arcname
+      fileExist descrname >>= bool (return Nothing) (do
+          fileGetBinary descrname >>== linesCRLF
+      -- Строки, начинающиеся с пробелов, надо прибавлять к предыдущим (это строки продолжения описаний)
+          >>== joinContLines ""
+      -- Искомая строка в files.bbs может начинаться с name.arc или с "The Name.arc", за которым идёт пробел
+          >>== listToMaybe . concatMap (filter (isSpace.head) . catMaybes . (\x -> [x.$startFrom basename
+                                          ,x.$startFrom ("\""++basename++"\"")]))
+      -- Выделим URL из строки с описанием
+          >>== fmap findURL)
+
+      where
+        findURL s = firstJust$ map (getURL s)$ strPositions s "://"
+      -- Выделить из строки s URL, чей "://" находится по смещению n
+        getURL s n = let (pre,post) = splitAt n s
+                         prefix    = reverse$ takeWhile isURLPrefix$ reverse pre
+                         postfix   = takeWhile isURLChar$ drop 3 post
+                     in
+                         prefix &&& postfix &&& Just (prefix++"://"++postfix)
+
+  -- Символы, которые могут встречаться в префиксе или теле URL
+    isURLPrefix = anyf [isAsciiLower, isAsciiUpper]
+    isURLChar   = anyf [flip elem "+-=._/*(),@'$:;&!?%", isDigit, isAsciiLower, isAsciiUpper]
+
+  -- Слить строки продолжения (начинающиеся с пробелов) с предыдущими строками
+    joinContLines prev (x@(c:_):xs) | isSpace c   =   joinContLines (prev++x) xs
+    joinContLines prev (x:xs)                     =   prev : joinContLines x xs
+    joinContLines prev []                         =   [prev]
+

--- a/ArcvProcessCompress.hs
+++ b/ArcvProcessCompress.hs
@@ -1,3 +1,155 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:580ef9075e0cdfa40d6b7f99fc2d83fef6b3bc538513edb92584bc0ea2684cd4
-size 9961
+----------------------------------------------------------------------------------------------------
+---- Процесс упаковки данных и служебной информации архива, и записи упакованных данных в архив.----
+---- Вызывается из ArcCreate.hs                                                                 ----
+----------------------------------------------------------------------------------------------------
+{-# LANGUAGE RecursiveDo #-}
+
+module ArcvProcessCompress where
+
+import Prelude hiding (catch)
+import Control.Concurrent (MVar, Chan)
+import Control.Monad
+import Data.IORef
+import Foreign.C.Types
+import Foreign.Ptr
+
+import Utils
+import Files
+import Errors
+import Process
+import FileInfo
+import Compression
+import Encryption
+import Options           (opt_data_password, opt_headers_password, opt_encryption_algorithm)
+import UI
+import ArhiveStructure
+import ArhiveDirectory
+import ArcvProcessExtract
+import ArcvProcessRead
+
+-- |Процесс упаковки данных и служебной информации архива, и записи упакованных данных в архив.
+-- Также возвращает через backdoor служебную информацию о блоках, созданных при записи архива
+compressAndWriteToArchiveProcess archive command backdoor pipe = do
+
+  -- Процедура отображения в UI входных данных
+  let display (FileStart fi)               =  uiStartFile      fi
+      display (DataChunk buf len)          =  uiUnpackedBytes  (i len)
+      display (CorrectTotals files bytes)  =  uiCorrectTotal   files bytes
+      display (FakeFiles cfiles)           =  uiFakeFiles      (map cfFileInfo cfiles) 0
+      display _                            =  return ()
+
+  -- Процедура записи упакованных данных в архив
+  let write_to_archive (DataBuf buf len) =  do uiCompressedBytes  (i len)
+                                               archiveWriteBuf    archive buf len
+                                               return len
+      write_to_archive  NoMoreData       =  return 0
+
+  -- Процедура копирования целиком солид-блока из входного архива в выходной без переупаковки
+  let copy_block = do
+        CopySolidBlock files <- receiveP pipe
+        let block       = cfArcBlock (head files)
+        uiFakeFiles       (map cfFileInfo files)  (blCompSize block)
+        archiveCopyData   (blArchive block) (blPos block) (blCompSize block) archive
+        DataEnd <- receiveP pipe
+        return ()
+
+  repeat_while (receiveP pipe) notTheEnd $ \case
+    DebugLog str -> debugLog str   -- Напечатать отладочное сообщение
+    DebugLog0 str -> debugLog0 str
+    CompressData block_type compressor real_compressor just_copy -> do
+        case block_type of             -- Сообщим UI какого типа данные сейчас будут паковаться
+            DATA_BLOCK  ->  uiStartFiles (length real_compressor)
+            DIR_BLOCK   ->  uiStartDirectory
+            _           ->  uiStartControlData
+        result <- ref 0   -- количество байт, записанных в последнем вызове write_to_archive
+
+        -- Подсчёт CRC (только для служебных блоков) и количества байт в неупакованных данных блока
+        crc      <- ref aINIT_CRC
+        origsize <- ref 0
+        let update_crc (DataChunk buf len) =  do when (block_type/=DATA_BLOCK) $ do
+                                                     crc .<- updateCRC buf len
+                                                 origsize += i len
+            update_crc _                   =  return ()
+
+        -- Выясним, нужно ли шифрование для этого блока
+        let useEncryption = password>""
+            password = case block_type of
+                         DATA_BLOCK     -> opt_data_password command
+                         DIR_BLOCK      -> opt_headers_password command
+                         FOOTER_BLOCK   -> opt_headers_password command
+                         DESCR_BLOCK    -> ""
+                         HEADER_BLOCK   -> ""
+                         RECOVERY_BLOCK -> ""
+                         _              -> error$ "Unexpected block type "++show (fromEnum block_type)++" in compressAndWriteToArchiveProcess"
+            algorithm = command.$ opt_encryption_algorithm
+
+        -- Если для этого блока нужно использовать шифрование, то добавить алгоритм шифрования
+        -- к цепочке методов сжатия. В реально вызываемый алгоритм шифрования передаётся key и initVector,
+        -- а в архиве запоминаются salt и checkCode, необходимый для быстрой проверки пароля
+        (add_real_encryption, add_encryption_info) <- if useEncryption
+                                                         then generateEncryption algorithm password   -- not thread-safe due to use of PRNG!
+                                                         else return (id,id)
+
+        -- Bind `times` before let so compressa is not in the same mdo rec-group
+        times <- uiStartDeCompression "compression"              -- создать структуру для учёта времени упаковки
+
+        -- Процесс упаковки одним алгоритмом
+        -- Последовательность процессов упаковки, соответствующая последовательности алгоритмов `real_compressor`
+        let real_crypted_compressor = add_real_encryption real_compressor
+            compressa :: Pipe (PairFunc Instruction) (PairFunc (Ptr CChar, Int)) (PairFunc CompressionData) (PairFunc Int) -> IO ()
+            compressa = case real_crypted_compressor of
+                          [m]  -> storingProcess |> de_compress_PROCESS freearcCompress times m 1
+                          ms   -> storingProcess
+                                   |> foldl1 (|>) [ de_compress_PROCESS freearcCompress times m n
+                                                  | (m, n) <- zip (init ms) [1..] ]
+                                   |> de_compress_PROCESS freearcCompress times (last ms) (length ms)
+        -- Процедура упаковки, вызывающая процесс упаковки со всеми необходимыми процедурами для получения/отправки данных
+        let compress_block  =  runFuncP compressa (do x<-receiveP pipe; display x; update_crc x; return x)
+                                                  (send_backP pipe)
+                                                  (write_to_archive .>>= writeIORef result)
+                                                  (val result)
+        -- Выбрать между процедурой упаковки и процедурой копирования целиком солид-блока из входного архива
+        let compress_f  =  if just_copy  then copy_block  else compress_block
+
+        -- Упаковать один солид-блок
+        pos_begin <- archiveGetPos archive
+        compress_f                                             -- упаковать данные
+        ; uiFinishDeCompression times `on` block_type==DATA_BLOCK  -- учесть в UI чистое время операции
+        ; uiUpdateProgressIndicator 0                              -- отметить, что прочитанные данные уже обработаны
+        pos_end   <- archiveGetPos archive
+
+        -- Возвратить в первый процесс информацию о только что созданном блоке
+        -- вместе со списком содержащихся в нём файлов
+        (Directory dir)  <-  receiveP pipe   -- Получим от первого процесса список файлов в блоке
+        crc'             <-  val crc >>== finishCRC     -- Вычислим окончательное значение CRC
+        origsize'        <-  val origsize
+        putP backdoor (ArchiveBlock {
+                           blArchive     = archive
+                         , blType        = block_type
+                         , blCompressor  = compressor .$(not just_copy &&& add_encryption_info) .$compressionDeleteTempCompressors
+                         , blPos         = pos_begin
+                         , blOrigSize    = origsize'
+                         , blCompSize    = pos_end-pos_begin
+                         , blCRC         = crc'
+                         , blFiles       = error "undefined ArchiveBlock::blFiles"
+                         , blIsEncrypted = error "undefined ArchiveBlock::blIsEncrypted"
+                       }, dir)
+
+
+{-# NOINLINE storingProcess #-}
+-- |Вспомогательный процесс, перекодирующий поток Instruction в поток CompressionData
+storingProcess pipe = do
+  let send (DataChunk buf len)  =  do failOnTerminated
+                                      resend_data pipe (DataBuf buf len)
+                                      send_backP pipe (buf,len)
+      send  DataEnd             =  void (resend_data pipe NoMoreData)
+      send _                    =  return ()
+
+  -- По окончании сообщим следующему процессу, что данных больше нет
+  ensureCtrlBreak "send DataEnd" (send DataEnd)$ do
+    -- Цикл перекодирования инструкций
+    repeat_while (receiveP pipe) notDataEnd send
+
+
+-- Compatibility alias
+compress_AND_write_to_archive_PROCESS = compressAndWriteToArchiveProcess

--- a/ArcvProcessExtract.hs
+++ b/ArcvProcessExtract.hs
@@ -1,3 +1,290 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4af10386ac7ead86dc32c3b9ab4b23cb89adcf45d0f4818b131afa9cc1fa878f
-size 24322
+----------------------------------------------------------------------------------------------------
+---- ������� ���������� ������� �������.                                                        ----
+---- ���������� �� ArcExtract.hs � ArcCreate.hs (��� ���������� � ������� �������).             ----
+----------------------------------------------------------------------------------------------------
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE RecursiveDo #-}
+
+module ArcvProcessExtract where
+
+import Prelude hiding (catch)
+import Control.Exception
+import Control.Concurrent (MVar, Chan)
+import Control.Monad
+import Data.Int
+import Data.IORef
+import Data.Maybe
+import Foreign.C.Types
+import Foreign.Ptr
+import Foreign.Marshal.Utils
+import Foreign.Storable
+
+import Utils
+import Errors
+import Process
+import FileInfo
+import Compression
+import CompressionLib (aFREEARC_OK, aFREEARC_ERRCODE_OPERATION_TERMINATED, aFREEARC_ERRCODE_GENERAL, aFREEARC_ERRCODE_NOT_IMPLEMENTED, aFREEARC_ERRCODE_NO_MORE_DATA_REQUIRED, compressionErrorMessage)
+import Encryption
+import Options
+import UI
+import ArhiveStructure
+import ArhiveDirectory
+
+{-# NOINLINE decompressFile #-}
+-- |���������� ����� �� ������ � �������������� ����������� �������� �������������
+-- � ������� ������������� ������ � ������� ������� `writer`
+decompressFile decompress_pipe compressed_file writer = do
+  -- �� �������� ����������� ��������/������ ����� � ����� ��� ������, ��������� ������� ��������� 0 ������ - �������� �������� ������� ;)
+  when (fiSize (cfFileInfo compressed_file) > 0  &&  not (isCompressedFake compressed_file)) $ do
+    sendP decompress_pipe (Just compressed_file)
+    repeat_while (receiveP decompress_pipe) ((>=0) . snd) (uncurry writer)
+    failOnTerminated
+
+{-# NOINLINE decompressProcess #-}
+-- |�������, ��������������� ����� �� �������
+decompressProcess command count_cbytes pipe = do
+  cmd <- receiveP pipe
+  case cmd of
+    Nothing     -> return ()
+    Just cfile' -> do
+      cfile <- ref cfile'
+      state <- ref (error "Decompression state is not initialized!")
+      repeat_until $ do
+        decompressBlock command cfile state count_cbytes pipe
+        operationTerminated' <- val operationTerminated
+        when operationTerminated' $ do
+          sendP pipe (error "Decompression terminated", aFREEARC_ERRCODE_OPERATION_TERMINATED)
+        (x,_,_) <- val state
+        return (x == aStopDecompressThread || operationTerminated')
+
+
+{-# NOINLINE decompressBlock #-}
+-- |����������� ���� �����-����
+decompressBlock command cfile state count_cbytes pipe = mdo
+  cfile' <- (val cfile :: IO FileToCompress)
+  let size        =  fiSize      (cfFileInfo cfile')
+      pos         =  cfPos        cfile'
+      block       =  cfArcBlock   cfile'
+      compressor  =  blCompressor block .$ limitDecompressionMemoryUsage (opt_limit_decompression_memory command)
+      startPos  | compressor==aNO_COMPRESSION  =  pos  -- ��� -m0 �������� ������ �������� � ������ ������� � �����
+                | otherwise                    =  0
+  (state :: IORef (Integer, Integer, Integer)) =: (startPos, pos, size)
+  archiveBlockSeek block startPos
+  bytesLeft <- ref (blCompSize block - startPos)
+
+  let reader buf size  =  do aBytesLeft <- val bytesLeft
+                             let bytes   = minI size aBytesLeft
+                             len        <- archiveBlockReadBuf block buf bytes
+                             bytesLeft  -= i len
+                             count_cbytes  len
+                             return len
+
+  let writer (DataBuf buf len)  =  decompressStep cfile state pipe buf len
+      writer  NoMoreData        =  return 0
+
+  -- �������� ���� � ������ ��������� ������������
+  keyed_compressor <- generateDecryption compressor (opt_decryption_info command)
+  when (any isNothing keyed_compressor) $ do
+    registerError$ BAD_PASSWORD (cmd_arcname command) (cfile'.$cfFileInfo.$storedName)
+
+  -- Создадим конвейер декомпрессии: последний метод цепочки читает первым, первый декодирует последним
+  -- Bind `times` before let so decompressa is not in the same mdo rec-group,
+  -- allowing GHC to generalise the Pipe element type over PipeElement.
+  times <- uiStartDeCompression "decompression"  -- ������� ��������� ��� ����� ������� ����������
+#ifdef __MHS__
+  -- MicroHs: polymorphic let bindings with PipeElement not supported.
+  -- Only single-method decompression is supported; multi-method chains error at runtime.
+  result <- ref 0
+  let decompress1mhs :: CompressionMethod -> Pipe (PairFunc CompressionData) (PairFunc Int) (PairFunc CompressionData) (PairFunc Int) -> IO ()
+      decompress1mhs p pipe = deCompressProcess1 freearcDecompress reader times p 0 pipe
+  case map fromJust keyed_compressor of
+    [p]    -> runFuncP (decompress1mhs p) (fail "decompressBlock::runFuncP" :: IO CompressionData) doNothing ((writer :: CompressionData -> IO Int) .>>= writeIORef result) (val result)
+    _      -> fail "decompressBlock: multi-method decompression not yet supported under MicroHs"
+#else
+  let
+      decompress1 p = deCompressProcess1 freearcDecompress reader times p 0
+      decompressN p = deCompressProcess  freearcDecompress times         p 0
+      -- Decompression pipeline: methods are applied in reverse of compression order.
+      -- For chain [p1,p2,...,pN] (p1 first to compress), pN must decompress first.
+      -- [p1,p2]: decompress1 p2 reads from archive, decompressN p1 reads p2 output.
+      -- N-stage: last ps = outermost; tail (reverse ps) are middle stages in order.
+      decompressa [p]     = decompress1 p
+      decompressa [p1,p2] = decompress1 p2 |> decompressN p1
+      decompressa (p1:ps) = decompress1 (last ps) |> foldl1 (|>) (map decompressN (tail (reverse ps))) |> decompressN p1
+
+  result <- ref 0   -- ���������� ����, ���������� � ��������� ������ writer
+  runFuncP (decompressa (map fromJust keyed_compressor)) (fail "decompressBlock::runFuncP" :: IO CompressionData) doNothing ((writer :: CompressionData -> IO Int) .>>= writeIORef result) (val result)
+#endif
+  uiFinishDeCompression times                    -- ������ � UI ������ ����� ��������
+
+
+{-# NOINLINE deCompressProcess #-}
+-- |��������������� ������� �������������� ������ �� ������� �������� ������
+-- �� ������� ������ ��������� ��������/����������
+--   comprMethod - ������ ������ ������ � �����������, ���� "ppmd:o10:m48m"
+--   num - ����� �������� � ������� ��������� ��������
+deCompressProcess de_compress times comprMethod num pipe = do
+  -- ���������� �� ������� ������, ���������� �� ����������� ��������, �� ��� �� ������������ �� ��������/����������
+  remains <- ref$ Just (error "undefined remains:buf0", error "undefined remains:srcbuf", 0)
+  let
+    -- ����������� ������ �� srcbuf � dstbuf � ���������� ������ ������������� ������
+    copyData prevlen dstbuf dstlen buf0 srcbuf srclen = do
+      let len = srclen `min` dstlen    -- ���������� - ������� ������ �� ����� ���������
+      copyBytes dstbuf srcbuf len
+      uiReadData num (i len)
+      remains =: Just (buf0, srcbuf+:len, srclen-len)
+      case () of
+       _ | len==srclen -> do send_backP pipe (srcbuf-:buf0+srclen)               -- ���������� ������ ������, ��������� ��� ������ �� ���� ��� �������� ����������/������������
+                             read_data (prevlen+len) (dstbuf+:len) (dstlen-len)  -- ��������� ��������� ����������
+         | len==dstlen -> return (prevlen+len)                                   -- ����� ���������� ��������
+         | otherwise   -> read_data (prevlen+len) (dstbuf+:len) (dstlen-len)    -- �������� ������� ������ ���������� ��������� ������
+
+    -- �������� ��������� ���������� �� ������ ������� ������ � ���������� �
+    processNextInstruction prevlen dstbuf dstlen = do
+      instr <- receiveP pipe
+      case instr of
+        DataBuf srcbuf srclen  ->  copyData prevlen dstbuf dstlen srcbuf srcbuf srclen
+        NoMoreData             ->  do remains =: Nothing;  return prevlen
+
+    -- ��������� "������" ������� ������. �����, ����� ������ ����� � dstlen=0 �� ��������� ���������� ���� �� �������� ���� �� ���� ���� ������ �� ����������� ��������
+    read_data prevlen  -- ������� ������ ��� ���������
+              dstbuf   -- �����, ���� ����� ��������� ������� ������
+              dstlen   -- ������ ������
+              = do     -- -> ��������� ������ ���������� ���������� ����������� ���� ��� 0, ���� ������ �����������
+      remains' <- val remains
+      case remains' of
+        Just (buf0, srcbuf, srclen)                                       -- ���� ��� ���� ������, ���������� �� ����������� ��������
+         | srclen>0  ->  copyData prevlen dstbuf dstlen buf0 srcbuf srclen --  �� �������� �� ����������/������������
+         | otherwise ->  processNextInstruction prevlen dstbuf dstlen      --  ����� �������� �����
+        Nothing      ->  return prevlen                                    -- ���� solid-���� ����������, ������ ������ ���
+
+  -- ��������� ������ ������� ������ �������� ��������/���������� (���������� ���� �������, � ������� �� ����������� read_data)
+  let reader dstbuf dstlen  =  read_data 0 dstbuf dstlen
+
+  deCompressProcess1 de_compress reader times comprMethod num pipe
+
+
+{-# NOINLINE deCompressProcess1 #-}
+-- |deCompressProcess � ��������������� �������� ������ (����� ������ ������ ��������
+-- �� ������ ��� ������� �������� � ������� ����������)
+deCompressProcess1 de_compress reader times comprMethod num pipe = do
+  total' <- ref ( 0 :: FileSize)
+  time'  <- ref (-1 :: Double)
+  let -- ��������� ������ ������� ������ �������� ��������/����������
+      callback "read" buf size = reader buf size
+      -- ��������� ������ �������� ������
+      callback "write" buf size = do total' += i size
+                                     uiWriteData num (i size)
+                                     resendData pipe (DataBuf buf size)
+      -- "�����������" ������ ������������� ������� ������ ����� �������� � ���������� ������
+      -- ��� ����������� ������. �������� ��������� ����� int64* ptr
+      callback "quasiwrite" ptr size = do bytes <- peek (castPtr ptr::Ptr Int64) >>==i
+                                          uiQuasiWriteData num bytes
+                                          return aFREEARC_OK
+      -- ���������� � ������ ������� ���������� ��������/����������
+      callback "time" ptr 0 = do t <- peek (castPtr ptr::Ptr CDouble) >>==realToFrac
+                                 time' =: t
+                                 return aFREEARC_OK
+      -- ������ (����������������) callbacks
+      callback _ _ _ = return aFREEARC_ERRCODE_NOT_IMPLEMENTED
+
+{-
+      -- Debugging wrapper
+      debug f what buf size = inside (print (comprMethod,what,size))
+                                     (print (comprMethod,what,size,"done"))
+                                     (f what buf size)
+-}
+      -- Non-debugging wrapper
+      debug f = f
+
+  -- ���������� �������� ��� ����������
+  result <- de_compress num comprMethod (debug callback)
+  debug callback "finished" nullPtr result
+  -- ����������
+  total <- val total'
+  time  <- val time'
+  uiDeCompressionTime times (comprMethod,time,total)
+  -- ������ � ����������, ���� ��������� ������
+  unlessM (val operationTerminated) $ do
+    unless (result `elem` [aFREEARC_OK, aFREEARC_ERRCODE_NO_MORE_DATA_REQUIRED]) $ do
+      registerThreadError$ COMPRESSION_ERROR [compressionErrorMessage result, comprMethod]
+      operationTerminated =: True
+  -- ������� ����������� ��������, ��� ������ ������ �� �����, � ���������� - ��� ������ ������ ���
+  send_backP  pipe aFREEARC_ERRCODE_NO_MORE_DATA_REQUIRED
+  resendData pipe NoMoreData
+  return ()
+
+
+-- |��������� ��������� ������ ������������� ������ (writer ��� ������������).
+-- ��������� (�������� �� ������ state) ��������:
+--   1) block_pos - ������� ������� � ����� ������
+--   2) pos       - �������, � ������� ���������� ���� (��� ��� ���������� �����)
+--   3) size      - ������ ����� (��� ��� ���������� �����)
+-- ��������������, ������� �� ������������ ������ �� ������ buf ������ len, �� ������:
+--   1) ���������� � ������ ������ ������, �������������� ���������������� ����� (���� ����)
+--   2) �������� �� ����� ������, ����������� � ����� ����� (���� ����)
+--   3) �������� ��������� - ������� � ����� ���������� �� ������ ����������� ������,
+--        � ������� � ������ ���������� ������ ����� - �� ������ ���������� �� ����� ������
+--   4) ���� ���� ���������� ��������� - ���� ��������� �� ���� ����������� �������
+--        � �������� ��������� ������� �� ����������
+--   5) ���� ��������� ��������������� ���� �������� � ������ ����� ��� � ��� ��������� �����
+--        �������� ����� - ���� �������� ���������� ����� ����� � ���, ����� decompressBlock
+--        ������� � ���������� ����, ��� ����� (�� ������ ��� ������ �� cfile)
+--
+decompressStep (cfile :: IORef FileToCompress) (state :: IORef (Integer, Integer, Integer)) pipe buf len = do
+  (block_pos, pos, size) <- (val state :: IO (Integer, Integer, Integer))
+  if block_pos<0   -- ������, ��� ����������� �� ������� ��������, ��� �� ����� ������� � ������� ����� ������
+    then return aFREEARC_ERRCODE_NO_MORE_DATA_REQUIRED   -- ������, ��������, ���� �� �����������. ������������: fail$ "Block isn't changed!!!"
+    else do
+  let skip_bytes = min (pos-block_pos) (i len)   -- ���������� ������ ���������� ������ � ������ ������
+      data_start = buf +: skip_bytes             -- ������ ������, ������������� ���������������� �����
+      data_size  = min size (i len-skip_bytes)   -- ���-�� ����, ������������� ���������������� �����
+      block_end  = block_pos+i len               -- ������� � �����-�����, ��������������� ����� ����������� ������
+  when (data_size>0) $ do    -- ���� � ������ ������� ������, ������������� ���������������� �����
+    sendP pipe (data_start, i data_size)  -- �� ������� ��� ������ �� ������ ����� �����������
+    receive_backP pipe                    -- �������� ������������� ����, ��� ������ ���� ������������
+  state =: (block_end, pos+data_size, size-data_size)
+  if data_size<size     -- ���� ���� ��� �� ���������� ���������
+    then return len     -- �� ���������� ���������� �����
+    else do             -- ����� ��������� � ���������� ������� �� ����������
+  sendP pipe (error "End of decompressed data", aFREEARC_ERRCODE_NO_MORE_DATA_REQUIRED)
+  old_block  <-  cfArcBlock ==<< val cfile
+  cmd <- receiveP pipe
+  case cmd of
+    Nothing -> do  -- ��� ��������� ��������, ��� ������ ������� ������ �� ����� ���������� �� ��������� � �� ������ ���� ��������
+      state =: (aStopDecompressThread, error "undefined state.pos", error "undefined state.size")
+      cfile =: error "undefined cfile"
+      return aFREEARC_ERRCODE_NO_MORE_DATA_REQUIRED
+
+    Just cfile' -> do
+      cfile =: cfile'
+      let size   =  fiSize (cfFileInfo cfile')
+          pos    =  cfPos      cfile'
+          block  =  cfArcBlock cfile'
+      if block/=old_block || pos<block_pos  -- ���� ����� ���� ��������� � ������ ����� ��� � ����, �� ������
+           || (pos>block_end && blCompressor block==aNO_COMPRESSION)   -- ��� �� ������������� ����, ������ � -m0, � � ��� ���� ����������� ���������� ����� ������
+        then do state =: (-1, error "undefined state.pos", error "undefined state.size")
+                return aFREEARC_ERRCODE_NO_MORE_DATA_REQUIRED   -- ������� ����, ��� ����� ��������� ���������� ����� �����
+        else do state =: (block_pos, pos, size)            -- ����� ���������� ���������� �����,
+                decompressStep cfile state pipe buf len   -- ��� � ��������� ���������� ������ �����
+
+-- |������, ��������� ���������� ������ ����� ����������
+aStopDecompressThread = -99
+
+
+-- |���������, ������������ ��� �������� ������ ���������� �������� ��������/����������
+data CompressionData = DataBuf (Ptr CChar) Int
+                     | NoMoreData
+
+{-# NOINLINE resendData #-}
+-- |��������� �������� �������� ������ ����������/������������ ��������� ��������� � �������
+resendData pipe x@DataBuf{}   =  sendP pipe x  >>  receive_backP pipe  -- ���������� ���������� ����������� ����, ������������ �� ��������-�����������
+resendData pipe x@NoMoreData  =  sendP pipe x  >>  return 0
+
+
+-- Compatibility aliases (old underscore-style names)
+decompress_PROCESS = decompressProcess
+decompress_file    = decompressFile
+de_compress_PROCESS = deCompressProcess
+resend_data         = resendData

--- a/ArcvProcessRead.hs
+++ b/ArcvProcessRead.hs
@@ -1,3 +1,266 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:348c22a70b1b0f8bbe93dbdeb058ed741cfd9b2b1229e69c88873816cf321f42
-size 16531
+----------------------------------------------------------------------------------------------------
+---- Process that builds the archive structure and reads the data to be packed.                    ----
+---- Called from ArcCreate.hs                                                                    ----
+----------------------------------------------------------------------------------------------------
+module ArcvProcessRead where
+
+import Prelude hiding (catch, readFile)
+import Control.Exception
+import Control.Monad
+import Data.IORef
+import Foreign.Ptr
+import Foreign.C.Types
+import Foreign.Marshal.Pool
+import Foreign.Marshal.Utils
+
+import Utils
+import Files
+import Process
+import Errors
+import FileInfo
+import Compression
+import Options
+import UI
+import ArhiveStructure
+import ArhiveDirectory
+import ArhiveFileList
+import ArcvProcessExtract
+
+
+-- |Instructions sent by the input-reading process to the packing process
+data Instruction
+  =   DebugLog  String                        --   Output a debug message with a timestamp
+  |   DebugLog0 String                        --   Output a debug message without timestamp
+  |   CompressData BlockType Compressor Compressor Bool
+                                              --   Start of an archive block
+  |   FileStart FileInfo                      --   Start of the next file
+  |   DataChunk (Ptr CChar) Int               --   Next chunk of data to be packed
+  |   CorrectTotals FileCount FileSize        --   Adjust Total Files/Bytes shown in the UI
+  |   FakeFiles [FileToCompress]              --   Adjust the list of already-packed files for the UI
+  |   CopySolidBlock [CompressedFile]         --   Copy an entire solid block from an existing archive
+  |   DataEnd                                 --   End of the archive block
+  |   Directory [FileWithCRC]                 --   Request for administrative data about the last created archive block
+  |   TheEnd                                  --   Archive creation complete
+
+-- |Predicates used in loops: run until end of archive block, run until end of archive
+notDataEnd DataEnd = False
+notDataEnd _       = True
+notTheEnd  TheEnd  = False
+notTheEnd  _       = True
+
+
+-- |Process that builds the archive structure - it splits files
+--   into separate archive volumes, directory blocks inside the archive and solid blocks.
+-- This same process also gathers input data for packing - it reads files from disk and
+--   decompresses data from input archives.
+createArchiveAtructureAndReadFilesProcess command archive oldarc files processDir arcComment writeRecoveryBlocks results backdoor pipe = do
+  initPos <- archiveGetPos archive
+  -- On error, set a flag to interrupt c_compress() operation
+  handleCtrlBreak "operationTerminated =: True" (operationTerminated =: True) $ do
+  -- Create a process for decompressing files from input archives and ensure it terminates correctly
+  bracket (runAsyncP$ decompress_PROCESS command doNothing)
+          ( \decompress_pipe -> do sendP decompress_pipe Nothing; joinP decompress_pipe)
+          $ \decompress_pipe -> do
+  -- Create a cache for lookahead reading of files to be archived
+  withPool $ \pool -> do
+  bufOps <- makeFileCache (opt_cache command) pool pipe
+  -- Parameters for writeControlBlock
+  let params = (command,bufOps,pipe,backdoor)
+
+  -- Write the header block (HEADER_BLOCK) at the start of the archive
+  header_block  <-  writeControlBlock HEADER_BLOCK aNO_COMPRESSION params $ do
+                      archiveWriteHeaderBlock bufOps
+
+  -- Write directory blocks for each solid block and collect their descriptors
+  dir_block        <-  createDirBlock archive processDir decompress_pipe params files
+  let directory_blocks = [dir_block]
+
+  -- Write the final block (FOOTER_BLOCK) containing the index of control blocks and the archive comment
+  let write_footer_block blocks arcRecovery = do
+          footerPos <- archiveGetPos archive
+          writeControlBlock FOOTER_BLOCK (dirCompressor command) params $ do
+            let lock_archive = opt_lock_archive command   -- Should the created archive be locked from modifications?
+            archiveWriteFooterBlock blocks lock_archive arcComment arcRecovery footerPos bufOps
+          return ()
+  write_footer_block (header_block:directory_blocks) ""
+
+  -- Print command execution statistics and save them for returning to the caller
+  uiDoneArchive  >>=  writeIORef results
+
+  -- If writing RECOVERY information is enabled - write RECOVERY blocks and repeat the FOOTER block
+  (recovery_blocks,recovery) <- writeRecoveryBlocks archive oldarc initPos command params bufOps
+  unless (null recovery_blocks) $ do
+    write_footer_block (header_block:directory_blocks++recovery_blocks) recovery
+
+  -- Notify the archive writer process that archive creation is complete
+  sendP pipe TheEnd
+
+
+-- |Записать в архив переданные файлы и dir-блок с их описанием
+createDirBlock archive processDir decompress_pipe params@(command,bufOps,pipe,backdoor) files = do
+  -- Split files into solid blocks and process each sublist separately. For debugging: mapM (print . map (fpFullname . fiDiskName . cfFileInfo)) (splitToSolidBlocks files)
+  solidBlocks <- foreach (splitToSolidBlocks command files)
+                         (createSolidBlock command processDir bufOps pipe decompress_pipe)
+  -- Get from the write_to_archive process information about created solid blocks and the files they contain.
+  -- Executing this forces completion of packing of all previously sent data and writing the packed data to the archive...
+  blocks_info  <-  replicateM (length solidBlocks) (getP backdoor)
+  -- ... after which we can be sure that the current position in the archive is where the directory block will start
+  dirPos <- archiveGetPos archive
+  -- Записать блок каталога и возвратить информацию о нём для формирования каталога каталогов
+  writeControlBlock DIR_BLOCK (dirCompressor command) params $ do
+    archiveWriteDir blocks_info dirPos bufOps
+
+
+-- |Create a solid block containing data from the provided files
+createSolidBlock command processDir bufOps pipe decompress_pipe (orig_compressor,files) = do
+  let -- Choose the compression algorithm for this solid block
+      -- and shrink dictionaries of its algorithms if they are larger than the data size of the block
+      -- (+1% + 512 because delta-type filters may increase data size):
+      compressor | copy_solid_block = cfCompressor (head files)
+                 | otherwise        = orig_compressor.$limitDictionary (clipToMaxMemSize$ roundMemUp$ totalBytes+(totalBytes `div` 100)+512)
+      -- Total size of files in the solid block
+      totalBytes = sum$ map (fiSize . cfFileInfo) files
+      -- True if this is a whole solid block from an input archive that can be copied without changes
+      copy_solid_block = not (opt_recompress command)  &&  isWholeSolidBlock files
+  -- Ограничить компрессор объёмом свободной памяти и значением -lc
+  real_compressor <- limit_compressor command compressor
+  opt_testMalloc command &&& testMalloc
+
+  -- Compress the solid block and send the list of files placed into it to the next process
+  unless (null files) $ do
+    printDebugInfo command pipe files totalBytes copy_solid_block compressor real_compressor
+    writeBlock pipe DATA_BLOCK compressor real_compressor copy_solid_block $ do
+      dir <- -- If the solid block is being transferred whole from archive to archive, skip unnecessary recompression
+             if copy_solid_block then do
+               sendP pipe (CopySolidBlock files)
+               return$ map fileWithCRC files
+             -- If --nodata is used, skip reading input files
+             else if isReallyFakeCompressor compressor then do
+               sendP pipe (FakeFiles files)
+               return$ map fileWithCRC files
+             -- Normal file reading for all other (more typical) cases
+             else do
+               mapMaybeM (readFile command pipe bufOps decompress_pipe) files
+      processDir dir   -- let the procedure passed from above inspect the list of archived files (used to implement options -tl, -ac, -d[f])
+      return dir
+
+
+-- |Print debug information
+printDebugInfo command pipe files totalBytes copy_solid_block compressor real_compressor = do
+  --print (clipToMaxInt totalBytes, compressor)
+  --print$ map (diskName . cfFileInfo) files   -- debugging tool :)
+  when (opt_debug command) $ do
+    sendP pipe$ DebugLog$  "Compressing "++show_files3 (length files)++" of "++show_bytes3 totalBytes
+    sendP pipe$ DebugLog0$ if copy_solid_block then "  Copying "++join_compressor compressor  else "  Using "++join_compressor real_compressor
+  unless copy_solid_block $ do
+      sendP pipe$ DebugLog0$ "  Memory for compression "++showMem (getCompressionMem   real_compressor)
+                                    ++", decompression "++showMem (getDecompressionMem real_compressor)
+
+
+---------------------------------------------------------------------------------------------------
+---- Procedure to read data of the file being packed -------------------------------------------------
+---------------------------------------------------------------------------------------------------
+
+{-# NOINLINE readFile #-}
+-- If this is a directory, skip reading data
+readFile command pipe _ _ file  | fi<-cfFileInfo file, fiIsDir fi = do
+  sendP pipe (FileStart fi)
+  return$ Just$ fileWithCRC file
+
+-- If this is a file on disk, read it in parts and send read chunks for packing
+readFile _ pipe (receiveBuf, sendBuf) _ (DiskFile old_fi) = do
+  -- Operation to inform the next process about change in file count/size that it should send to the UI
+  let correctTotals files bytes  =  when (files/=0 || bytes/=0) (sendP pipe (CorrectTotals files bytes)) >> return Nothing
+  -- Check possibility to open the file - it may be locked or the file might have been deleted in the meantime :)
+  mfile <- tryOpen (diskName old_fi)
+  case mfile of
+    Nothing -> correctTotals (-1) (-fiSize old_fi)
+    Just file -> ensureCtrlBreak "fileClose:readFile" (fileClose file) $ do  -- Ensure file is closed
+      -- Re-read file information in case it changed
+      mfi <- rereadFileInfo old_fi file
+      case mfi of
+        Nothing -> correctTotals (-1) (-fiSize old_fi)
+        Just fi -> do
+          correctTotals 0 (fiSize fi - fiSize old_fi) -- Adjust UI totals if the file size has changed
+          sendP pipe (FileStart fi)                   -- Inform the user about the start of packing the file
+          let readFile crc bytes = do                 -- Read the file in a loop, sending read chunks for packing:
+                (buf, size) <- receiveBuf                 -- Get a free buffer from the buffer queue
+                len         <- fileReadBuf file buf size  -- Read the next portion of data from file into it
+                newcrc      <- updateCRC buf len crc      -- Update CRC with buffer contents
+                sendBuf        buf size len               -- Send the data to the packing process
+                if len>0
+                  then readFile newcrc $! bytes+i len    -- Update the count of read bytes
+                  else return (finishCRC newcrc, bytes)  -- Exit the loop if the file ended
+          (crc,bytesRead) <- readFile aINIT_CRC 0     -- Read the file, obtaining its CRC and size
+          correctTotals 0 (bytesRead - fiSize fi)     -- Adjust UI totals if the actual read size differs from getFileInfo
+          return$ Just$ FileWithCRC crc FILE_ON_DISK fi{fiSize=bytesRead}
+
+-- If this is a file from an existing archive, decompress it and send decompressed chunks for packing
+readFile _ pipe (receiveBuf, sendBuf) decompress_pipe compressed_file = do
+  crc  <-  ref aINIT_CRC                       -- Initialize CRC value
+  -- The operation of "writing" decompressed data by copying them into our own buffers
+  -- and sending these buffers for further processing
+  let writer inbuf 0 = send_backP decompress_pipe ()  -- сообщим распаковщику, что теперь буфер свободен
+      writer inbuf insize = do
+        (buf, size) <- receiveBuf              -- get a free buffer from the buffer queue
+        let len  = min insize size             -- determine how many bytes we can process
+        crc    .<- updateCRC inbuf len         -- update CRC with buffer contents
+        copyBytes  buf inbuf len               -- copy data into the acquired buffer
+        sendBuf    buf size len                -- send them to the next process in the pipeline
+        writer     (inbuf+:len) (insize-len)   -- process remaining data, if any
+  let fi  =  cfFileInfo compressed_file
+  sendP pipe (FileStart fi)                    -- Inform the user about beginning re-packing of the file
+  decompress_file decompress_pipe compressed_file writer   -- Decompress the file in a separate thread
+  crc'  <-  val crc >>== finishCRC            -- Compute the final CRC value
+  if cfCRC compressed_file == crc'            -- If CRC matches
+    then return$ Just$ fileWithCRC compressed_file  -- then return file info
+    else registerError$ BAD_CRC$ diskName fi        -- otherwise register an error
+
+
+---------------------------------------------------------------------------------------------------
+---- Auxiliary definitions ------------------------------------------------------------------
+---------------------------------------------------------------------------------------------------
+-- |Create a cache for lookahead reading and return procedures receiveBuf and sendBuf
+-- to get a free buffer from the cache and to release used buffers respectively
+makeFileCache cache_size pool pipe = do
+  -- Size of buffers the whole cache will be split into
+  let bufsize | cache_size>=aLARGE_BUFFER_SIZE*16  =  aLARGE_BUFFER_SIZE
+              | otherwise                          =  aBUFFER_SIZE
+  -- Allocate memory for the cache and start memoryAllocator on the allocated block
+  heap                     <-  pooledMallocBytes pool cache_size
+  (getBlock, shrinkBlock)  <-  memoryAllocator   heap cache_size bufsize 256 (receive_backP pipe)
+  let -- Операция получения свободного буфера
+      receiveBuf            =  do buf <- getBlock
+                                  failOnTerminated
+                                  return (buf, bufsize)
+      -- Operation to obtain a free buffer
+      -- Operation to send a filled buffer to the next process
+      sendBuf buf size len  =  do shrinkBlock buf len
+                                  failOnTerminated
+                                  when (len>0)$  do sendP pipe (DataChunk buf len)
+  return (receiveBuf, sendBuf)
+
+{-# NOINLINE writeBlock #-}
+-- |Записать в архив блок данных/служебный/дескриптор блока
+writeBlock pipe blockType compressor real_compressor just_copy action = do
+  sendP pipe (CompressData blockType compressor real_compressor just_copy)
+  directory <- action
+  sendP pipe  DataEnd
+  sendP pipe (Directory directory)
+
+{-# NOINLINE writeControlBlock #-}
+-- Записать в архив служебный блок вместе с его дескриптором и возвратить информацию об этом блоке
+writeControlBlock blockType compressor (command,bufOps,pipe,backdoor) action = do
+    if opt_nodir command   -- Опция "--nodir" отключает запись в архив всех служебных блоков - остаются только сами сжатые данные
+    then return (error "Attempt to use value returned by writeControlBlock when \"--nodir\"")
+    else do
+      writeBlock pipe blockType compressor compressor False $ do  -- запишем в архив блок каталога
+        action
+        return []
+      (thisBlock, [])  <-  getP backdoor                      -- получим его дескриптор
+      writeBlock pipe DESCR_BLOCK aNO_COMPRESSION aNO_COMPRESSION False $ do  -- запишем этот дескриптор в архив
+        archiveWriteBlockDescriptor thisBlock bufOps
+        return []
+      (_, [])  <-  getP backdoor                              -- оприходуем ненужный дескриптор дескриптора
+      return thisBlock                                        -- возвратим дескриптор блока каталога
+

--- a/ArhiveDirectory.hs
+++ b/ArhiveDirectory.hs
@@ -1,3 +1,419 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b3450c1ac2c051bb2ae5edb9d6f755d4554e398522afb34cc9102fffe29be419
-size 35132
+----------------------------------------------------------------------------------------------------
+---- ������ � ����������� ������.                                                             ------
+---- ���� ������ �������� ��������� ���:                                                      ------
+----   * ������ ��������� �������� ������ (�.�. ��������� � ������ ��������� ������)          ------
+----   * ������ � ������ ��������� ������                                                     ------
+----------------------------------------------------------------------------------------------------
+module ArhiveDirectory where
+
+import Prelude hiding (catch)
+import Control.Monad
+import qualified HashTable as Hash
+import Data.List
+import Foreign.Marshal.Pool
+import System.Mem
+
+-- import GHC.PArr
+
+import Utils
+import Errors
+import Files
+import qualified ByteStream
+import FileInfo
+import Compression      (CRC, Compressor, isFakeCompressor)
+import UI               (debugLog)
+import Options
+import ArhiveStructure
+
+----------------------------------------------------------------------------------------------------
+---- ������ ��������� �������� ������ --------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |��� ����������� ���������� � ������� ������
+data ArchiveInfo = ArchiveInfo
+         { arcArchive    :: Archive           -- �������� ���� ������
+         , arcFooter     :: FooterBlock       -- FOOTER BLOCK ������
+         , arcDirectory  :: [CompressedFile]  -- �����, ������������ � ������
+         , arcDataBlocks :: [ArchiveBlock]    -- ������ �����-������
+         , arcDirBytes   :: FileSize          -- ������ ��������� ������ � ������������� ����
+         , arcDirCBytes  :: FileSize          -- ������ ��������� ������ � ����������� ����
+         , arcDataBytes  :: FileSize          -- ������ ������ � ������������� ����
+         , arcDataCBytes :: FileSize          -- ������ ������ � ����������� ����
+         , arcPhantom    :: Bool              -- True, ���� ������ �� ����� ���� ��� (������������ ��� main_archive)
+         }
+
+-- ���������, ���������� ������ � ��������
+arcGetPos  = archiveGetPos . arcArchive
+arcSeek    = archiveSeek   . arcArchive
+arcComment = ftComment . arcFooter
+
+-- |���������, �������������� �����, ����������� ��� ���������� � ��������� ���������
+-- (������� ������� ������, �������� ������� �������)
+phantomArc  =  (dirlessArchive (error "phantomArc:arcArchive") (FooterBlock [] False "" "" 0)) {arcPhantom = True}
+
+-- |����� ��� �������� ������ - ������������ ������ ��� ������ writeSFX �� runArchiveRecovery
+dirlessArchive archive footer = ArchiveInfo archive footer [] [] (error "emptyArchive:arcDirBytes") (error "emptyArchive:arcDirCBytes") (error "emptyArchive:arcDataBytes") (error "emptyArchive:arcDataCBytes") False
+
+-- |������� �������� ����, ���� ������ ��� �� ��������� �����
+arcClose arc  =  unless (arcPhantom arc) $  do archiveClose (arcArchive arc)
+
+
+{-# NOINLINE archiveReadInfo #-}
+-- |��������� ������� ������
+archiveReadInfo command               -- ����������� ������� �� ����� � �������
+                arc_basedir           -- ������� ������� ������ ������ ("" ��� ������ ����������)
+                disk_basedir          -- ������� ������� �� ����� ("" ��� ������ ����������/��������)
+                filter_f              -- �������� ��� ���������� ������ ������ � ������
+                processFooterInfo     -- ���������, ����������� �� ������ �� FOOTER_BLOCK
+                arcname = do          -- ��� �����, ����������� �����
+  -- ��������� FOOTER_BLOCK � ��������� �� ��� ���������� ���������
+  (archive,footer) <- if opt_broken_archive command /= "-"
+                         then findBlocksInBrokenArchive arcname
+                         else archiveReadFooter command arcname
+  processFooterInfo archive footer
+
+  -- ��������� ���������� ������ ��������, ��������� � FOOTER_BLOCK
+  let dir_blocks  =  filter ((DIR_BLOCK ==) . blType) (ftBlocks footer)
+  files  <-  foreach dir_blocks $ \block -> do
+    withPool $ \pool -> do
+      (buf,size) <- archiveBlockReadAll pool (opt_decryption_info command) block
+      archiveReadDir arc_basedir disk_basedir (opt_dir_exclude_path command) archive (blPos block) filter_f (return (buf,size))
+
+  let data_blocks = concatMap fst files
+      directory   = concatMap snd files
+
+  -- ������� � arcinfo ���������� � ������ ������ � ������
+  return ArchiveInfo { arcArchive    = archive
+                     , arcFooter     = footer
+                     , arcDirectory  = directory
+                     , arcDataBlocks = data_blocks
+                     , arcDirBytes   = sum (map blOrigSize dir_blocks)
+                     , arcDirCBytes  = sum (map blCompSize dir_blocks)
+                     , arcDataBytes  = sum (map blOrigSize data_blocks)
+                     , arcDataCBytes = sum (map blCompSize data_blocks)
+                     , arcPhantom    = False
+                     }
+
+
+{-# NOINLINE archiveReadFooter #-}
+-- |��������� ��������� ���� ������
+archiveReadFooter command               -- ����������� ������� �� ����� � �������
+                  arcname = do          -- ��� �����, ����������� �����
+  archive <- archiveOpen arcname
+  arcsize <- archiveGetSize archive
+  let scan_bytes = min aScanMax arcsize  -- ��������� 4096 ���� � ����� ������, ���� ������� ������� :)
+
+  withPool $ \pool -> do
+    -- ��������� 4096 ���� � ����� ������, ������� ������ ��������� ���������� FOOTER_BLOCK'�
+    buf <- archiveMallocReadBuf pool archive (arcsize-scan_bytes) (i scan_bytes)
+    -- ����� � ���������� ��������� ���������� ������ (��� ������ ���� ���������� FOOTER_BLOCK'�)
+    res <- archiveFindBlockDescriptor archive (arcsize-scan_bytes) buf (i scan_bytes) (i scan_bytes)
+    case res of
+      Left  msg -> registerError msg
+      Right footer_descriptor -> do
+              -- ��������� FOOTER_BLOCK, ����������� ���� ������������, ������� � ����� � ���������� ��� ����������
+              footer <- archiveReadFooterBlock footer_descriptor (opt_decryption_info command)
+              return (archive,footer)
+
+
+----------------------------------------------------------------------------------------------------
+---- ������ ����� �������� -------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+{-# NOINLINE archiveWriteDir #-}
+-- |������������ `dirdata` � ������� ���������� ������ �� ���������� ��������� � ������� `sendBuf`
+archiveWriteDir dirdata     -- ������ ��� (block :: ArchiveBlock, directory :: [FileWithCRC])
+                arcpos      -- ������� � ������, ��� ���������� ���� �������
+                (receiveBuf -- "(buf,size) <- receiveBuf" �������� ��� ������ ��������� ����� �������� `size`
+                ,sendBuf)   -- "sendBuf buf size len" �������� �������������� � ������ ������ �� �����
+                = do
+  debugLog "\n  Writing directory"
+  let blocks      :: [ArchiveBlock]
+      blocks       = map fst dirdata            -- ������ �����-������, �������� � ������ �������
+      crcfilelist  :: [FileWithCRC]
+      crcfilelist  = concatMap snd dirdata      -- ������������ ������ ������ - � ��� �������, � ����� ��� ����������� � ������!
+      filelist     :: [FileInfo]
+      filelist     = map fwFileInfo crcfilelist -- ���������� � ����� ������
+
+  -- 0. C������� �������� �����, ������������ ��� ������� � ������� ����� ������� `receiveBuf` � `sendBuf`
+  stream <- ByteStream.create receiveBuf sendBuf (return ())
+  let write         :: (ByteStream.BufferData a) =>  a -> IO ()   -- shortcuts ��� ������� ������ � �����
+      write          =  ByteStream.write          stream
+      writeLength    :: [a] -> IO ()
+      writeLength xs =  ByteStream.writeInteger   stream (length xs)
+      writeList     :: (ByteStream.BufferData a) =>  [a] -> IO ()
+      writeList      =  ByteStream.writeList      stream
+      writeIntegers  =  mapM_ (ByteStream.writeInteger stream)
+      writeTagged     tag x   =  write tag >> write x     -- ������ � ������ - ��� ������������ �����
+      writeTaggedList tag xs  =  write tag >> writeList xs
+
+  -- 1. ���������� �������� ������ ������ � ���-�� ������ � ������ �� ���
+  writeLength dirdata               -- ���-�� ������.    ��� ������� ����� ������������:
+  mapM_ (writeLength . snd) dirdata                        -- ���-�� ������
+  let compressors   = map blCompressor blocks  :: [Compressor]
+      encodedPositions = map (blEncodePosRelativeTo arcpos) blocks
+      compSizes        = map blCompSize blocks  :: [FileSize]
+  writeList compressors   -- ����� ������
+  writeList encodedPositions   -- ������������� ������� ����� � ����� ������
+  writeList compSizes   -- ������ ����� � ����������� ����
+
+  -- 2. ������� � ����� ������ ��� ���������
+    -- ������� ������ ��� ��������� � ������ ���������, ��������������� ������ � filelist
+  (n, dirnames, dir_numbers)  <-  enumDirectories filelist
+  debugLog$ "  Found "++show n++" directory names"
+  writeLength dirnames  -- ��������, ��� ������ �������� � Compressor==[String]
+  writeList   dirnames
+
+  -- 3. ���������� �������� ������ ���������� ���� � CompressedFile/FileInfo
+    -- to do: �������� RLE-����������� �����?
+  writeList$ map (fpBasename . fiStoredName)  filelist     -- ����� ������
+  writeIntegers                             dir_numbers  -- ������ ���������
+  writeList$ map fiSize                     filelist     -- ������� ������
+  writeList$ map fiTime                     filelist     -- ������� ��������
+  writeList$ map fiIsDir                    filelist     -- �������� ��������
+  -- cfArcBlock � cfPos ���������� ������, ���� ���������� �� ���� ���� �����
+  writeList$ map fwCRC                      crcfilelist  -- CRC
+
+  -- 4. ������������ ����, �������������� ������ ������, � ����� - ��� ��������� ������������ �����
+  write aTagEnd  -- ���� ������������ ����� ���, ��� ������� ������ ����� �������� ��� �� ���������
+
+  -- 5. �����! :)
+  ByteStream.closeOut stream
+  -- ��� �������� � ������ Arc.exe!!! - when (length filelist >= 10000) performGC  -- ������ �����, ���� ���� �������� ���������� ����� ������
+  debugLog "  Directory written"
+
+
+-- �������� �� ������ ������ - ������ ���������� ��������� + ����� �������� ��� ������� ����� � ������
+enumDirectories filelist = do
+  -- ��� ������� Stored ����� ����� �� ���� ��� � ��� �� ��������� � ���-������� `table`.
+  -- ���� ��� �������, �� �� �������� �� ���-������� ����� ����� ��������,
+  -- � ���� ��� - ��������� ��� ��� � ���-������� � ��������� ���������� �������, �������
+  -- ��������� ����� ���������� n, � ��������� ��� �������� � ������ `dirnames`.
+  -- ����� �������, ���-������� `table` ���������� ����� ��������� � �� ������
+  -- � ����������� ������ ���� ��������� `dirnames`.
+  table <- Hash.new (==) fpHash                     -- ���������� �������� � �� ������
+
+  -- ���������� ��� ������ ������ ���������� ���������� ��� ���������, �� ������ ������,
+  -- � ����� �������� ��� ������� ����� (��������, [0,1,0,0,2] ��� a\1 b\1 a\2 a\3 c\1)
+  let go []              dirnames dir_numbers n = return (n, reverse dirnames, reverse dir_numbers)
+      go (fileinfo:rest) dirnames dir_numbers n = do
+        let storedName  =  fiStoredName fileinfo    -- ���, ��������������� ��� ���������� � ������
+            dirname     =  fpParent storedName      -- �������, � �������� ����������� ����
+        x <- Hash.lookup table dirname              -- ���� �� ��� � ���� ���� �������?
+        case x of                                   -- ���� ���, ��
+          Nothing -> do Hash.insert table dirname n -- ������� � ��� ����� ��������
+                        -- �������� ��� �������� � ������ ��� ���������,
+                        -- ����� �������� � ������ ������� �������� ��� ������� �����,
+                        -- � ���������������� ������� ���������
+                        go rest (fpDirectory storedName:dirnames) (n:dir_numbers) $! n+1
+          Just x  -> do go rest dirnames (x:dir_numbers) n
+  --
+  go filelist [] [] (0::FileCount)
+
+
+----------------------------------------------------------------------------------------------------
+---- ������ ����� �������� -------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+{-# NOINLINE archiveReadDir #-}
+-- |��������� �������, ���������� �������� `archiveWriteDir`
+archiveReadDir arc_basedir   -- ������� ������� � ������
+               disk_basedir  -- ������� ������� �� �����
+               ep            -- ��������� �������� �� ���/��������� ���������� ����
+               archive       -- ���� ������
+               arcpos        -- ������� � ������, ��� ���������� ���� �������
+               filter_f      -- �������� ���������� ������
+               receiveBuf    -- "(buf,size) <- receiveBuf" �������� ��� ������ ��������� ����� �������� `size`
+               = do
+  debugLog "  Decoding directory"
+
+  -- 0. C������� ������� �����, ������������ ��� ������� � ������� ����� ������� `receiveBuf`
+  stream <- ByteStream.open receiveBuf (\a b c->return ()) (return ())
+  let read         :: (ByteStream.BufferData a) =>  IO a   -- shortcuts ��� ������� ������ �� ������
+      read           = ByteStream.read stream
+      readList     :: (ByteStream.BufferData a) =>  Int -> IO [a]
+      readList       = ByteStream.readList stream
+      readInteger    = ByteStream.readInteger stream
+      readLength     = readInteger
+      readIntegers n = replicateM n readInteger
+
+  -- 1. ��������� �������� ������ ������
+  num_of_blocks <- readLength                     -- ���-�� ������
+  -- ��� ������� ����� ���������:
+  num_of_files  <- readIntegers num_of_blocks     -- ���-�� ������
+  blCompressors <- readList     num_of_blocks     -- ����� ������
+  blOffsets     <- readList     num_of_blocks     -- ������������� ������� ����� � ����� ������
+  blCompSizes   <- readList     num_of_blocks     -- ������ ����� � ����������� ����
+
+  -- 2. ��������� ����� ���������
+  total_dirs    <-  readLength                    -- ������� ����� ��� ��������� ��������� � ���� ���������� ������
+  storedName    <-  readList total_dirs >>== toP  -- ������ ��� ���������
+
+  -- 3. ��������� ������ ������ ��� ������� ���� � CompressedFile/FileInfo
+  let total_files = sum num_of_files              -- ��������� ���-�� ������ � ��������
+  names         <- readList     total_files       -- ����� ������ (��� ����� ��������)
+  dir_numbers   <- readIntegers total_files       -- ����� �������� ��� ������� �� ������
+  sizes         <- readList     total_files       -- ������� ������
+  times         <- readList     total_files       -- ����� ����������� ������
+  dir_flags     <- readList     total_files       -- ��������� ����� "��� �������?"
+  crcs          <- readList     total_files       -- CRC ������
+
+  -- 4. �������������� ����, �������������� ������ ������, � ����� - ��� ��������� �������������� �����
+{-repeat_while (read) (/=aTagEnd) $ \tag -> do
+    (isMandatory::Bool) <- read
+    when isMandatory $ do
+      registerError$ GENERAL_ERROR ("can't skip mandatory field TAG="++show tag++" in archive directory")
+    readInteger >>= ByteStream.skipBytes stream   -- ���������� ������ ����� ����
+    return ()
+-}
+  -- 5. �����! :)
+  ByteStream.closeIn stream
+  debugLog "  Directory decoded"
+
+  ------------------------------------------------------------------------------------------------
+  -- ������ �������� ������� �� ����������� ������ -----------------------------------------------
+  ------------------------------------------------------------------------------------------------
+  -- �������, ���������� ���������� � ���������
+  let drop_arc_basedir  = if arc_basedir>""  then drop (length arc_basedir + 1)  else id
+      make_disk_name    = case ep of         -- ���������� ��� � ������ � ��� �� �����
+                            0 -> const ""    --   ������� "e"  -> ������������ ������ ������� ���
+                            3 -> id          --   ����� -ep3   -> ������������ ������ ���
+                            _ -> stripRoot   --   �� ��������� -> �������� "d:\" �����
+      -- �������, ������������ ����� �������� � ��� Filtered/Disk name (������ ��� Stored name �������� ����� ��� ������)
+      filteredName      = fmap drop_arc_basedir                    storedName
+      diskName          = fmap ((disk_basedir </>) . make_disk_name) filteredName
+      -- �������, ������������ ����� �������� � ��������� PackedFilePath
+      storedInfo        = fmap packParentDirPath storedName
+      filteredInfo      = fmap packParentDirPath filteredName
+      diskInfo          = fmap packParentDirPath diskName
+      -- ��� ������� �������� - ��������� ����: ���������� �� ��� ��� � �������� �������� ("-ap")
+      dirIncludedArray  = fmap (arc_basedir `isParentDirOf`) storedName
+      dirIncluded       = if arc_basedir==""  then const True  else (dirIncludedArray!:)
+
+  -- ������ �������� Maybe FileInfo (Nothing ��� ��� ������, ������� �� �����������
+  -- �������� �������� ("-ap") ��� �� �������� ����� �������� ���������� ������)
+  let make_fi dir name size time dir_flag =
+        if dirIncluded dir && filter_f fileinfo  then Just fileinfo  else Nothing
+
+        where fileinfo = FileInfo { fiFilteredName  =  if arc_basedir>""           then fiFilteredName  else fiStoredName
+                                  , fiDiskName      =  if disk_basedir>"" || ep/=3 then fiDiskName      else fiFilteredName
+                                  , fiStoredName    =  fiStoredName
+                                  , fiSize          =  size
+                                  , fiTime          =  time
+                                  , fiAttr          =  0
+                                  , fiIsDir         =  dir_flag
+                                  , fiGroup         =  fiUndefinedGroup
+                                  }
+              fiStoredName    =  packFilePathPacked2 stored   (fpPackedFullname stored)   name
+              fiFilteredName  =  packFilePathPacked2 filtered (fpPackedFullname filtered) name
+              fiDiskName      =  packFilePathPacked2 disk     (fpPackedFullname disk)     name
+              stored   = storedInfo  !:dir
+              filtered = filteredInfo!:dir
+              disk     = diskInfo    !:dir
+
+  -- �������� ��������� FileInfo �� ��������� �����, ����������� �� ������
+  let fileinfos = zipWith5 make_fi dir_numbers names sizes times dir_flags
+
+  -- �������������� ����������� ������ ������.
+  -- ������� �������� ������ ���� ������ �� ���������, ����������� � ��������� ������.
+  -- ��� �������� ��� ��������� ��������� ����� ������ � ������ �� ������
+  let filesizes = splitByLens num_of_files sizes
+  let blocks    = map (tupleToDataBlock archive arcpos) $
+                    zip5 blCompressors
+                         blOffsets
+                         (map sum filesizes)
+                         blCompSizes
+                         num_of_files
+
+  -- ��������� ������ �� ����������� ������ ������, ����� ������� �� ��� ����� :)
+  let arcblocks = concat [ replicate files_in_block blockDescriptor
+                           | (files_in_block, blockDescriptor) <- zip num_of_files blocks
+                         ]
+
+  -- ������� ����� � ����� ����� ��������� ����� ���������� ������ � ���� �����.
+  -- filesizes - ������ ������� ���� ������, ����������� � ������� �����.
+  -- ��� ����, ����� �������� �� ���� ������� ����� ������ �����, �� ������ �������
+  -- "����������� �����". ��������� [0] � ������ ������� ������ �������,
+  -- ����� �������� ������� ����� �������, � �� ����� ��� :)
+  -- ����� ������, ����  num_of_files = [1..4]
+  --                  �  sizes = [1..10]
+  --               ��  filesizes = [[1],[2,3],[4,5,6],[7,8, 9,10]]
+  --                �  positions = [ 0,  0,2,  0,4,9,  0,7,15,24]
+  let positions = concatMap scanningSum filesizes
+      scanningSum [] = []
+      scanningSum xs = 0 : scanl1 (+) (init xs)
+
+  -- ������ � ��� ������ ��� ���������� ��� �������� ������ ������, ������������ � ���� ��������
+  let files = [ CompressedFile fileinfo arcblock pos crc
+              | (Just fileinfo, arcblock, pos, crc)  <-  zip4 fileinfos arcblocks positions crcs
+              ]
+
+  return $! evalList files               -- �������� ��������� ������ ������ � ����������� ���������
+  when (total_files >= 10000) performGC  -- ������ �����, ���� ���� �������� ���������� ����� ������
+  debugLog "  Directory built"
+
+  return (blocks, files)
+
+--  let f CompressedFile{cfFileInfo=FileInfo{fiFilteredName=PackedFilePath{fpParent=PackedFilePath{fpParent=RootDir}}}} = True
+--      f _ = False
+
+
+----------------------------------------------------------------------------------------------------
+---- ������������� ���� (��� � �����, ��� �� ��� ������������� ������) -----------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |File to compress: either file on disk or compressed file in existing archive
+data FileToCompress
+  = DiskFile
+      { cfFileInfo           :: !FileInfo
+      }
+  | CompressedFile
+      { cfFileInfo           :: !FileInfo
+      , cfArcBlock           ::  ArchiveBlock   -- Archive datablock which contains file data
+      , cfPos                ::  FileSize       -- Starting byte of file data in datablock
+      , cfCRC :: {-# UNPACK #-} !CRC            -- File's CRC
+      }
+
+-- |Assign type synonym because variant label can't be used in another types declarations
+type CompressedFile = FileToCompress
+
+
+-- |�������� ����, ��� ������������� ���� - �� ��� ������������� ������, � �� � �����
+isCompressedFile CompressedFile{} = True
+isCompressedFile DiskFile{}       = False
+
+-- |�������� ������, �������������� ��� ������� (�������) �����
+cfCompressor = blCompressor . cfArcBlock
+
+-- |��� ������ ����, ������������ �������� ����� ����������?
+isCompressedFake file  =  isCompressedFile file  &&  isFakeCompressor (cfCompressor file)
+
+-- |��� ���������������� ����?
+cfIsEncrypted = blIsEncrypted . cfArcBlock
+
+-- |���������� ��� ����� �� ������, ���� ��� �� ����������� - ��������� �� �����
+cfType command file | group/=fiUndefinedGroup  =  opt_group2type command group
+                    | otherwise                =  opt_find_type command fi
+                                                    where fi    = cfFileInfo file
+                                                          group = fiGroup fi
+
+
+----------------------------------------------------------------------------------------------------
+---- ���� � ��� CRC - ������������ ��� �������� ����������� �������� -------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |File and it's CRC
+data FileWithCRC = FileWithCRC { fwCRC  :: {-# UNPACK #-} !CRC
+                               , fwType :: {-# UNPACK #-} !FileType
+                               , fwFileInfo            :: !FileInfo
+                               }
+
+data FileType = FILE_ON_DISK | FILE_IN_ARCHIVE  deriving (Eq)
+
+-- |�������� ����, ��� ����������� ���� - �� ��������� ������, � �� � �����
+isFileOnDisk fw  =  fwType fw == FILE_ON_DISK
+
+-- |Convert FileToCompress to FileWithCRC
+fileWithCRC (DiskFile       fi)          = FileWithCRC 0   FILE_ON_DISK    fi
+fileWithCRC (CompressedFile fi _ _ crc)  = FileWithCRC crc FILE_IN_ARCHIVE fi
+

--- a/ArhiveStructure.hs
+++ b/ArhiveStructure.hs
@@ -1,3 +1,392 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b231352bd6d75fdc0dc9cdb33b8041fce4173ad01be73fc7db5733863cf8c7f2
-size 28130
+----------------------------------------------------------------------------------------------------
+---- Работа со структурой архивного файла.                                                    ------
+---- Архив представляет из себя последовательность блоков, каждый из который может быть:      ------
+----   * блоком данных                                                                        ------
+----   * блоком каталога архива                                                               ------
+----   * другим служебным блоком (recovery record, общая информация об архиве и т.д.)         ------
+---- После каждого служебного блока (то есть любого, кроме блоков данных), записывается       ------
+----   дескриптор, позволяющий разыскать и прочитать этот блок даже в случае сбоев            ------
+----   в содержимом архива.                                                                   ------
+---- Этот модуль содержит процедуры для:                                                      ------
+----   * записи и чтения служебных блоков архива                                              ------
+----   * записи, поиска и чтения дескрипторов служебных блоков                                ------
+----------------------------------------------------------------------------------------------------
+module ArhiveStructure where
+
+import Prelude hiding (catch)
+import Control.Monad
+import Data.Word
+import Data.Maybe
+import Foreign.Ptr
+import Foreign.C.Types
+import Foreign.Marshal.Alloc
+import Foreign.Marshal.Pool
+import Foreign.Storable
+
+import qualified Data.Foldable
+import Utils
+import Errors
+import Files
+import qualified ByteStream
+import FileInfo
+import Compression
+import Encryption
+import Options
+
+-- |Сигнатура для поиска дескрипторов служебных блоков
+aSIGNATURE = make4byte 65 114 67 1 :: Word32
+
+-- |Сигнатура, записываемая в самое начало архива - по ней можно опознать архивный файл, + версия архиватора
+aArchiveSignature = (aSIGNATURE, aARCHIVE_VERSION)
+
+-- |Сколько байт в конце архива сканировать в поиске сигнатуры, с которой начинается дескриптор последнего блока архива
+aScanMax = 4096
+
+-- Теги опциональных полей
+aTagEnd = 0::Integer   -- ^тег окончания опциональных полей
+
+
+----------------------------------------------------------------------------------------------------
+---- Запись/чтение/поиск дескриптора служебного блока архива ---------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Записать в архив дескриптор служебного блока `block` и CRC этого дескриптора
+archiveWriteBlockDescriptor block (receiveBuf,sendBuf) = do
+  crc  <- ref aINIT_CRC
+  let sendBuf_UpdatingCRC buf size len  =  do crc .<- updateCRC buf len;  sendBuf buf size len
+  ByteStream.writeAll receiveBuf sendBuf_UpdatingCRC (return ())
+    -- Структура блока каталога и любого другого управляющего блока - сначала идут упакованные данные, затем его дескриптор:
+    --   сигнатура, тип блока, использованный компрессор, размер в распакованном и упакованном виде, CRC распакованных данных
+    (aSIGNATURE, blType block, blCompressor block, blOrigSize block, blCompSize block, blCRC block)
+  acrc <- val crc
+  -- После дескриптора записывается CRC самого дескриптора
+  ByteStream.writeAll receiveBuf sendBuf (return ())
+    (finishCRC acrc)
+
+-- |Прочитать из буфера дескриптор служебного блока и декодировать его с учётом того,
+-- что в архиве этот дескриптор находится по смещению `arcpos`
+archiveReadBlockDescriptor archive arcpos buf bufsize = do
+  -- Проверим сначала CRC самого дескриптора
+  right_crc  <- peekByteOff buf (bufsize - sizeOf (undefined::CRC))
+  descriptor_crc <- calcCRC buf (bufsize - sizeOf (undefined::CRC))
+  if descriptor_crc/=right_crc
+    then return$ Left$ BROKEN_ARCHIVE (archiveName archive) ["0354 block descriptor at pos %1 is corrupted", show arcpos]
+    else do
+  -- Расшифруем содержимое дескриптора:
+  -- сигнатуру, тип блока, использованный компрессор, размер в распакованном и упакованном виде, CRC распакованных данных
+  (sign, block_type, compressor, origsize, compsize, crc)  <-  ByteStream.readMemory buf bufsize
+  let pos   =  blDecodePosRelativeTo arcpos compsize  -- позиция в архиве начала блока
+      block =  ArchiveBlock archive block_type compressor pos origsize compsize crc undefined (enc compressor)
+  if sign/=aSIGNATURE || pos<0
+    then return$ Left$ BROKEN_ARCHIVE (archiveName archive) ["0355 %1 is corrupted", blockName block]
+    else return$ Right block
+
+{-# NOINLINE archiveWriteBlockDescriptor #-}
+{-# NOINLINE archiveReadBlockDescriptor #-}
+
+
+----------------------------------------------------------------------------------------------------
+---- Сканирование испорченного архива в поисках уцелевших блоков -----------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Сканирование архива в поисках уцелевших блоков.
+-- Создаёт их список и возвращает псевдо-FOOTER BLOCK, содержащий все найденные блоки.
+-- Процедура читает архив с конца кусками по 8 мб, ищет дескрипторы блоков в этих кусках
+-- и затем проверяет, что дескриптор и сам блок в порядке.
+findBlocksInBrokenArchive arcname = do
+  archive <- archiveOpen arcname
+  arcsize <- archiveGetSize archive
+  -- Выделяем буфер в 8 мб + 2 раза по 4 кбайт для упрощения реализации поиска дескриптора
+  allocaBytes (aHUGE_BUFFER_SIZE+2*aScanMax) $ \buf -> do
+  blocks <- withList $ scanArchiveSearchingDescriptors archive buf arcsize
+  if null blocks
+    then registerError$ BROKEN_ARCHIVE arcname ["0356 archive directory not found"]
+    else do
+  -- Возвратить нормальный FOOTER_BLOCK, если он нашёлся в архиве
+  --if blType (head blocks) == FOOTER_BLOCK
+  --  then return (archive, (head blocks) {ftBlocks=reverse blocks})
+  --  else do
+  let pseudo_footer = FooterBlock
+        { ftBlocks   = reverse blocks
+        , ftLocked   = False
+        , ftComment  = ""
+        , ftRecovery = ""
+        , ftSFXSize  = minimum (map blPos blocks)   -- Размер SFX = позиции HEADER_BLOCK в архиве
+        }
+  return (archive, pseudo_footer)
+
+-- Найти в архиве управляющие блоки, чьи дескрипторы начинаются
+-- по адресам <pos, и занести эти дескрипторы в список found
+scanArchiveSearchingDescriptors archive buf pos found =
+  when (pos>0) $ do
+    -- Для ускорения чтения архива округляем требуемый адрес вниз до 8-мбайтной границы
+    -- и ищем дескриптор начиная с этой границы base_pos до позиции pos-1
+    let base_pos = (pos-1) `roundDown` aHUGE_BUFFER_SIZE
+    archiveSeek archive base_pos
+    -- Читаем на 4 кбайта больше необходимого чтобы иметь возможность проверить
+    -- дескриптор, начинающийся в самом конце буфера (длина дескриптора заведомо меньше 4 кбайт)
+    len <- archiveReadBuf archive buf (i$ pos-base_pos+aScanMax)
+    memset (buf+:len) 0 aScanMax  -- на всякий случай дополним прочитанное 4096-ю нулями
+    -- scanMem возвращает позицию в архиве, после которой все дескрипторы уже обнаружены
+    newpos <- scanMem archive base_pos found buf (i (pos-base_pos) `min` len)
+    -- Вызываем функцию рекурсивно для поиска дескрипторов в предыдущем блоке
+    scanArchiveSearchingDescriptors archive buf newpos found
+
+-- Сканировать буфер buf в поисках дескрипторов, начинающихся в первых len байтах этого буфера
+scanMem archive base_pos found buf len = do
+  pos' <- ref base_pos
+  whenRightM_ (archiveFindBlockDescriptor archive base_pos buf (len+aScanMax) len) $ \block -> do
+    -- Найден дескриптор блока block. Значит, дальнейший поиск может быть ограничен
+    -- его позицией, а если это блок каталога - то позицией первого блока данных в нём
+    pos' =: blPos block
+    -- Возможно, не стоит этого делать, поскольку архив может содержат "перепутавшиеся сектора"
+    -- и соответственно, на месте данных вроде бы этого блока вполне могут оказаться совсем
+    -- другие блоки. С другой же стороны, эти данные могут содержать просто другой архив в несжатом
+    -- виде, и тогда мы включим его блоки в список блоков нашего архива :)
+    -- Как вариант - "дотошность поиска" может регулироваться опцией
+    -- when (blType block == DIR_BLOCK) $ do
+    --   data_blocks <- archiveReadDir_OnlyBlocks
+    --   pos' =: minpos data_blocks
+    found <<= block
+  -- Если буфер содержит ещё не просканированные данные, то продолжить поиск в нём,
+  -- иначе - перейти к предыдущему куску архива
+  pos <- val pos'
+  if pos > base_pos
+    then scanMem archive base_pos found buf (i$ pos-base_pos)
+    else return pos
+
+-- |Попытаться найти (последний) дескриптор блока в переданном буфере.
+-- Общий объём данных в блоке - size, но при этом нас интересуют только дескрипторы,
+-- начинающиеся в первых len байтах блока.
+archiveFindBlockDescriptor archive base_pos buf size len =
+  go ((size-sizeOf aSIGNATURE) `max` (len-1)) defaultError
+    where
+  go pos err | pos<0     = return$ Left err
+             | otherwise = do
+       x <- peekByteOff buf pos
+       if x==aSIGNATURE
+         then do -- Найдена сигнатура дескриптора по адресу pos, проверяем реальный ли это дескриптор
+                 res <- archiveReadBlockDescriptor
+                          archive            -- файл архива
+                          (base_pos+i pos)   -- позиция в архивном файле декодируемого дескриптора
+                          (buf+:pos)         -- адрес в памяти декодируемого дескриптора
+                          (size-pos)         -- максимально возможный размер этого дескриптора
+                 case res of
+                   Left  err -> go (pos-1) err
+                   Right _   -> return res
+         else go (pos-1) err
+  -- Сообщение об ошибке, возращаемое если в блоке вообще не найдено ни одного дескритора
+  defaultError = BROKEN_ARCHIVE (archiveName archive) ["0357 archive signature not found at the end of archive"]
+
+{-# NOINLINE findBlocksInBrokenArchive #-}
+{-# NOINLINE scanArchiveSearchingDescriptors #-}
+{-# NOINLINE scanMem #-}
+{-# NOINLINE archiveFindBlockDescriptor #-}
+
+
+----------------------------------------------------------------------------------------------------
+---- Запись начального блока архива (HEADER_BLOCK) -------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Записать в начальный блок архива (HEADER_BLOCK) сигнатуру архива
+archiveWriteHeaderBlock (receiveBuf,sendBuf) = do
+  ByteStream.writeAll receiveBuf sendBuf (return ()) aArchiveSignature
+
+
+----------------------------------------------------------------------------------------------------
+---- Запись и чтение RECOVERY блока ----------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Записать RECOVERY блок
+archiveWriteRecoveryBlock :: (ByteStream.BufferData a) =>  Maybe a -> Ptr CChar -> Int -> (ByteStream.RecvBuf, ByteStream.SendBuf) -> IO ()
+archiveWriteRecoveryBlock moreinfo buf size (receiveBuf,sendBuf) = do
+  stream <- ByteStream.create receiveBuf sendBuf (return ())
+  Data.Foldable.forM_ moreinfo (ByteStream.write stream)
+  ByteStream.writeBuf stream buf size
+  ByteStream.closeOut stream
+
+
+----------------------------------------------------------------------------------------------------
+---- Запись и чтение финального блока архива (FOOTER_BLOCK) ------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Информация, содержащаяся в FOOTER BLOCK
+data FooterBlock = FooterBlock
+       { ftBlocks     :: ![ArchiveBlock]     -- список блоков в архиве (за исключением блоков данных)
+       , ftLocked     :: !Bool               -- архив закрыт от изменений?
+       , ftComment    :: !String             -- комментарий архива
+       , ftRecovery   :: !String             -- настройка recovery info
+       , ftSFXSize    :: !FileSize           -- размер SFX-модуля, предшествующего собственно архиву (вычисляется как объём данных, предшествующих первому блоку архива)
+       }
+
+-- |Записать FOOTER_BLOCK
+archiveWriteFooterBlock control_blocks arcLocked arcComment (arcRecovery::String) arcpos (receiveBuf,sendBuf) = do
+  stream <- ByteStream.create receiveBuf sendBuf (return ())
+  let utf8comment  =  ByteStream.toUTF8List arcComment
+  ByteStream.write        stream (map (blockToTuple arcpos) control_blocks)   -- запишем описания управляющих блоков,
+  ByteStream.write        stream arcLocked                                    -- ... признак закрытия архива от изменений
+  ByteStream.writeInteger stream 0                                            -- ... комментарий архива в старом формате - отсутствует
+  ByteStream.write        stream arcRecovery                                  -- ... объём recovery инормации
+  ByteStream.writeInteger stream (length utf8comment)                         -- ... комментарий архива (кодируем как список, поскольку при этом явно кодируется длина и комментарий таким образом может содержать нулевые символы)
+  ByteStream.writeList    stream utf8comment                                  --     -.-
+  ByteStream.closeOut     stream
+
+-- |Прочитать информацию из FOOTER_BLOCK
+archiveReadFooterBlock footer@ArchiveBlock {
+                                   blArchive  = archive
+                                 , blType     = block_type
+                                 , blPos      = pos
+                                 , blOrigSize = origsize
+                               }
+                       decryption_info = do
+  when (block_type/=FOOTER_BLOCK) $
+    registerError$ BROKEN_ARCHIVE (archiveName archive) ["0358 last block of archive is not footer block"]
+  withPool $ \pool -> do   -- используем пул памяти, чтобы автоматически освободить выделенные буферы при выходе
+    (buf,size) <- archiveBlockReadAll pool decryption_info footer  -- поместим в буфер распакованные данные блока
+    stream <- ByteStream.openMemory buf size
+    control_blocks <- ByteStream.read stream      -- прочитаем описания управляющих блоков,
+    locked         <- ByteStream.read stream      -- ... признак закрытия архива от изменений
+    oldComment     <- ByteStream.readInteger stream >>= ByteStream.readList stream >>== map (toEnum.i :: Word32 -> Char)  -- ... и комментарий архива (читаем как список, поскольку при этом явно кодируется длина и комментарий таким образом может содержать нулевые символы)
+    isEOF          <- ByteStream.isEOFMemory stream  -- Старая версия программы не записывала информацию о recovery record
+    recovery       <- not isEOF &&& ByteStream.read stream  -- ... настройку RECOVERY информации, добавляемой к архиву
+    isEOF          <- ByteStream.isEOFMemory stream
+    comment        <- not isEOF &&& (ByteStream.readInteger stream >>= ByteStream.readList stream >>== ByteStream.fromUTF8)  -- ... и комментарий архива (читаем как список, поскольку при этом явно кодируется длина и комментарий таким образом может содержать нулевые символы)
+    ByteStream.closeIn stream
+    let blocks = map (tupleToBlock archive pos) control_blocks   -- сконструируем структуры ArchiveBlock из прочитаных данных
+    return FooterBlock
+             { ftBlocks   = blocks++[footer]
+             , ftLocked   = locked
+             , ftComment  = comment ||| oldComment
+             , ftRecovery = recovery
+             , ftSFXSize  = minimum (map blPos blocks)   -- Размер SFX = позиции HEADER_BLOCK в архиве
+             }
+
+{-# NOINLINE archiveWriteFooterBlock #-}
+{-# NOINLINE archiveReadFooterBlock #-}
+
+
+----------------------------------------------------------------------------------------------------
+---- Блок архива (блок данных, каталог или служебный) ----------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Блок архива
+data ArchiveBlock = ArchiveBlock
+       { blArchive     :: !Archive      -- архив, к которому принадлежит данный блок
+       , blType        :: !BlockType    -- тип блока
+       , blCompressor  :: !Compressor   -- метод сжатия
+       , blPos         :: !FileSize     -- позиция блока в файле архива
+       , blOrigSize    :: !FileSize     -- размер блока в распакованном виде
+       , blCompSize    :: !FileSize     -- размер блока в упакованном виде
+       , blCRC         :: !CRC          -- CRC распакованных данных (только для служебных блоков)
+       , blFiles       ::  Int          -- количество файлов (только для блоков данных)
+       , blIsEncrypted ::  Bool         -- блок зашифрован?
+       }
+
+instance Eq ArchiveBlock where
+  (==)  =  map2eq$ map2 (blPos, archiveName . blArchive)
+
+-- |Вспомогательная функция для вычисления поля blIsEncrypted по blCompressor
+enc = any isEncryption
+
+-- |Для хранения в архиве информации об архивных блоках. Позиция блока записывается в архив
+-- относительно `arcpos` - позиции в архиве того блока, в котором сохраняется эта информация
+blockToTuple              arcpos (ArchiveBlock _ t c p o s crc f e) = (t,c,arcpos-p,o,s,crc)
+tupleToBlock     archive arcpos (t,c,p,o,s,crc) = ArchiveBlock archive t c (arcpos-p) o s crc undefined (enc c)
+tupleToDataBlock archive arcpos   (c,p,o,s,f)   = ArchiveBlock archive DATA_BLOCK c (arcpos-p) o s 0 f (enc c)
+
+-- Отдельные функции для (де)кодирования позиции блока относительно другого места в архиве
+blEncodePosRelativeTo arcpos arcblock  =  arcpos - blPos arcblock
+blDecodePosRelativeTo arcpos offset    =  arcpos - offset
+
+-- |Описание блока
+blockName block  =  (case blType block of
+                          DESCR_BLOCK    -> "block descriptor"
+                          HEADER_BLOCK   -> "header block"
+                          DATA_BLOCK     -> "data block"
+                          DIR_BLOCK      -> "directory block"
+                          FOOTER_BLOCK   -> "footer block"
+                          RECOVERY_BLOCK -> "recovery block"
+                          _              -> "block of unknown type"
+                      ) ++ " at pos "++ show (blPos block)
+
+-- |Тип блока архива (значения добавлять только в конец, поскольку они записываются в архив!)
+data BlockType = DESCR_BLOCK       -- ^Тэг дескриптора блока архива  (записывается после каждого служебного блока, то есть всех, кроме DATABLOCK)
+               | HEADER_BLOCK      -- ^Тэг начального блока архива   (используемого как сигнатура архивного файла)
+               | DATA_BLOCK        -- ^Тэг блока данных
+               | DIR_BLOCK         -- ^Тэг блока каталога
+               | FOOTER_BLOCK      -- ^Тэг конечного блока архива    (содержащего список блоков в архиве)
+               | RECOVERY_BLOCK    -- ^Тэг блока с recovery info
+               | UNKNOWN_BLOCK     -- Реально неиспользуемые варианты для всех неподдерживаемых этой версией программы типов блока
+               | UNKNOWN_BLOCK2
+               | UNKNOWN_BLOCK3
+     deriving (Eq,Enum)
+
+instance ByteStream.BufferData BlockType  where
+  write buf = ByteStream.writeInteger buf . fromEnum
+  read  buf = ByteStream.readInteger  buf >>== toEnum
+
+-- Операции с блоками архива
+archiveBlockSeek    block pos       =  archiveSeek    (blArchive block) (blPos block + pos)
+archiveBlockRead block = archiveRead    (blArchive block)
+archiveBlockReadBuf block = archiveReadBuf (blArchive block)
+
+-- |Выделить буфер, прочитать в него содержимое блока и проверить CRC
+archiveBlockReadAll pool
+                    decryption_info
+                    block@ArchiveBlock {
+                              blArchive     = archive
+                            , blType        = block_type
+                            , blCompressor  = compressor
+                            , blPos         = pos
+                            , blCRC         = right_crc
+                          } = do
+  let origsize = i$ blOrigSize block
+      compsize = i$ blCompSize block
+  (origbuf, decompressed_size)  <-  decompressInMemory pool compressor decryption_info archive pos compsize origsize
+  crc <- calcCRC origbuf origsize
+  when (crc/=right_crc || decompressed_size/=origsize) $ do
+    registerError$ BROKEN_ARCHIVE (archiveName archive) ["0359 %1 failed decompression", blockName block]
+  return (origbuf, origsize)
+
+-- |Выделить буфер и прочитать в него содержимое блока. Не проверяет CRC и не распаковывает данные!
+archiveBlockReadUnchecked pool block = do
+  when (blCompressor block/=aNO_COMPRESSION) $ do
+    registerError$ BROKEN_ARCHIVE (archiveName$ blArchive block) ["0360 %1 should be uncompressed", blockName block]
+  archiveMallocReadBuf pool (blArchive block) (blPos block) (i$ blOrigSize block)
+
+-- |Выделить буфер и прочитать в него данные из архива
+archiveMallocReadBuf pool archive pos size = do
+  buf         <- pooledMallocBytes pool (size+8)  -- +8 - из-за недоработок в ByteStream :(
+  archiveSeek    archive pos
+  archiveReadBuf archive buf size
+  return buf
+
+-- |Рпаспаковать в памяти блок, который может быть упакован несколькими алгоритмами и вдобавок зашифрован
+decompressInMemory mainPool compressor decryption_info archive pos compsize origsize = do
+  withPool $ \tempPool -> do
+  let process srcbuf srcsize [] = return (srcbuf, srcsize)
+      process srcbuf srcsize (algorithm:algorithms) = do
+        let (dstsize, pool) = if null algorithms
+                                then (origsize, mainPool)
+                                else (max compsize origsize*2+100*kb, tempPool)
+        dstbuf <- pooledMallocBytes pool (dstsize+8)  -- +8 - из-за недоработок в ByteStream :(
+        decompressed_size <- decompressMem algorithm srcbuf srcsize dstbuf dstsize
+        pooledReallocBytes tempPool srcbuf 0
+        process dstbuf decompressed_size algorithms
+  --
+  if compressor==aNO_COMPRESSION
+    then do compbuf <- archiveMallocReadBuf mainPool archive pos (compsize+8)
+            return (compbuf, compsize)
+    else do
+  -- Дополнить алгоритмы шифрования ключами, необходимыми для расшифровки
+  keyed_compressor <- generateDecryption compressor decryption_info
+  when (any isNothing keyed_compressor) $ do
+    registerError$ BAD_PASSWORD (archiveName archive) ""
+  -- Прочитать исходный блок из архива
+  compbuf <- archiveMallocReadBuf tempPool archive pos compsize
+  process compbuf compsize (reverse (map fromJust keyed_compressor))
+
+
+{-# NOINLINE archiveBlockReadAll #-}
+{-# NOINLINE archiveMallocReadBuf #-}
+

--- a/ByteStream.hs
+++ b/ByteStream.hs
@@ -1,3 +1,862 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2f5d9ecdf12e8a31a7739c26684af857777e2785331d6e51c1d56a74fcec0c8f
-size 43286
+{-# LANGUAGE CPP #-}
+----------------------------------------------------------------------------------------------------
+---- Кодирование структур данных в виде потока байтов и буферизация его записи/чтения --------------
+----------------------------------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  ByteStream
+-- Copyright   :  (c) Bulat Ziganshin <Bulat.Ziganshin@gmail.com>
+-- License     :  Public domain
+--
+-- Maintainer  :  Bulat.Ziganshin@gmail.com
+-- Stability   :  experimental
+-- Portability :  GHC/Hugs on x86 processors
+--
+--  This module is like 'Binary' module from NHC - it supports writing data
+--  structures to binary files or memory buffers and reading them back.
+--
+--  This module features:
+--  * Compatibility with last versions of GHC and Hugs
+--  * Lightning speed, especially for large strings and lists of Ints/Words
+--      (i have seen a 10mb/s speed on my 1.2 ghz machine)
+--  * Flexibility of input/output - data may be hold in files, memory buffers,
+--      or reading/writing may be performed via callbacks
+--
+--  This module currently DON'T supports:
+--  * Haskell'98 compatibility (because it uses "too complex" class scheme)
+--  * Compatibility with MSB (most significant byte first) processors,
+--      including Power PC, Motorola and Sparc
+--  * Compatibility with processors, which require aligning of Ints on word
+--      boundaries
+--  * Bit-oriented compression (instead it uses byte-oriented compression,
+--      which is faster and simplier)
+--  * Writing strings which contains null chars
+--  * Tell/Seek-like operations on streams and "freezing" streams
+--  * Reading input streams via fixed-size buffer (buffering at this time
+--      supported only for output streams, input streams must be placed
+--      in one memory buffer containing all the data. MOREOVER, YOU MUST
+--      ALLOCATE BUFFER WITH 8 ADDITIONAL BYTES AFTER END OF REAL DATA.
+--      It's because Integer demarshalling can pre-read whole 9 bytes
+--      even for values which use only 1 byte)
+--
+--  Example of simple usage you can see in the last section of this file,
+--  and examples of defining functions to read/write values of some type -
+--  in two preceding sections of file. If you need more explanations -
+--  please write me.
+--
+-----------------------------------------------------------------------------
+
+module ByteStream where
+
+import Prelude hiding (read,readList)
+import Control.Exception
+import Control.Monad
+import Control.Monad.Fix
+import Data.Bits
+import Data.Char
+import Data.IORef
+import Data.Int
+import Data.Word
+import Foreign.C.String
+import Foreign.C.Types
+import Foreign.Marshal.Alloc
+import Foreign.Ptr
+import Foreign.Marshal.Utils
+import Foreign.Storable
+import System.IO  hiding (openFile)
+import GHC.Base (unsafeChr)
+
+import Files
+import Utils
+
+aTypicalBuffer = 64*1024
+
+----------------------------------------------------------------------------------------------------
+---- Выходной буфер для быстрой записи структурированных данных ------------------------------------
+----------------------------------------------------------------------------------------------------
+
+data OutStream = OutStream
+  { ref_buf     :: IORef (Ptr CChar)    -- буфер в памяти, используемый в настоящий момент
+  , ref_size    :: IORef Int            -- его размер в байтах
+  , ref_pos     :: IORef Int            -- текущая позиция записи в буфере
+  , functions   :: ( RecvBuf              -- функции, обеспечивающие связь с внешним миром
+                   , SendBuf              --   (см. описание create)
+                   , Cleanup )
+  }
+
+type RecvBuf = IO (Ptr CChar, Int)
+type SendBuf = Ptr CChar -> Int -> Int -> IO ()
+type Cleanup = IO ()
+
+
+-- |Записать выводимые данные в файл `filename`, буферизуя их в буфере размером `size` байт
+createFile filename size = do
+  file <- fileCreate filename
+  createBuffered size (fileWriteBuf file) (fileClose file)
+
+-- |Создать выходной поток, выделив для него буфер размером `size` байт.
+-- Данные, накапливаемые в буфере, сплавлять наружу функцией `writer`
+createBuffered size writer closer = do
+  buf <- mallocBytes size
+  let sendBuf buf size = writer buf
+  create (return (buf,size)) sendBuf (free buf >> closer)
+
+-- |Создать выходной поток, выделив для него буфер размером `size` байт.
+-- Данные, накапливаемые в буфере, сплавлять наружу функцией `writer`
+createMemBuf buf size = do
+  create (return (buf,size)) (\buf size len -> fail "createMemBuf: Buffer overflow") (return ())
+
+-- |Создать универсальный выходной поток, используя следующие функции:
+-- receiveBuf : IO (buf,size)                - получить в своё распоряжение очередной буфер
+-- sendBuf    : buf -> size -> len -> IO ()  - отправить буфер на выход с данными длиной `len`
+-- cleanup    : IO ()                        - cleanup при завершении работы
+create receiveBuf sendBuf cleanup = do
+  (buf, size) <- receiveBuf   -- сразу получить первый в своей жизни буфер
+  ref_buf  <- ref buf
+  ref_size <- ref size
+  ref_pos  <- ref 0
+  return (OutStream ref_buf ref_size ref_pos (receiveBuf, sendBuf, cleanup))
+
+-- |Получить очередной буфер для записи данных
+receiveBuffer (OutStream ref_buf ref_size ref_pos (receiveBuf, _, _)) = do
+  (buf, size) <- receiveBuf
+  ref_buf  =: buf
+  ref_size =: size
+  ref_pos  =: 0
+
+-- |Удостовериться, что в буфере ещё есть место для записи `bytes` байт.
+-- Если нет - сплавить этот буфер перекупщикам и получить новый, чистенький, где места уж точно должно хватить!
+ensureFreeSpaceInOutStream buffer@(OutStream _ ref_size ref_pos _) bytes = do
+  size <- val ref_size
+  pos  <- val ref_pos
+  when (pos+bytes>size-1) $ do
+    sendBuffer buffer
+    receiveBuffer buffer
+    size <- val ref_size
+    pos  <- val ref_pos
+    when (pos+bytes>size-1) $
+      fail$ "OutStream: needs "++show bytes++" bytes, but entire new buffer contains only "++show size++" bytes"
+
+-- |Отослать накопленное содержимое буфера через выходную функцию и прекратить его использование
+sendBuffer (OutStream ref_buf ref_size ref_pos (_, sendBuf, _)) = do
+  modifyIORefIO ref_buf $ \buf -> do
+    size <- val ref_size
+    pos  <- val ref_pos
+    sendBuf buf size pos
+    return (error "OutStream::buf undefined")
+
+-- |Отослать накопленное содержимое буфера и закрыть поток
+closeOut buffer@(OutStream _ _ _ (_, _, cleanup)) = do
+  sendBuffer buffer
+  cleanup
+
+-- |All-in-one операция: создаёт выходной поток, записывает в него значение и закрывает поток.
+-- Если вам нужно записать несколько значений - соберите их в tuple
+writeAll :: (BufferData a) =>  RecvBuf -> SendBuf -> Cleanup -> a -> IO ()
+writeAll receiveBuf sendBuf cleanup x =
+  bracket (create receiveBuf sendBuf cleanup) closeOut
+    (\buf -> write buf x)
+
+-- |All-in-one операция: записывает значение в файл и закрывает его.
+-- Если вам нужно записать несколько значений - соберите их в tuple
+writeFile :: (BufferData a) => FilePath -> a -> IO ()
+writeFile filename x =
+  bracket (createFile filename aTypicalBuffer) closeOut
+    (\buf -> write buf x)
+
+{-# NOINLINE createFile #-}
+{-# NOINLINE createBuffered #-}
+{-# NOINLINE create #-}
+{-# NOINLINE receiveBuffer #-}
+{-# NOINLINE ensureFreeSpaceInOutStream #-}
+{-# NOINLINE sendBuffer #-}
+{-# NOINLINE closeOut #-}
+{-# NOINLINE writeAll #-}
+
+
+----------------------------------------------------------------------------------------------------
+---- Входной буфер для быстрого чтения структурированных данных ------------------------------------
+----------------------------------------------------------------------------------------------------
+
+data InStream = InStream
+  { iref_buf     :: IORef (Ptr CChar)   -- буфер в памяти, используемый в настоящий момент
+  , iref_size    :: IORef Int           -- его размер в байтах
+  , iref_pos     :: IORef Int           -- текущая позиция записи в буфере
+  , ifunctions   :: ( RecvBuf             -- функции, обеспечивающие связь с внешним миром
+                    , SendBuf             --   (см. описание open)
+                    , Cleanup )
+  }
+
+-- |to do: Декодировать данные из файла, читая их через буфер размером `size` байт
+-- В настоящий момент файл читается в память целиком,
+-- что вызвано отсутствием поддержки перехода к следующему буферу
+openFile filename _size = do
+  file     <- fileOpen filename
+  filesize <- fileGetSize file   -- temporary solution
+  let size  = 8 + i filesize     -- ditto
+  buf      <- mallocBytes size
+  let receiveBuf = do len <- fileReadBuf file buf size;  return (buf, len)
+      sendBuf buf size len  =  return ()
+  open receiveBuf sendBuf (free buf >> fileClose file)
+
+-- |Декодировать данные, содержащиеся в буфере `buf` длиной `size`
+openMemory buf size = do
+  ref_bytes_read <- ref 0   -- сколько байт в буфере уже обработано
+  let   -- receiveBuf возвращает (buf,size) без той части данных, которые уже были обработаны
+      receiveBuf = do bytes_read <- val ref_bytes_read
+                      return (buf+:bytes_read, size-bytes_read)
+        -- sendBuf отмечает, что ещё `len` байтов было обработано
+      sendBuf buf size len  =  ref_bytes_read += len
+   -- Использовать универсальный `open`; при попытке перейти к следующему буферу просто возвращать
+   -- остаток данных в `buf`
+  open receiveBuf sendBuf (return ())
+
+-- |to do: Создать универсальный входной поток, используя следующие функции:
+-- receiveBuf : IO (buf,size)                - получить буфер `buf` с данными размером `size`
+-- sendBuf    : buf -> size -> len -> IO ()  - освободить полученный буфер, из которого прочитано `len` байт
+-- cleanup    : IO ()                        - cleanup при завершении работы
+open receiveBuf sendBuf cleanup = do
+  (buf, size) <- receiveBuf   -- сразу получить первый в своей жизни буфер
+  ref_buf  <- ref buf
+  ref_size <- ref size
+  ref_pos  <- ref 0
+  return (InStream ref_buf ref_size ref_pos (receiveBuf, sendBuf, cleanup))
+
+-- |Закрыть входной поток и выполнить процедуру `cleanup`
+closeIn (InStream _ _ _ (_, _, cleanup)) = do
+  cleanup
+
+-- |Возвращает указатель чтения в начало текущего буфера
+rewindMemory buffer@(InStream _ _ pos _) = do
+  pos =: 0
+
+-- |Пропускает заданное число байт
+skipBytes buffer@(InStream _ _ pos _) bytes = do
+  pos += bytes
+
+-- |Проверяет, что мы достигли конца текущего буфера
+isEOFMemory buffer@(InStream _ size' pos' _) = do
+  size <- val size'
+  pos  <- val pos'
+  return (pos==size)
+
+-- |All-in-one операция: создаёт входной поток, читает значение и закрывает поток.
+-- Если вам нужно прочитать несколько значений - соберите их в tuple
+readMemory :: (BufferData a) =>  Ptr CChar -> Int -> IO a
+readMemory buf size = do
+  bracket (openMemory buf size) closeIn read
+
+-- |All-in-one операция: открывает файл, читает значение и закрывает файл.
+-- Если вам нужно прочитать несколько значений - соберите их в tuple
+readFile filename = do
+  bracket (openFile filename aTypicalBuffer) closeIn read
+
+{-# NOINLINE openFile #-}
+{-# NOINLINE openMemory #-}
+{-# NOINLINE open #-}
+{-# NOINLINE closeIn #-}
+{-# NOINLINE readMemory #-}
+
+
+
+----------------------------------------------------------------------------------------------------
+---- Запись блока памяти ---------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+writeBuf :: OutStream -> Ptr a -> Int -> IO ()
+writeBuf buffer@(OutStream ref_buf ref_size ref_pos _) dataptr datasize = do
+  when (datasize>0) $ do
+    ensureFreeSpaceInOutStream buffer 1
+    buf  <- val ref_buf
+    size <- val ref_size
+    pos  <- val ref_pos
+    let len = min datasize (size-pos)
+    copyBytes (buf+:pos) dataptr len
+    ref_pos =: pos+len
+    writeBuf buffer (dataptr+:len) (datasize-len)
+
+
+----------------------------------------------------------------------------------------------------
+---- Классы типов данных, для которых реализовано чтение/запись в буфер ----------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Элементы этого класса могут записываться в выходной буфер и читаться из входного
+class BufferData a where
+  -- |Записать одно значение в выходной буфер
+  write :: OutStream -> a -> IO ()
+
+  -- |Записать в буфер целый список значений - реализация по умолчанию делает это медленно и печально :)
+  writeList :: OutStream -> [a] -> IO ()
+  writeList buffer xs = mapM_ (write buffer) xs
+
+  -- |Прочитать одно значение из входного буфера
+  read :: InStream -> IO a
+
+  -- |Прочитать из входного буфера целый список значений - и тоже реализация по умолчанию слегка задумчива :)
+  readList :: InStream -> Int -> IO [a]
+  readList buffer length  =  replicateM length (read buffer)
+
+  {-# NOINLINE readList #-}
+  {-# NOINLINE writeList #-}
+
+
+-- Утвердить на должности процедуры класса FastBufferData, выполняющие функции процедур класса BufferData :)
+instance (FastBufferData a) => BufferData a where
+  write     = writeFast
+  writeList = writeListFast
+  read      = readFast
+  readList  = readListFast
+
+
+-- |Элементы этого класса могут ОЧЕНЬ БЫСТРО записываться в выходной буфер и читаться из входного
+class FastBufferData a where
+  -- Для этого они должны предоставить следующие справки:
+  --   Максимальное кол-во байт, которое может занимать одно значение (1 для CChar, 4 для Int32 и т.д.)
+  maxSizeOf :: a -> Int
+  --   Процедура, записывающая в буфер `buf` на позицию `pos` значение `x`, и возвращающая
+  --   позицию в буфере после записанных данных (для типов, занимающих фиксированное число байт,
+  --   это будет просто "pos+maxSizeOf x")
+  writeUnchecked :: Ptr CChar -> a -> Int -> IO Int
+  --   Процедура, читающая из буфера `buf` с позиции `pos` значение, возвращающая это значение,
+  --   и обновляющая позицию в буфере
+  readUnchecked :: Ptr CChar -> Int -> IO (a, Int)
+
+  -- |Записать в буфер одно значение - и побыстрее
+  writeFast :: OutStream -> a -> IO ()
+  writeFast buffer@(OutStream ref_buf _ ref_pos _) x = do
+    ensureFreeSpaceInOutStream buffer (maxSizeOf x)   -- проверить, что в буфере хватит места
+    buf <- val ref_buf
+    modifyIORefIO ref_pos (writeUnchecked buf x)   -- записать данные в буфер и обновить значение ref_pos
+
+  -- |Быстро-быстро записать в буфер целый список!
+  writeListFast :: OutStream -> [a] -> IO ()
+  writeListFast buffer@(OutStream ref_buf _ ref_pos _)   list = do
+    let aSIZE = 100
+    -- Проверить, что в буфере хватит места на `aSIZE` значений данного типа
+    ensureFreeSpaceInOutStream buffer (aSIZE * maxSizeOf (head list))
+    buf <- val ref_buf
+    pos <- val ref_pos
+
+    -- Процедура "go list pos n" записывает без всяких проверок, начиная с позиции `pos`,
+    -- данные из списка `list`, но не более `n` значений. Если список оказался
+    -- длиннее - снова вызывается процедура `writeListFast`, которая проверит,
+    -- что в буфере найдётся место для ещё 100 значений, и продолжит запись списка с того
+    -- места, на котором мы остановились
+    --
+    let --go :: (FastBufferData a) => [a] -> Int -> Int -> IO ()
+        go []     pos _  = ref_pos =: pos  -- Мы кончили! Надо только записать новую позицию в буфере!
+        go list   pos 0  = do ref_pos =: pos             -- Записываем новую позицию в буфере
+                              writeListFast buffer list  -- ... и вызываем функцию рекурсивно для остатка списка
+        go (x:xs) pos n  = do new_pos <- writeUnchecked buf x pos    -- записать очередной элемент
+                              go xs new_pos (n-1)                    -- ... и перейти к следующему
+    go list pos aSIZE  -- записать список в память без проверок, но не более `aSIZE` значений
+
+
+  -- |Быстрое чтение одного значения из входного буфера
+  readFast :: InStream -> IO a
+  readFast buffer@(InStream buf _ pos _) = do
+    abuf <- val buf
+    apos <- val pos
+    (x, new_pos) <- readUnchecked abuf apos
+    pos =: new_pos
+    return x
+
+  -- |Быстрое чтение целого списка из входного буфера
+  readListFast :: InStream -> Int -> IO [a]
+  readListFast buffer@(InStream buf _ pos _) length = do
+    abuf <- val buf
+    apos <- val pos
+    let --go :: (FastBufferData a) => Int -> Int -> [a] -> IO [a]
+        go apos 0 xs = do pos =: apos
+                          return (reverse xs)
+        go apos n xs = do (x, new_pos) <- readUnchecked abuf apos
+                          go new_pos (n-1) (x:xs)
+    go apos length []
+
+
+  {-# NOINLINE readFast #-}
+  {-# NOINLINE writeFast #-}
+  {-# NOINLINE readListFast #-}
+  {-# NOINLINE writeListFast #-}
+
+
+
+----------------------------------------------------------------------------------------------------
+---- Реализации для простых типов данных -----------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- Любая инстанция класса Storable автоматически становится инстанцией класса FastBufferData:
+-- мы знаем, сколько данные такого типа занимают байт, и как записать их в память/прочитать из памяти
+instance (Storable a) => FastBufferData a where
+  maxSizeOf = sizeOf
+  writeUnchecked buf x pos = do
+    pokeByteOff buf pos x
+    return (pos + sizeOf x)
+  readUnchecked buf pos = do
+    x <- peekByteOff buf pos
+    return (x, pos + sizeOf x)
+
+
+-- Символы записываются в UTF-8
+instance BufferData Char where
+  write buf c  =  writeList buf (toUTF8List [c])
+  read  buffer@(InStream buf _ pos _) = do
+    buf' <- val buf
+    pos' <- val pos
+    unpackCharUtf8 buf' pos' pos
+
+
+-- Строка записывается как обычный список символов, но с нулевым символом в конце (в стиле Си)
+instance BufferData String where
+  write buf str  =  writeList buf (toUTF8List str)  >>  write buf (0::Word8)
+  read  buffer@(InStream buf _ pos _) = do
+    buf' <- val buf
+    pos' <- val pos
+    unpackCStringUtf8 buf' pos' pos
+
+
+-- Целые числа неограниченной точности кодируются методом, являющимся улучшением используемого в 7-zip.
+-- При этом величины вплоть до 2^64 требуют для записи переменное число байт: от 1 до 9
+instance FastBufferData Integer where
+  maxSizeOf x = 9   -- максимум: 1 байт из единичек и 8 байтов данных
+  writeUnchecked buf x pos = do
+    let write1  x  =  writeUnchecked buf (x::Word8)
+        write4  x  =  writeUnchecked buf (x::Word32)
+        write_8 x  =  writeUnchecked buf (x::Word64)
+    -- В память записывается сразу 4 или 8 байт, но указатель позиции изменяется только на нужное
+    -- число байт. Кол-во младших битов-единичек в первом записанном байте определяет, сколько
+    -- дополнительных байт нужно прочитать, чтобы получить всё число
+    -- Эта реализация рассчитана только на машины, где первым в памяти идёт младший значащий байт!!!
+    -- Кроме того, она оптимизирована для 32-разрядных машин, для 64-битных этот код будет неоптимален
+    case () of
+     _ | x<0       ->  fail$ "Sorry, FastBufferData.Integer.writeUnchecked don't support negative values like this: "++show x
+       | x<128     ->  do write4  (i x*  2+  0) pos; return (pos+1)
+       | x<128^2   ->  do write4  (i x*  4+  1) pos; return (pos+2)
+       | x<128^3   ->  do write4  (i x*  8+  3) pos; return (pos+3)
+       | x<128^4   ->  do write4  (i x* 16+  7) pos; return (pos+4)
+       | x<128^5   ->  do write_8 (i x* 32+ 15) pos; return (pos+5)
+       | x<128^6   ->  do write_8 (i x* 64+ 31) pos; return (pos+6)
+       | x<128^7   ->  do write_8 (i x*128+ 63) pos; return (pos+7)
+       | x<128^8   ->  do write_8 (i x*256+127) pos; return (pos+8)
+       | x<256^8   ->  do write1 255 pos  >>=  write_8 (i x); return (pos+9)
+       | otherwise ->  fail$ "Sorry, FastBufferData.Integer.writeUnchecked don't support numbers larger than 256^8, like this: "++show x
+
+  readUnchecked buf pos = do
+    -- Из памяти читаются сразу 4 байта, но из них используются только младшие байты, остальные маскируются
+    (x::Word32,_)  <-  readUnchecked buf pos
+    case () of
+     _ | x .&.  1 ==   0  ->  return (i$ (x `mod` 256^1) `shiftR` 1, pos+1)
+       | x .&.  3 ==   1  ->  return (i$ (x `mod` 256^2) `shiftR` 2, pos+2)
+       | x .&.  7 ==   3  ->  return (i$ (x `mod` 256^3) `shiftR` 3, pos+3)
+       | x .&. 15 ==   7  ->  return (i$  x              `shiftR` 4, pos+4)
+       | otherwise -> do
+          -- Если значение занимает больше 4-х байт, то прочитать из памяти 8 байтов и опять же замаскировать старшие
+          (x::Word64,_)  <-  readUnchecked buf pos
+          case () of
+           _ | x .&. 31 ==  15  ->  return (i$ (x `mod` 256^5) `shiftR` 5, pos+5)
+             | x .&. 63 ==  31  ->  return (i$ (x `mod` 256^6) `shiftR` 6, pos+6)
+             | x .&.127 ==  63  ->  return (i$ (x `mod` 256^7) `shiftR` 7, pos+7)
+             | x .&.255 == 127  ->  return (i$  x              `shiftR` 8, pos+8)
+             | otherwise        ->  do
+                 -- И последний вариант - байт из единичных битов плюс 8 байт собственно значения
+                 (x::Word64, _) <- readUnchecked buf (pos+1); return (i x, pos+9)
+
+
+-- Булевские величины поодиночке записываются как значения типа Word8 (т.е на каждое
+-- расходуется целый байт), а при записи списка группируются по восемь значений на один байт
+instance FastBufferData Bool where
+  maxSizeOf x = maxSizeOf (undefined :: Word8)
+  writeUnchecked buf x   =  writeUnchecked buf (toWord8 x)
+  readUnchecked buf pos  =  do (x, new_pos) <- readUnchecked buf pos; return (fromWord8 x, new_pos)
+{-
+  writeListFast buffer  =  writeListFast buffer . makeBytes
+   where
+    makeBytes (a:b:c:d:e:f:g:h:xs) = (((((((n a*2+n b)*2+n c)*2+n d)*2+n e)*2+n f)*2+n g)*2+n h) : makeBytes xs
+    makeBytes [a,b,c,d,e,f,g]      = (((((((n a*2+n b)*2+n c)*2+n d)*2+n e)*2+n f)*2+n g)*2) : []
+    makeBytes [a,b,c,d,e,f]        = (((((((n a*2+n b)*2+n c)*2+n d)*2+n e)*2+n f)*2)*2) : []
+    makeBytes [a,b,c,d,e]          = (((((((n a*2+n b)*2+n c)*2+n d)*2+n e)*2)*2)*2) : []
+    makeBytes [a,b,c,d]            = (((((((n a*2+n b)*2+n c)*2+n d)*2)*2)*2)*2) : []
+    makeBytes [a,b,c]              = (((((((n a*2+n b)*2+n c)*2)*2)*2)*2)*2) : []
+    makeBytes [a,b]                = (((((((n a*2+n b)*2)*2)*2)*2)*2)*2) : []
+    makeBytes [a]                  = (((((((n a*2)*2)*2)*2)*2)*2)*2) : []
+    makeBytes []                   = []
+    n = toWord8
+-}
+
+
+
+----------------------------------------------------------------------------------------------------
+---- Реализации для составных типов данных ---------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Функции, позволяющие записывать значения любых целочисленных типов в формате с переменной длиной
+writeInteger buf  =  write buf . toInteger
+readInteger  buf  =  fromInteger <$> read buf
+
+{-
+-- |Записать список неотрицательных значений, ограниченных сверху величиной max'
+-- Для эффективности процесса записи и большей сжимаемости представления все значения при этом
+-- представляются 1/2/4/8 байтами
+writeBoundList buf max =
+  case () of
+    _ | toInteger max <= toInteger (maxBound::Word8)   ->  writeList buf . map toWord8
+      | toInteger max <= toInteger (maxBound::Word16)  ->  writeList buf . map toWord16
+      | toInteger max <= toInteger (maxBound::Word32)  ->  writeList buf . map toWord32
+      | toInteger max <= toInteger (maxBound::Word64)  ->  writeList buf . map toWord64
+      | otherwise                                      ->  writeList buf
+
+-- |Прочитать список неотрицательных значений, ограниченных сверху величиной max'
+-- Для эффективности процесса записи и большей сжимаемости представления все значения при этом
+-- представляются 1/2/4/8 байтами
+readBoundList buf max n =
+  case () of
+    _ | toInteger max <= toInteger (maxBound::Word8)   ->  readList buf n >>= return.map fromWord8
+      | toInteger max <= toInteger (maxBound::Word16)  ->  readList buf n >>= return.map fromWord16
+      | toInteger max <= toInteger (maxBound::Word32)  ->  readList buf n >>= return.map fromWord32
+      | toInteger max <= toInteger (maxBound::Word64)  ->  readList buf n >>= return.map fromWord64
+      | otherwise                                      ->  readList buf n
+-}
+
+instance (BufferData a) => BufferData [a]  where
+  write buf list  =  writeInteger buf (length list)  >>  mapM_ (write buf) list
+  read  buf       =  readInteger  buf                >>=  readList  buf
+
+instance (BufferData a, BufferData b) => BufferData (a,b)  where
+  write buf (a,b) = write buf a  >>  write buf b
+  read  buf       = do a <- read buf; b <- read buf; return (a,b)
+
+instance (BufferData a, BufferData b, BufferData c) => BufferData (a,b,c)  where
+  write buf (a,b,c) = write buf ((a,b),c)
+  read  buf         = do ((a,b),c) <- read buf; return (a,b,c)
+
+instance (BufferData a, BufferData b, BufferData c, BufferData d) => BufferData (a,b,c,d)  where
+  write buf (a,b,c,d) = write buf ((a,b),c,d)
+  read  buf           = do ((a,b),c,d) <- read buf; return (a,b,c,d)
+
+instance (BufferData a, BufferData b, BufferData c, BufferData d, BufferData e) => BufferData (a,b,c,d,e)  where
+  write buf (a,b,c,d,e) = write buf ((a,b),c,d,e)
+  read  buf             = do ((a,b),c,d,e) <- read buf; return (a,b,c,d,e)
+
+instance (BufferData a, BufferData b, BufferData c, BufferData d, BufferData e, BufferData f) => BufferData (a,b,c,d,e,f)  where
+  write buf (a,b,c,d,e,f) = write buf ((a,b),c,d,e,f)
+  read  buf               = do ((a,b),c,d,e,f) <- read buf; return (a,b,c,d,e,f)
+
+instance (BufferData a, BufferData b, BufferData c, BufferData d, BufferData e, BufferData f, BufferData g) => BufferData (a,b,c,d,e,f,g)  where
+  write buf (a,b,c,d,e,f,g) = write buf ((a,b),c,d,e,f,g)
+  read  buf                 = do ((a,b),c,d,e,f,g) <- read buf; return (a,b,c,d,e,f,g)
+
+instance (BufferData a, BufferData b, BufferData c, BufferData d, BufferData e, BufferData f, BufferData g, BufferData h) => BufferData (a,b,c,d,e,f,g,h)  where
+  write buf (a,b,c,d,e,f,g,h) = write buf ((a,b),c,d,e,f,g,h)
+  read  buf                   = do ((a,b),c,d,e,f,g,h) <- read buf; return (a,b,c,d,e,f,g,h)
+
+instance (BufferData a) => BufferData (Maybe a)  where
+  write buf (Just  a) = write buf (True,a)
+  write buf Nothing = write buf False
+  read buf = do x <- read buf; if x  then Just <$> read buf  else return Nothing
+
+instance (BufferData a, BufferData b) => BufferData (Either a b)  where
+  write buf (Left  a) = write buf (True, a)
+  write buf (Right b) = write buf (False,b)
+  read buf = do x <- read buf; if x  then Left <$> read buf  else Right <$> read buf
+
+{- Попытка сделать универсальный класс для чтения/записи данных
+class DerivedBufferData a where
+  toTuple   :: BufferData b => a -> b
+  fromTuple :: BufferData b => b -> a
+
+instance DerivedBufferData a => BufferData a where
+  write buf a  =  write buf (toTuple a)
+  read  buf    =  do a <- read buf; return (fromTuple a)
+
+instance (BufferData a, BufferData b) => DerivedBufferData (Either a b)  where
+  toTuple   (Left  a)  = (True,  a)
+  toTuple   (Right b)  = (False, b)
+  fromTuple (True,  a) = (Left   a)
+  fromTuple (False, b) = (Right  b)
+
+instance (Enum a) => BufferData a  where
+  write buf a = writeInteger buf (fromEnum a)
+  read  buf   = readInteger  buf >>= return.toEnum
+-}
+
+instance (FastBufferData a, FastBufferData b) => FastBufferData (a,b)  where
+  maxSizeOf (a,b)               =  maxSizeOf a + maxSizeOf b
+  writeUnchecked buf (a,b) pos  =  writeUnchecked buf a pos  >>=  writeUnchecked buf b
+  readUnchecked buf pos         =  do
+    (a, pos) <- readUnchecked buf pos
+    (b, pos) <- readUnchecked buf pos
+    return ((a,b), pos)
+  {-# NOINLINE writeUnchecked #-}
+  {-# NOINLINE readUnchecked #-}
+
+instance (FastBufferData a, FastBufferData b, FastBufferData c) => FastBufferData (a,b,c)  where
+  maxSizeOf (a,b,c)               =  maxSizeOf a + maxSizeOf b + maxSizeOf c
+  writeUnchecked buf (a,b,c) pos  =
+    writeUnchecked buf a pos
+      >>=  writeUnchecked buf b
+      >>=  writeUnchecked buf c
+  readUnchecked buf pos           =  do
+    (a, pos) <- readUnchecked buf pos
+    (b, pos) <- readUnchecked buf pos
+    (c, pos) <- readUnchecked buf pos
+    return ((a,b,c), pos)
+  {-# NOINLINE writeUnchecked #-}
+  {-# NOINLINE readUnchecked #-}
+
+instance (FastBufferData a, FastBufferData b, FastBufferData c, FastBufferData d) => FastBufferData (a,b,c,d)  where
+  maxSizeOf (a,b,c,d)               =  maxSizeOf a + maxSizeOf b + maxSizeOf c + maxSizeOf d
+  writeUnchecked buf (a,b,c,d) pos  =
+    writeUnchecked buf a pos
+      >>=  writeUnchecked buf b
+      >>=  writeUnchecked buf c
+      >>=  writeUnchecked buf d
+  readUnchecked buf pos             =  do
+    (a, pos) <- readUnchecked buf pos
+    (b, pos) <- readUnchecked buf pos
+    (c, pos) <- readUnchecked buf pos
+    (d, pos) <- readUnchecked buf pos
+    return ((a,b,c,d), pos)
+  {-# NOINLINE writeUnchecked #-}
+  {-# NOINLINE readUnchecked #-}
+
+
+
+----------------------------------------------------------------------------------------------------
+---- Вспомогательные функции -----------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Функции преобразования к заданным типам
+toWord8  x = toEnum (fromEnum x) :: Word8
+toWord16 x = toEnum (fromEnum x) :: Word16
+toWord32 x = toEnum (fromEnum x) :: Word32
+toWord64 x = i x                 :: Word64
+
+-- |Функции преобразования из заданных типов
+fromWord8  (x::Word8 ) = toEnum (fromEnum x)
+fromWord16 (x::Word16) = toEnum (fromEnum x)
+fromWord32 (x::Word32) = toEnum (fromEnum x)
+fromWord64 (x::Word64) = i x
+
+
+
+
+
+
+
+
+toUTF8List :: String -> [Word8]
+toUTF8List a | a `seq` False = undefined
+toUTF8List [] = []
+toUTF8List (x:xs)
+  | ord x<=0x007f = fromIntegral (ord x):
+                    toUTF8List xs
+  | ord x<=0x07ff = fromIntegral (0xC0 .|. ((ord x `shiftR` 6) .&. 0x1F)):
+                    fromIntegral (0x80 .|. (ord x .&. 0x3F)):
+                    toUTF8List xs
+  | ord x<=0xffff = fromIntegral (0xE0 .|. ((ord x `shiftR` 12) .&. 0x0F)):
+                    fromIntegral (0x80 .|. ((ord x `shiftR` 6) .&. 0x3F)):
+                    fromIntegral (0x80 .|. (ord x .&. 0x3F)):
+                    toUTF8List xs
+  | otherwise     = fromIntegral (0xF0 .|. (ord x `shiftR` 18)) :
+                    fromIntegral (0x80 .|. ((ord x `shiftR` 12) .&. 0x3F)) :
+                    fromIntegral (0x80 .|. ((ord x `shiftR` 6) .&. 0x3F)) :
+                    fromIntegral (0x80 .|. (ord x .&. 0x3F)) :
+                    toUTF8List xs
+
+
+-- | Convert UTF-8 to Unicode.
+fromUTF8 :: [Word8] -> String
+fromUTF8 xs = fromUTF' (map fromIntegral xs) where
+    fromUTF' [] = []
+    fromUTF' all@(x:xs)
+        | x<=0x7F = chr x:fromUTF' xs
+        | x<=0xBF = err
+        | x<=0xDF = twoBytes all
+        | x<=0xEF = threeBytes all
+        | otherwise   = fourBytes all
+    twoBytes (x1:x2:xs) = chr  (((x1 .&. 0x1F) `shift` 6) .|.
+                                  (x2 .&. 0x3F)):fromUTF' xs
+    twoBytes _ = error "fromUTF8: illegal two byte sequence"
+
+    threeBytes (x1:x2:x3:xs) = chr (((x1 .&. 0x0F) `shift` 12) .|.
+                                     ((x2 .&. 0x3F) `shift` 6) .|.
+                                      (x3 .&. 0x3F)):fromUTF' xs
+    threeBytes _ = error "fromUTF8: illegal three byte sequence"
+
+    fourBytes (x1:x2:x3:x4:xs) = chr (((x1 .&. 0x0F) `shift` 18) .|.
+                                       ((x2 .&. 0x3F) `shift` 12) .|.
+                                       ((x3 .&. 0x3F) `shift` 6) .|.
+                                        (x4 .&. 0x3F)):fromUTF' xs
+    fourBytes _ = error "fromUTF8: illegal four byte sequence"
+
+    err = error "fromUTF8: illegal UTF-8 character"
+
+
+-- |Convert UTF8-encoded byte array to Char
+unpackCharUtf8 a b c | a `seq` b `seq` c `seq` False = undefined
+unpackCharUtf8 buf pos ref_pos = do
+      let addr = castPtr buf :: Ptr Word8
+      ch0 <- fromIntegral <$> peekElemOff addr pos
+      case () of
+         _ | ch0 <= 0x7F -> do
+                ref_pos =: pos+1
+                return $! unsafeChr (fromIntegral ch0)
+           | ch0 <= 0xDF -> do
+                ref_pos =: pos+2
+                ch1 <- fromIntegral <$> peekElemOff addr (pos+1)
+                return $! unsafeChr (((ch0 - 0xC0) `shiftL` 6) +
+                                       (ch1 - 0x80))
+           | ch0 <= 0xEF -> do
+                ref_pos =: pos+3
+                ch1 <- fromIntegral <$> peekElemOff addr (pos+1)
+                ch2 <- fromIntegral <$> peekElemOff addr (pos+2)
+                return $! unsafeChr (((ch0 - 0xE0) `shiftL` 12) +
+                                      ((ch1 - 0x80) `shiftL` 6) +
+                                       (ch2 - 0x80))
+           | otherwise -> do
+                ref_pos =: pos+4
+                ch1 <- fromIntegral <$> peekElemOff addr (pos+1)
+                ch2 <- fromIntegral <$> peekElemOff addr (pos+2)
+                ch3 <- fromIntegral <$> peekElemOff addr (pos+3)
+                return $! unsafeChr (((ch0 - 0xF0) `shiftL` 18) +
+                                      ((ch1 - 0x80) `shiftL` 12) +
+                                      ((ch2 - 0x80) `shiftL` 6) +
+                                       (ch3 - 0x80))
+
+
+-- |Convert UTF8-encoded byte array to String
+--unpackCStringUtf8 :: Ptr Word8 -> Int -> IO String
+unpackCStringUtf8 a b c | a `seq` b `seq` c `seq` False = undefined
+unpackCStringUtf8 buf pos ref_pos = do
+  unpack pos
+  where
+    addr = castPtr buf :: Ptr Word8
+    unpack nh = do
+      ch0 <- fromIntegral <$> peekElemOff addr nh
+      case () of
+         _ | ch0 == 0 -> do
+                ref_pos =: nh + 1
+                return []
+           | ch0 <= 0x7F -> do
+                chs <- unpack (nh + 1)
+                return $! (unsafeChr (fromIntegral ch0) : chs)
+           | ch0 <= 0xDF -> do
+                ch1 <- fromIntegral <$> peekElemOff addr (nh+1)
+                chs <- unpack (nh + 2)
+                return $! (unsafeChr (((ch0 - 0xC0) `shiftL` 6) +
+                                       (ch1 - 0x80)) : chs)
+           | ch0 <= 0xEF -> do
+                ch1 <- fromIntegral <$> peekElemOff addr (nh+1)
+                ch2 <- fromIntegral <$> peekElemOff addr (nh+2)
+                chs <- unpack (nh + 3)
+                return $! (unsafeChr (((ch0 - 0xE0) `shiftL` 12) +
+                                      ((ch1 - 0x80) `shiftL` 6) +
+                                       (ch2 - 0x80)) : chs)
+           | otherwise -> do
+                ch1 <- fromIntegral <$> peekElemOff addr (nh+1)
+                ch2 <- fromIntegral <$> peekElemOff addr (nh+2)
+                ch3 <- fromIntegral <$> peekElemOff addr (nh+3)
+                chs <- unpack (nh + 4)
+                return $! (unsafeChr (((ch0 - 0xF0) `shiftL` 18) +
+                                      ((ch1 - 0x80) `shiftL` 12) +
+                                      ((ch2 - 0x80) `shiftL` 6) +
+                                       (ch3 - 0x80)) : chs)
+
+
+----------------------------------------------------------------------------------------------------
+---- Example of simple usage of in/out byte streams ------------------------------------------------
+----------------------------------------------------------------------------------------------------
+{-
+test = do
+  -- Writing and reading memory buffer as one operation
+  --to do: (buf,bufsize)  <-  ByteStream.writeMemory (sign, block_type, crc)
+  (sign::Word32, block_type::Int16, crc::Word64)  <-  ByteStream.readMemory buf bufsize
+
+  -- Writing and reading file as one operation
+  ByteStream.writeFile "test" [1..1000::Integer]
+  (restored::[Integer]) <- ByteStream.readFile "test"
+
+  -- Writing and reading file, divided to low-level operations
+  stream <- ByteStream.createFile "test" 5000
+  ByteStream.write stream  "asdfr"
+  ByteStream.write stream  "12345"
+  ByteStream.write stream  [10,20..500::Int]
+  ByteStream.write stream  ([10,20..500] ++ [103*10^3, 106*10^6, 109*10^9, 112*10^12, 115*10^15::Integer])
+  ByteStream.write stream  (concat$ replicate 100 [True,False,True])
+  ByteStream.closeOut stream
+
+  stream <- ByteStream.openFile "test" 5000
+  (x::String)    <- ByteStream.read stream
+  (y::String)    <- ByteStream.read stream
+  (a::[Int])     <- ByteStream.read stream
+  (b::[Integer]) <- ByteStream.read stream
+  (c::[Bool])    <- ByteStream.read stream
+  ByteStream.closeIn stream
+  print [x,y]
+  print a
+  print b
+  print c
+-}
+--Checklist:
+--1. +получать буфера функцией receiveBuf = receiveP pipe
+--2. +write для Storable по умолчанию - проверяет наличие свободного места и делает pokeByteOff elem
+--3. +быстрая запись строк
+--4. +использовать writeUnchecked
+--5. +доделать кодирование Integer
+--6. +переименовать WriteList в WriteListWithoutLength
+--7. +упростить имена функций для квалифицированного импорта и сделать read/writeList=writeLength+writeListWithoutLength
+--8. правильно переходить с одного буфера на другой
+--9. читать более 100 элементов в списке
+--10. восстановить кодирование [Bool]
+--11. переделать чтение строк чтоб избавиться от reverse (в стёк помещать пормежуточные данные - без tail recursion)
+--12. чтение FastBufferData организовать без возврашения tuple - pos сделать или IORef Int, или FastMutInt, или IORef (Ptr CChar)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/CUI.hs
+++ b/CUI.hs
@@ -1,3 +1,249 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2f37f092beb4f437f07fe26a7521185d77f5776c6016045200149c5056c4d098
-size 9971
+{-# OPTIONS_GHC -cpp #-}
+----------------------------------------------------------------------------------------------------
+---- Информирование пользователя о ходе выполнения программы (CUI - Console User Interface).  ------
+----------------------------------------------------------------------------------------------------
+module CUI where
+
+import Prelude hiding (catch)
+import Control.Monad
+import Control.Concurrent
+import Data.Char
+import Data.IORef
+import Foreign
+import Foreign.C
+import Numeric           (showFFloat)
+import System.CPUTime    (getCPUTime)
+import System.IO
+import System.Time
+#ifdef FREEARC_WIN
+import System.Win32.Types
+#endif
+#ifdef FREEARC_UNIX
+import System.Posix.IO
+import System.Posix.Terminal
+#endif
+
+import Utils
+import Errors
+import Files
+import FileInfo
+import Options
+import UIBase
+
+
+----------------------------------------------------------------------------------------------------
+---- Отображение индикатора прогресса --------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Запускает background thread для вывода индикатора прогресса
+guiStartProgram = do
+  -- Обновляем индикатор прогресса и заголовок окна раз в 0.5 секунды
+  indicatorThread 0.5 $ \indicator indType title b bytes total processed p -> do
+    myPutStr$ back_percents indicator ++ p
+    myFlushStdout
+    setConsoleTitle title
+
+-- |Вызывается в начале обработки файла
+guiStartFile = do
+  command <- val ref_command
+  when (opt_indicator command == "2") $ do
+    syncUI $ do
+    uiSuspendProgressIndicator
+    uiMessage' <- val uiMessage
+    myPutStrLn   ""
+    myPutStr$    left_justify 72 (msgFile(cmd_name command) ++ uiMessage')
+    uiResumeProgressIndicator
+    hFlush stdout
+
+-- |Приостановить вывод индикатора прогресса и стереть его следы
+uiSuspendProgressIndicator = do
+  aProgressIndicatorEnabled =: False
+  (indicator, indType, arcname, direction, b, bytes', total') <- val aProgressIndicatorState
+  myPutStr$ clear_percents indicator
+  myFlushStdout
+
+-- |Возобновить вывод индикатора прогресса и вывести его текущее значение
+uiResumeProgressIndicator = do
+  (indicator, indType, arcname, direction, b, bytes', total') <- val aProgressIndicatorState
+  bytes <- bytes' b;  total <- total'
+  myPutStr$ percents indicator bytes total
+  myFlushStdout
+  aProgressIndicatorEnabled =: True
+
+{-# NOINLINE guiStartProgram #-}
+{-# NOINLINE guiStartFile #-}
+{-# NOINLINE uiSuspendProgressIndicator #-}
+{-# NOINLINE uiResumeProgressIndicator #-}
+
+
+----------------------------------------------------------------------------------------------------
+---- Запросы к пользователю ("Перезаписать файл?" и т.п.) ------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Запрос о перезаписи файла
+askOverwrite filename _ _ _ =  ask ("Overwrite " ++ filename)
+{-# NOINLINE askOverwrite #-}
+
+-- |Общий механизм для выдачи запросов к пользователю
+ask question ref_answer answer_on_u =  do
+  old_answer <- val ref_answer
+  new_answer <- case old_answer of
+                  "a" -> return old_answer
+                  "u" -> return old_answer
+                  "s" -> return old_answer
+                  _   -> ask_user question
+  ref_answer =: new_answer
+  case new_answer of
+    "u" -> return answer_on_u
+    _   -> return (new_answer `elem` ["y","a"])
+
+-- |Собственно общение с пользователем происходит здесь
+ask_user question = syncUI $ pauseTiming go  where
+  go = do myPutStr$ "\n  "++question++" ("++valid_answers++")? "
+          hFlush stdout
+          answer  <-  getLine >>== strLower
+          when (answer=="q") $ do
+              terminateOperation
+          if (answer `elem` (split '/' valid_answers))
+            then return answer
+            else myPutStr askHelp >> go
+
+-- |Подсказка, выводимая на экран при недопустимом ответе
+askHelp = unlines [ "  Valid answers are:"
+                  , "    y - yes"
+                  , "    n - no"
+                  , "    a - always, answer yes to all remaining queries"
+                  , "    s - skip, answer no to all remaining queries"
+                  , "    u - update remaining files (yes for each extracted file that is newer than file on disk)"
+                  , "    q - quit program"
+                  ]
+
+valid_answers = "y/n/a/s/u/q"
+
+
+----------------------------------------------------------------------------------------------------
+---- Запрос паролей --------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+ask_passwords = (ask_encryption_password, ask_decryption_password, bad_decryption_password)
+
+-- |Печатает сообщение о том, что введённый пароль не подходит для дешифрования
+bad_decryption_password = myPutStrLn "Incorrect password"
+
+-- |Запрос пароля при сжатии. Используется невидимый ввод
+-- и запрос повторяется дважды для исключения ошибки при его вводе
+ask_encryption_password opt_parseData = syncUI $ pauseTiming $ do
+  withoutEcho $ go where
+    go = do myPutStr "\n  Enter encryption password:"
+            hFlush stdout
+            answer <- getHiddenLine >>== opt_parseData 't'
+            myPutStr "  Reenter encryption password:"
+            hFlush stdout
+            answer2 <- getHiddenLine >>== opt_parseData 't'
+            if answer/=answer2
+              then do myPutStrLn "  Passwords are different. You need to repeat input"
+                      go
+              else return answer
+
+-- |Запрос пароля для распаковки. Используется невидимый ввод
+ask_decryption_password opt_parseData = syncUI $ pauseTiming $ do
+  withoutEcho $ do
+  myPutStr "\n  Enter decryption password:"
+  hFlush stdout
+  getHiddenLine >>== opt_parseData 't'
+
+-- |Ввести строку, не отображая её на экране
+getHiddenLine = go ""
+  where go s = do c <- getHiddenChar
+                  case c of
+                    '\r' -> do myPutStrLn ""; return s
+                    '\n' -> do myPutStrLn ""; return s
+                    c    -> go (s++[c])
+
+
+#ifdef FREEARC_WIN
+
+-- |Перевести консоль в режим невидимого ввода
+withoutEcho = id
+-- |Ввести символ без эха
+getHiddenChar = liftM (chr.fromEnum) c_getch
+foreign import ccall unsafe "conio.h getch"
+   c_getch :: IO CInt
+
+#else
+
+getHiddenChar = getChar
+
+withoutEcho action = do
+  let setAttr attr = setTerminalAttributes stdInput attr Immediately
+      disableEcho = do origAttr <- getTerminalAttributes stdInput
+                       setAttr$ origAttr.$ flip withMode ProcessInput
+                                        .$ flip withoutMode EnableEcho
+                                        .$ flip withMode KeyboardInterrupts
+                                        .$ flip withoutMode IgnoreBreak
+                                        .$ flip withMode InterruptOnBreak
+                       return origAttr
+  --
+  bracketCtrlBreak "restoreEcho" disableEcho setAttr (\_ -> action)
+
+#endif
+
+{-# NOINLINE ask_passwords #-}
+
+
+----------------------------------------------------------------------------------------------------
+---- Ввод/вывод комментариев к архиву  -------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Вывести на экран комментарий к архиву
+uiPrintArcComment arcComment = do
+  when (arcComment>"") $ do
+    myPutStrLn arcComment
+
+-- |Ввести с stdin комментарий к архиву
+uiInputArcComment old_comment = syncUI $ pauseTiming $ do
+  myPutStrLn "Enter archive comment, ending with \".\" on separate line:"
+  hFlush stdout
+  let go xs = do line <- myGetLine
+                 if line/="."
+                   then go (line:xs)
+                   else return$ joinWith "\n" $ reverse xs
+  --
+  go []
+
+{-# NOINLINE uiPrintArcComment #-}
+{-# NOINLINE uiInputArcComment #-}
+
+----------------------------------------------------------------------------------------------------
+----- External functions ---------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+#ifdef FREEARC_WIN
+type TString = Ptr TCHAR
+#else
+withTString  = withCString
+type TString = CString
+#endif
+
+-- |Set console title
+#if defined(FREEARC_WIN)
+setConsoleTitle title = do
+  withTString title c_SetConsoleTitle
+
+-- |Set console title (external C function on Windows)
+foreign import ccall unsafe "Environment.h EnvSetConsoleTitle"
+  c_SetConsoleTitle :: TString -> IO ()
+
+-- |Reset console title (Windows)
+foreign import ccall unsafe "Environment.h EnvResetConsoleTitle"
+  resetConsoleTitle :: IO ()
+
+#else
+-- |Set console title via ANSI/xterm escape sequence on Unix
+setConsoleTitle title = hPutStr stderr ("\ESC]0;" ++ title ++ "\BEL") >> hFlush stderr
+
+-- |Reset console title - no-op on Unix (title was set with escape sequence)
+resetConsoleTitle :: IO ()
+resetConsoleTitle = return ()
+#endif
+

--- a/Charsets.hs
+++ b/Charsets.hs
@@ -1,3 +1,456 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:66ebb4d8eb559ad616b3f8d5e5900d4e2dcc04c2ff02b4fe032e32cee935e7b5
-size 20954
+{-# LANGUAGE CPP #-}
+----------------------------------------------------------------------------------------------------
+---- Поддержка различных кодировок и локализации интерфейса программы                           ----
+----------------------------------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Charsets
+-- Copyright   :  (c) Bulat Ziganshin <Bulat.Ziganshin@gmail.com>
+-- License     :  Public domain
+--
+-- Maintainer  :  Bulat.Ziganshin@gmail.com
+-- Stability   :  experimental
+-- Portability :  GHC
+--
+-----------------------------------------------------------------------------
+
+module Charsets where
+
+import Prelude hiding (catch)
+import Control.Concurrent
+import Control.Concurrent.MVar
+import Control.Exception
+import Control.Monad
+import Data.Array
+import Data.Char
+import Data.IORef
+import Data.List
+import Foreign
+import Foreign.C
+import Foreign.Marshal.Alloc
+import System.Posix.Internals
+import System.Posix.Types
+import System.IO
+import System.IO.Error hiding (catch)
+import System.IO.Unsafe
+-- import System.Locale
+-- import System.Time
+import System.Process
+import System.Directory
+import System.Environment
+import Utils
+import Files
+
+
+---------------------------------------------------------------------------------------------------
+---- Глобальные настройки перекодировки для использования в глубоко вложенных функциях ------------
+---------------------------------------------------------------------------------------------------
+
+-- DWORD: 32-bit unsigned int; equivalent to System.Win32.Types.DWORD on Windows
+type DWORD = CUInt
+
+-- |Translate string from internal to terminal encoding
+{-# NOINLINE str2terminal' #-}
+str2terminal'     = unsafePerformIO$ newIORef$ unParseData (domainTranslation aCharsetDefaults 't')
+str2terminal s    = val str2terminal' >>== ($ s)
+-- |Translate string from terminal to internal encoding
+{-# NOINLINE terminal2str' #-}
+terminal2str'     = unsafePerformIO$ newIORef$ parseData (domainTranslation aCharsetDefaults 't')
+terminal2str s    = val terminal2str' >>== ($ s)
+-- |Translate string from cmdline to internal encoding
+{-# NOINLINE cmdline2str' #-}
+cmdline2str'      = unsafePerformIO$ newIORef$ parseData (domainTranslation aCharsetDefaults 'p')
+cmdline2str s     = val cmdline2str' >>== ($ s)
+-- |Translate string from internal to logfile encoding
+{-# NOINLINE str2logfile' #-}
+str2logfile'      = unsafePerformIO$ newIORef$ unParseData (domainTranslation aCharsetDefaults 'i')
+str2logfile s     = val str2logfile' >>== ($ s)
+
+-- |Операция, устанавливающая глобальные настройки перекодировки для использования в глубоко вложенных функциях
+setGlobalCharsets charsets = do
+  str2filesystem' =: unParseData (domainTranslation charsets 'f')
+  str2terminal'   =: unParseData (domainTranslation charsets 't')
+  str2logfile'    =: unParseData (domainTranslation charsets 'i')
+  terminal2str'   =: parseData (domainTranslation charsets 't')
+  filesystem2str' =: parseData (domainTranslation charsets 'f')
+  cmdline2str'    =: parseData (domainTranslation charsets 'p')
+
+
+-- Получение командной строки
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+myGetArgs = getArgs >>= mapM cmdline2str
+
+
+
+---------------------------------------------------------------------------------------------------
+---- Парсер опции командной строки -sc/--charset --------------------------------------------------
+---------------------------------------------------------------------------------------------------
+
+-- |Тип функции, транслирующей входных данные заданного типа в Unicode
+type ParseDataFunc  =  Domain -> String -> String
+
+-- |Обработать список опций --charset/-sc, возвратив таблицу кодировок
+-- и процедуры чтения/записи файлов с её учётом
+parseCharsetOption optionsList = (charsets
+                                   ,parseFile   . domainTranslation charsets
+                                   ,unParseFile . domainTranslation charsets
+                                   ,parseData   . domainTranslation charsets
+                                   ,unParseData . domainTranslation charsets)
+  where
+    -- Таблица кодировок
+    charsets = foldl f aCharsetDefaults optionsList
+    -- Функция обработки опций --charset
+    f value "--"      =  aCharsetDefaults      -- -sc-- означает восстановить значения по умолчанию
+    f value ('s':cs)  =  _7zToRAR value "l" cs  -- -scs... устанавливает кодировку для листфайлов
+    f value ('l':cs)  =  _7zToRAR value "l" cs  -- -scl... does the same
+    f value ('c':cs)  =  _7zToRAR value "c" cs  -- -scs... устанавливает кодировку для комментфайлов
+    f value ('f':cs)  =  _7zToRAR value "f" cs  -- -scf... устанавливает кодировку для файловой системы
+    f value ('d':cs)  =  _7zToRAR value "d" cs  -- -scd... устанавливает кодировку для каталога архива
+    f value ('t':cs)  =  _7zToRAR value "t" cs  -- -sct... устанавливает кодировку для терминала (консоли)
+    f value ('p':cs)  =  _7zToRAR value "p" cs  -- -scp... устанавливает кодировку для параметров ком. строки
+    f value ('i':cs)  =  _7zToRAR value "i" cs  -- -sci... устанавливает кодировку для ini-файлов (arc.ini/arc.groups)
+    f value (x:cs)    =  foldl Utils.update value [(c,x) | c<-cs|||"cl"]  -- установить в `x` элементы списка, перечисленные в cs (по умолчанию 'c' и 'l')
+    -- Вспомогательные функции, преобразующие 7zip-овский формат опций в RAR'овский
+    _7zToRAR value typ cs  =  f value (g (strLower cs):typ)
+    g "utf-8"  = '8';  g "win"  = 'a'
+    g "utf8"   = '8';  g "ansi" = 'a'
+    g "utf-16" = 'u';  g "dos"  = 'o'
+    g "utf16"  = 'u';  g "oem"  = 'o'
+
+
+-- Процедура чтения файла, транслирующая его кодировку и разбивающая на отдельные строки
+parseFile encoding file  =  fileGetBinary file >>== parseData encoding >>== linesCRLF
+
+-- Процедура трансляции входных данных из encoding в Unicode
+parseData encoding  =  aTRANSLATE_INPUT (charsetTranslation encoding)
+
+-- Процедура записи файла, транслирующая данные в кодировку encoding
+unParseFile encoding file  =  filePutBinary file . unParseData encoding
+
+-- Процедура трансляции выходных данных из encoding из Unicode
+unParseData encoding  =  aTRANSLATE_OUTPUT (charsetTranslation encoding)
+
+-- |Разбиение на строки файла, ипользующего любое представление конца строки (CR, LF, CR+LF)
+linesCRLF = recursive oneline  -- oneline "abc\n..." = ("abc","...")
+              where oneline ('\r':'\n':s)  =  ("",'\xFEFF':s)
+                    oneline ('\r':s)       =  ("",'\xFEFF':s)
+                    oneline ('\n':s)       =  ("",'\xFEFF':s)
+                    oneline ('\xFEFF':s)   =  oneline s
+                    oneline (c:s)          =  (c:s0,s1)  where (s0,s1) = oneline s
+                    oneline ""             =  ("","")
+
+
+-- Будем считать, что все GUI конфиг-файлы хранятся в UTF-8
+readConfigFile          = parseFile   '8'
+saveConfigFile   file   = unParseFile '8' file . joinWith "\n"
+modifyConfigFile file f = handle (\(e::SomeException)->return []) (readConfigFile file) >>== f >>= saveConfigFile file
+
+
+---------------------------------------------------------------------------------------------------
+---- Поддержка различных кодировок для ввода/вывода -----------------------------------------------
+---------------------------------------------------------------------------------------------------
+
+-- |Возвращает charset, используемый в domainCharsets для данных типа domain
+domainTranslation domainCharsets domain =
+  lookup domain domainCharsets `defaultVal` error ("Unknown charset domain "++quote [domain])
+
+-- |Трансляция данных, заданных в кодировке charset
+charsetTranslation charset =
+  lookup charset aCHARSETS `defaultVal` error ("Unknown charset "++quote [charset])
+
+-- |Трансляция данных из области domain (листфайлы, конфигфайлы, коммент-файлы...),
+-- используя charset, заданный для неё в domainСharsets
+translation domainCharsets domain =
+  charsetTranslation $ domainTranslation domainCharsets domain
+
+-- Типы, используемые для представления domain и charset
+type Domain  = Char
+type Charset = Char
+
+-- |Each charset is represented by pair of functions: input translation (byte sequence into Unicode String) and output translation
+data TRANSLATION = TRANSLATION {aTRANSLATE_INPUT, aTRANSLATE_OUTPUT :: String->String}
+
+-- |Character sets and functions to translate texts from/to these charsets
+aCHARSETS = [ ('0', TRANSLATION id               id)
+            , ('8', TRANSLATION utf8_to_unicode  unicode2utf8)
+            , ('u', TRANSLATION utf16_to_unicode unicode2utf16)
+            ] ++ aLocalCharsets
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+-- |Windows-specific charsets
+aLocalCharsets = [ ('o', TRANSLATION oem2unicode  unicode2oem)
+                  , ('a', TRANSLATION ansi2unicode unicode2ansi)
+                  ]
+
+-- |Default charsets for various domains
+#ifdef FREEARC_WIN
+aCharsetDefaults = [ ('f','u')  -- filenames in filesystem: UTF-16 (Windows uses wide-char API)
+                    , ('d','8')  -- filenames in archive directory: UTF-8
+                    , ('l','o')  -- filelists: OEM
+                    , ('c','o')  -- comment files: OEM
+                    , ('t','o')  -- terminal: OEM
+                    , ('p','a')  -- program arguments: ANSI
+                    , ('i','o')  -- ini/group files: OEM
+                    ]
+#else
+aCharsetDefaults = [ ('f','8')  -- filenames in filesystem: UTF-8 (Linux/Unix uses UTF-8 paths)
+                    , ('d','8')  -- filenames in archive directory: UTF-8
+                    , ('l','8')  -- filelists: UTF-8
+                    , ('c','8')  -- comment files: UTF-8
+                    , ('t','8')  -- terminal: UTF-8
+                    , ('p','8')  -- program arguments: UTF-8
+                    , ('i','8')  -- ini/group files: UTF-8
+                    ]
+#endif
+
+---------------------------------------------------------------------------------------------------
+---- Windows-specific codecs ----------------------------------------------------------------------
+---------------------------------------------------------------------------------------------------
+
+-- |Преобразовать виндовые коды символов \r и \n в человеческий вид
+iHateWindows = replace (chr 9834) '\r' . replace (chr 9689) '\n'
+
+#ifdef FREEARC_WIN
+-- |Translate string from Unicode to OEM encoding
+unicode2oem s =
+  if all isAscii s
+    then s
+    else unsafePerformIO $ do
+           withCWStringLen s $ \(wstr,len) -> do
+             allocaBytes len $ \cstr -> do
+               c_WideToOemBuff wstr cstr (i len)
+               peekCStringLen (cstr,len)
+
+-- |Translate string from OEM encoding to Unicode
+oem2unicode s =
+  if all isAscii s
+    then s
+    else iHateWindows $
+         unsafePerformIO $ do
+           withCStringLen s $ \(cstr,len) -> do
+             allocaBytes (len*2) $ \wstr -> do
+               c_OemToWideBuff cstr wstr (i len)
+               peekCWStringLen (wstr,len)
+
+-- |Translate string from Unicode to ANSI encoding
+unicode2ansi s =
+  if all isAscii s
+    then s
+    else unsafePerformIO $ do
+           withCWStringLen s $ \(wstr,len) -> do
+             allocaBytes len $ \cstr -> do
+               c_WideToOemBuff wstr cstr (i len)
+               c_OemToAnsiBuff cstr cstr (i len)
+               peekCStringLen (cstr,len)
+
+-- |Translate string from ANSI encoding to Unicode
+ansi2unicode s =
+  if all isAscii s
+    then s
+    else iHateWindows $
+         unsafePerformIO $ do
+           withCStringLen s $ \(cstr,len) -> do
+             allocaBytes (len*2) $ \wstr -> do
+               c_AnsiToOemBuff cstr cstr (i len)
+               c_OemToWideBuff cstr wstr (i len)
+               peekCWStringLen (wstr,len)
+
+foreign import stdcall unsafe "winuser.h CharToOemBuffW"
+  c_WideToOemBuff :: CWString -> CString -> DWORD -> IO Bool
+
+foreign import stdcall unsafe "winuser.h OemToCharBuffW"
+  c_OemToWideBuff :: CString -> CWString -> DWORD -> IO Bool
+
+foreign import stdcall unsafe "winuser.h OemToCharBuffA"
+  c_OemToAnsiBuff :: CString -> CString -> DWORD -> IO Bool
+
+foreign import stdcall unsafe "winuser.h CharToOemBuffA"
+  c_AnsiToOemBuff :: CString -> CString -> DWORD -> IO Bool
+#else
+-- Non-Windows stubs: on Unix, strings are already in Unicode (UTF-8)
+unicode2oem  = id
+oem2unicode  = id
+unicode2ansi = id
+ansi2unicode = id
+#endif
+
+
+
+
+---------------------------------------------------------------------------------------------------
+---- UTF-8, UTF-16 codecs -------------------------------------------------------------------------
+---------------------------------------------------------------------------------------------------
+
+-- |Translate string from UTF-16 encoding to Unicode
+utf16_to_unicode = tryToSkip [chr 0xFEFF] . map chr . fromUTF16 . map ord
+ where
+  fromUTF16 (c1:c2:c3:c4:wcs)
+    | 0xd8<=c2 && c2<=0xdb  &&  0xdc<=c4 && c4<=0xdf =
+      ((c1+c2*256 - 0xd800)*0x400 + (c3+c4*256 - 0xdc00) + 0x10000) : fromUTF16 wcs
+  fromUTF16 (c1:c2:wcs) = c1+c2*256 : fromUTF16 wcs
+  fromUTF16 _ = []  -- discard any trailing incomplete code unit
+
+-- |Translate string from Unicode to UTF-16 encoding
+unicode2utf16 = map chr . foldr (utf16Char . ord) []
+ where
+  utf16Char c wcs
+    | c < 0x10000 = c `mod` 256 : c `div` 256 : wcs
+    | otherwise   = let c' = c - 0x10000 in
+                    ((c' `div` 0x400) .&. 0xFF) :
+                    (c' `div` 0x40000 + 0xd8) :
+                    (c' .&. 0xFF) :
+                    (((c' `mod` 0x400) `div` 256) + 0xdc) : wcs
+
+-- |Translate string from UTF-8 encoding to Unicode
+utf8_to_unicode s =
+  if all isAscii s
+    then s
+    else (tryToSkip [chr 0xFEFF] . fromUTF' . map ord) s  where
+            fromUTF' [] = []
+            fromUTF' all@(x:xs)
+                | x<=0x7F = chr x : fromUTF' xs
+                | x<=0xBF = err
+                | x<=0xDF = twoBytes all
+                | x<=0xEF = threeBytes all
+                | x<=0xFF = fourBytes all
+                | otherwise = err
+            twoBytes (x1:x2:xs) = chr  (((x1 .&. 0x1F) `shift` 6) .|.
+                                          (x2 .&. 0x3F)):fromUTF' xs
+            twoBytes _ = error "fromUTF: illegal two byte sequence"
+
+            threeBytes (x1:x2:x3:xs) = chr (((x1 .&. 0x0F) `shift` 12) .|.
+                                             ((x2 .&. 0x3F) `shift` 6) .|.
+                                              (x3 .&. 0x3F)):fromUTF' xs
+            threeBytes _ = error "fromUTF: illegal three byte sequence"
+
+            fourBytes (x1:x2:x3:x4:xs) = chr (((x1 .&. 0x0F) `shift` 18) .|.
+                                               ((x2 .&. 0x3F) `shift` 12) .|.
+                                               ((x3 .&. 0x3F) `shift` 6) .|.
+                                                (x4 .&. 0x3F)):fromUTF' xs
+            fourBytes _ = error "fromUTF: illegal four byte sequence"
+
+            err = error "fromUTF: illegal UTF-8 character"
+
+-- |Translate string from Unicode to UTF-8 encoding
+unicode2utf8 s =
+  if all isAscii s
+    then s
+    else go s
+      where go [] = []
+            go (x:xs) | ord x<=0x007f = chr (ord x) : go xs
+                      | ord x<=0x07ff = chr (0xC0 .|. ((ord x `shiftR` 6) .&. 0x1F)):
+                                        chr (0x80 .|. ( ord x .&. 0x3F)):
+                                        go xs
+                      | ord x<=0xffff = chr (0xE0 .|. ((ord x `shiftR` 12) .&. 0x0F)):
+                                        chr (0x80 .|. ((ord x `shiftR`  6) .&. 0x3F)):
+                                        chr (0x80 .|. ( ord x .&. 0x3F)):
+                                        go xs
+                      | otherwise     = chr (0xF0 .|. ( ord x `shiftR` 18)) :
+                                        chr (0x80 .|. ((ord x `shiftR` 12) .&. 0x3F)) :
+                                        chr (0x80 .|. ((ord x `shiftR`  6) .&. 0x3F)) :
+                                        chr (0x80 .|. ( ord x .&. 0x3F)) :
+                                        go xs
+
+
+---------------------------------------------------------------------------------------------------
+---- Internalization ------------------------------------------------------------------------------
+---------------------------------------------------------------------------------------------------
+
+{-# NOINLINE locale #-}
+-- |Локализация: отображение индекса в локализованную строку
+locale :: IORef (Array Int (Maybe String))
+locale = unsafePerformIO $ ref$ array (0,-1) []
+
+{-# NOINLINE setLocale #-}
+-- |Установить локализацию по файлу
+setLocale "--"       = return ()
+setLocale localeFile = do
+  localeInfo <- parseLocaleFile localeFile
+  locale =: localeInfo
+
+-- |Переводит строку/список строк на местный язык
+i18ns = mapM i18n
+i18n  = i18n' .>>== fst
+i18n' = i18n_general (val locale)
+
+{-# NOINLINE i18fmt #-}
+-- |Отформатировать список строк, используя первую как требущий локализации шаблон,
+-- а остальные - как его аргументы
+i18fmt (x:xs)  =  i18n x >>== (`formatn` xs)
+
+
+{-# NOINLINE parseLocaleFile #-}
+-- |Прочитать из файла список строк локализации
+parseLocaleFile localeFile = do
+  -- Прочитаем файл локализации или возвратим пустую болванку
+  localeInfo <- readConfigFile localeFile `catch` (\(e::SomeException) -> return ["0000=English"])
+  -- Отбираем строки, начинающиеся на "dddd", и создаём из них массив: dddd -> текст после знака '='
+  -- Если текст после '=' заключён в двойные кавычки - избавимся от них
+  -- Символы '&' заменяются на '_' (различие в акселераторах 7-zip и Gtk)
+  -- \" заменяется на просто ", запись "\\n" на сам символ \n
+  return$ localeInfo .$ filter   (\s -> length s > 4  &&  s `contains` '=')
+                     .$ filter   (all isDigit . take 4)
+                     .$ map      (split2 '=')
+                     .$ deleteIf (("??"==) . snd)
+                     .$ mapFsts  (readInt . take 4)
+                     .$ mapSnds  (\s -> s.$ (s.$match "\"*\"" &&& (reverse . drop 1 . reverse . drop 1)))
+                     .$ mapSnds  (replace '&' '_' . replaceAll "\\\"" "\"" . replaceAll "\\n" "\n")
+                     .$ populateArray Nothing Just
+
+{-# NOINLINE i18n_general #-}
+-- |Возвращает локализованный текст надписи и её всплывающую подсказку
+i18n_general getLocale text = do
+  -- Если текст содержит в начале "dddd ", то вернём вместо него строку локализации за номером dddd
+  -- Если такой строки не найдено - возвратим переданный текст за вычетом "dddd "
+  -- Кроме того, тексты вида "  *  " локализуются в аналогичный вид
+  case splitAt 4 text of
+    (d,' ':engText) | all isDigit d -> do
+         let f = (engText.$match "  *  ")  &&&  (("  "++).(++"  "))
+         arr <- getLocale
+         let n = readInt d
+             g i def = if i.$inRange (bounds arr)
+                         then fmap f (arr!i) `defaultVal` def
+                         else def
+         return (g n engText, g (n+1000) "")
+    _ -> return (text, "")
+
+
+
+
+
+
+
+
+
+
+

--- a/Compression.hs
+++ b/Compression.hs
@@ -1,3 +1,607 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2b58232241032487e0464ec2b34b427bc56b9a14046738b540c7c46776723b6f
-size 35678
+----------------------------------------------------------------------------------------------------
+---- Упаковка, распаковка и вычисление CRC.                                                     ----
+---- Типы данных CompressionMethod, Compressor, UserCompressor - описание метода сжатия.        ----
+---- Интерфейс с написанными на Си процедурами, выполняющими всю реальную работу.               ----
+----------------------------------------------------------------------------------------------------
+module Compression (module Compression, CompressionLib.decompressMem) where
+
+import Control.Concurrent
+import Control.Monad
+import Data.Array
+import Data.Array.Base (unsafeAt)
+import Data.Array.Unboxed (UArray)
+import qualified Data.Array.Unboxed as UA
+import Data.Bits
+import Data.Char
+import Data.IORef
+import Data.List
+import Data.Maybe
+import Data.Word
+import Foreign
+import Foreign.C.String
+import Foreign.C.Types
+import Foreign.Marshal.Alloc
+import Foreign.Marshal.Pool
+import Foreign.Ptr
+import System.IO.Unsafe
+
+import qualified CompressionLib
+import Utils
+import Errors
+import Files
+import qualified ByteStream
+
+
+-- |Метод сжатия или препроцессор и его параметры
+type CompressionMethod  =  CompressionLib.Method
+
+-- Методы "сжатия", поддерживаемые напрямую, а не через CompressionLib
+aSTORING              = "storing"
+aFAKE_COMPRESSION     = "fake"
+aCRC_ONLY_COMPRESSION = "crc"
+
+-- |Фейковые (нераспаковываемые) методы сжатия.
+isFakeMethod             =  any_function [(==aFAKE_COMPRESSION), (==aCRC_ONLY_COMPRESSION)] . method_name
+-- |LZP метод сжатия.
+isLZP_Method     method  =  method_name method == "lzp"
+-- |Tornado метод сжатия.
+isTornado_Method method  =  method_name method == "tor"
+-- |DICT метод сжатия.
+isDICT_Method    method  =  method_name method == "dict"
+-- |TTA метод сжатия.
+isTTA_Method     method  =  method_name method == "tta"
+-- |MM метод сжатия.
+isMM_Method      method  =  method_name method == "mm"
+-- |JPG метод сжатия.
+isJPG_Method     method  =  method_name method == "jpg"
+-- |GRZip метод сжатия.
+isGRZIP_Method   method  =  method_name method == "grzip"
+-- |Очень быстрый метод упаковки (>10 mb/s на 1ГГц процессоре)
+isVeryFastMethod         =  CompressionLib.compressionIs "VeryFast?"
+-- |Быстрый метод распаковки
+isFastDecMethod          =  not . any_function [(=="ppmd"), (=="ppmm"), (=="pmm"), isEXTERNAL_Method] . method_name
+-- |Метод сжатия, выполняемый внешней программой
+isEXTERNAL_Method        =  CompressionLib.compressionIs "external?"
+-- |Метод шифрования.
+isEncryption             =  CompressionLib.compressionIs "encryption?"
+
+
+-- |Последовательность алгоритмов сжатия, используемых для обработки данных
+type Compressor = [CompressionMethod]
+
+-- |Метод "storing" (-m0)
+aNO_COMPRESSION = [aSTORING] :: Compressor
+
+-- |Очень быстрое сжатие для уже сжатых файлов
+aCOMPRESSED_METHOD = split_compressor "tor:8m:c3"
+
+-- |Это - фейковый компрессор, если в нём ровно один метод сжатия и он - фейковый
+isFakeCompressor (method:xs)  =  isFakeMethod method  &&  null xs
+
+-- |Это - fake компрессор, если в нём ровно один метод сжатия и он - "fake"
+isReallyFakeCompressor (method:xs)  =  method_name method == aFAKE_COMPRESSION  &&  null xs
+
+-- |Это - LZP компрессор, если в нём ровно один метод сжатия и он - LZP
+isLZP_Compressor (method:xs)  =  isLZP_Method method  &&  null xs
+
+-- |Это - очень быстрый упаковщик, если в нём ровно один, очень быстрый метод сжатия.
+isVeryFastCompressor (method:xs)  =  isVeryFastMethod method  &&  null xs
+
+-- |Это - быстрый распаковщик, если он включает только быстрые методы распаковки
+isFastDecompressor = all isFastDecMethod
+
+
+-- |Выбор компрессора в зависимости от типа обрабатываемых данных.
+-- Первый элемент списка безымянен и описывает компрессор, используемый
+-- по умолчанию (для файлов всех прочих типов, не описанных в списке явно)
+type UserCompressor = [(String,Compressor)]  -- список ассоциаций типа "$text->m3t, $exe->m3x, $compressed->m0"
+
+getCompressors :: UserCompressor -> [Compressor]
+getCompressors = map snd
+
+getMainCompressor :: UserCompressor -> Compressor
+getMainCompressor = snd . head
+
+-- |Это - метод Storing, если в нём только один компрессор aNO_COMPRESSION для файлов всех типов
+isStoring ((_,compressor):xs)  =  compressor==aNO_COMPRESSION  &&  null xs
+
+-- |Это - fake compression, если в нём только один фейковый компрессор для файлов всех типов
+isFakeCompression ((_,compressor):xs)  =  isFakeCompressor compressor  &&  null xs
+
+-- |Это - LZP compression, если в нём только один LZP компрессор для файлов всех типов
+isLZP_Compression ((_,compressor):xs)  =  isLZP_Compressor compressor  &&  null xs
+
+-- |Это очень быстрая упаковка, если в ней используются только очень быстрые упаковщики для файлов всех типов
+isVeryFastCompression = all (isVeryFastCompressor . snd)
+
+-- |Это быстрая распаковка, если в ней используются только быстрые распаковщики для файлов всех типов
+isFastDecompression = all (isFastDecompressor . snd)
+
+-- |Найти компрессор, наиболее подходящий для данных типа `ftype`.
+-- Если компрессор для файлов этого типа не описан в списке - возвратить компрессор
+-- по умолчанию, записанный в первый элемент списка
+findCompressor ftype list  =  lookup ftype list  `defaultVal`  snd (head list)
+
+-- |Для записи в оглавление архива информации об использованных алгоритмах сжатия.
+instance ByteStream.BufferData Compressor where
+  write buf x  =  ByteStream.write buf (join_compressor x)
+  read  buf    =  ByteStream.read  buf  >>==  split_compressor
+
+
+----------------------------------------------------------------------------------------------------
+----- Операции над алгоритмами сжатия                                                          -----
+----------------------------------------------------------------------------------------------------
+
+class Compression a where
+  getCompressionMem              :: a -> Integer
+  getDecompressionMem            :: a -> Integer
+  getBlockSize                   :: a -> MemSize
+  getDictionary                  :: a -> MemSize
+  setDictionary                  :: MemSize -> a -> a
+  limitCompressionMem            :: MemSize -> a -> a
+  limitDecompressionMem          :: MemSize -> a -> a
+  limitDictionary                :: MemSize -> a -> a
+  limitCompressionMemoryUsage    :: MemSize -> a -> a
+  limitDecompressionMemoryUsage  :: MemSize -> a -> a
+
+-- |Превратить функцию из CompressionLib, изменяющую Method, в функцию, изменяющую CompressionMethod
+liftSetter action  method | aSTORING ==  method   =  method
+liftSetter action  method | isFakeMethod method   =  method
+liftSetter action  method                         =  action method
+
+-- |Превратить функцию из CompressionLib, опрашивающую Method, в функцию, опрашивающую CompressionMethod
+liftGetter action  method | aSTORING ==  method   =  0
+liftGetter action  method | isFakeMethod method   =  0
+liftGetter action  method                         =  action method
+
+instance Compression CompressionMethod where
+  getCompressionMem              = i . liftGetter   CompressionLib.getCompressionMem
+  getDecompressionMem            = i . liftGetter   CompressionLib.getDecompressionMem
+  getBlockSize                   =  liftGetter   CompressionLib.getBlockSize
+  getDictionary                  =  liftGetter   CompressionLib.getDictionary
+  setDictionary                  =  liftSetter . CompressionLib.setDictionary
+  limitCompressionMem            =  liftSetter . CompressionLib.limitCompressionMem
+  limitDecompressionMem          =  liftSetter . CompressionLib.limitDecompressionMem
+  limitDictionary                =  liftSetter . CompressionLib.limitDictionary
+  limitCompressionMemoryUsage    =  limitCompressionMem
+  limitDecompressionMemoryUsage  =  const id
+
+instance Compression Compressor where
+  getCompressionMem              =  calcMem getCompressionMem
+  getDecompressionMem            =  calcMem getDecompressionMem
+  getBlockSize                   =  maximum . map getBlockSize
+  getDictionary                  =  maximum . map getDictionary
+  setDictionary                  =  mapLast . setDictionary
+  limitCompressionMem            =  map . limitCompressionMem
+  limitDecompressionMem          =  map . limitDecompressionMem
+  limitDictionary                =  compressionLimitDictionary
+  limitCompressionMemoryUsage    =  compressionLimitMemoryUsage
+  limitDecompressionMemoryUsage  =  genericLimitMemoryUsage getDecompressionMem
+
+instance Compression UserCompressor where
+  -- Определить максимальное потребление памяти / размер блока в заданном UserCompressor
+  getCompressionMem              =  maximum . map (getCompressionMem   . snd)
+  getDecompressionMem            =  maximum . map (getDecompressionMem . snd)
+  getBlockSize                   =  maximum . map (getBlockSize        . snd)
+  getDictionary                  =  maximum . map (getDictionary       . snd)
+  -- Установить словарь / Ограничить используемую при сжатии/распаковке память
+  -- сразу для всех методов, входящих в UserCompressor
+  setDictionary                  =  mapSnds . setDictionary
+  limitCompressionMem            =  mapSnds . limitCompressionMem
+  limitDecompressionMem          =  mapSnds . limitDecompressionMem
+  limitDictionary                =  mapSnds . limitDictionary
+  limitCompressionMemoryUsage    =  mapSnds . limitCompressionMemoryUsage
+  limitDecompressionMemoryUsage  =  mapSnds . limitDecompressionMemoryUsage
+
+
+-- |Минимальный объём памяти, необходимый для упаковки/распаковки
+compressorGetShrinkedCompressionMem    = maximum . map (compressionGetShrinkedCompressionMem . snd)
+compressorGetShrinkedDecompressionMem  = maximum . map (compressionGetShrinkedDecompressionMem . snd)
+compressionGetShrinkedCompressionMem    = maximum . map getCompressionMem
+compressionGetShrinkedDecompressionMem  = maximum . map getDecompressionMem
+
+-- |Ограничить словари для цепочки алгоритмов, прекратив это делать после первого алгоритма,
+-- который может существенно раздуть данные (типа precomp). Среди внутренних алгоритмов
+-- таких нет, но мы держим под подозрением все внешние :)
+compressionLimitDictionary mem (x:xs) =  new_x : (not(isEXTERNAL_Method new_x)  &&&  compressionLimitDictionary mem) xs
+                                             where new_x = limitDictionary mem x
+compressionLimitDictionary mem []     =  []
+
+-- |Уменьшает потребности в памяти каждого алгоритма в цепочке до mem
+-- и затем вставляет между ними вызовы tempfile, если необходимо
+compressionLimitMemoryUsage mem  =  genericLimitMemoryUsage getCompressionMem mem . map (limitCompressionMem mem)
+
+-- |Вставляет вызовы tempfile между алгоритмами сжатия, разбивая их на "кластера",
+-- умещающиеся в memory_limit+5% (при этом "маленькие" алгоритмы не должны начинать новых кластеров).
+-- При этом для dict/dict+lzp используется особый учёт памяти (blocksize*2 на оба, blocksize/2 на выходе),
+-- а external compressors обнуляют потребление памяти
+genericLimitMemoryUsage getMem memory_limit = go (0::Double) ""
+  where go _   _    []      =  []
+        go mem prev (x:xs) | isEXTERNAL_Method x          =  x: go 0            x xs
+                           | mem+newMem < memlimit*1.05   =  x: go (mem+newMem) x xs
+                           | otherwise                    =  "tempfile":x: go newMem x xs
+
+           where newMem | mem==0 && isDICT_Method x             =  realToFrac (getBlockSize x) / 2
+                        | isDICT_Method prev && isLZP_Method x  =  0
+                        | otherwise                             =  realToFrac$ getMem x
+                 memlimit = realToFrac memory_limit
+
+-- |Посчитать потребности в памяти цепочки алгоритмов сжатия с учётом их разбиения.
+-- на кластеры по compressionIs "external?" и особым учётом dict/dict+lzp
+calcMem getMem  = maximum . map getMemSum . splitOn isEXTERNAL_Method
+  where getMemSum (x:y:xs) | isDICT_Method x && isLZP_Method y  =  max (i$ getMem x) (i(getBlockSize x `div` 2) + getMemSum xs)
+        getMemSum (x:xs)   | isDICT_Method x                    =  max (i$ getMem x) (i(getBlockSize x `div` 2) + getMemSum xs)
+        getMemSum (x:xs)                                        =  i(getMem x) + getMemSum xs
+        getMemSum []                                            =  0::Integer
+
+-- |Удаляет все упоминания о "tempfile" из записи алгоритма сжатия.
+compressionDeleteTempCompressors = filter (/="tempfile")
+
+
+----------------------------------------------------------------------------------------------------
+----- (De)compression of data stream                                                           -----
+----------------------------------------------------------------------------------------------------
+
+{-
+compress   method callback      - упаковать данные
+decompress method callback      - распаковать данные
+
+  method :: CompressionMethod - алгоритм упаковки
+  callback "read" buf size - прочитать входные данные в буфер `buf` длиной `size`
+                             Возвращает 0   - конец данных
+                                        <0  - прервать (рас)паковку (ошибка или больше данных не нужно)
+                                        >0  - кол-во прочитанных байт
+  callback "write" buf size - записать выходные данные
+                              Возвращает <0  - прервать (рас)паковку (ошибка или больше данных не нужно)
+                                         >=0 - всё ок
+                              При возвращении из этой функции данные должны быть "использованы", потому что
+                                (рас)паковщик может начать запись новых данных на то же место
+Входные и выходные буфера выделяются и освобождаются (рас)паковщиком
+-}
+
+-- |Процедуры упаковки для различных алгоритмов сжатия.
+freearcCompress   num method | aSTORING ==  method =  copy_data
+freearcCompress   num method | isFakeMethod method =  eat_data
+freearcCompress   num method                       =  checkingCtrlBreak num (CompressionLib.compress method)
+
+-- |Процедуры распаковки для различных алгоритмов сжатия.
+freearcDecompress num method | aSTORING ==  method =  copy_data
+freearcDecompress num method | isFakeMethod method =  impossible_to_decompress   -- эти типы сжатых данных не подлежат распаковке
+freearcDecompress num method                       =  checkingCtrlBreak num (CompressionLib.decompress method)
+
+-- |Поскольку Haskell'овский код, вызываемый из Си, не может получать
+-- исключений, добавим к процедурам чтения/записи явные проверки
+checkingCtrlBreak num action callback = do
+  let checked_callback what buf size auxdata = do
+        operationTerminated' <- val operationTerminated
+        if operationTerminated'
+          then return CompressionLib.aFREEARC_ERRCODE_OPERATION_TERMINATED   -- foreverM doNothing0
+          else callback what buf size
+  --
+  res <- checked_callback "read" nullPtr 0 undefined   -- этот вызов позволяет отложить запуск следующего в цепочке алгоритма упаковки/распаковки до момента, когда предыдущий возвратит хоть какие-нибудь данные (а если это поблочный алгоритм - до момента, когда он обработает весь блок)
+  if res<0  then return res
+            else action (checked_callback)
+
+-- |Копирование данных без сжатия (-m0)
+copy_data callback = do
+  allocaBytes aHUGE_BUFFER_SIZE $ \buf -> do  -- используем `alloca`, чтобы автоматически освободить выделенный буфер при выходе
+    let go ptr = do
+          len <- callback "read" ptr ((buf+:aHUGE_BUFFER_SIZE)-:ptr)
+          if (len>0)
+            then do let newptr = ptr+:len
+                    if newptr < buf+:aHUGE_BUFFER_SIZE
+                       then go newptr
+                       else do result <- callback "write" buf (newptr-:buf)
+                               if (result>=0)
+                                 then go buf
+                                 else return (result)  -- Возвратим отрицательное число, если произошла ошибка/больше данных не нужно
+            else do if (len==0 && ptr>buf)
+                      then do result <-  callback "write" buf (ptr-:buf)
+                              return (if result>0 then 0 else result)
+                      else return len  -- Возвратим 0, если данные кончились, и отрицательное число, если произошла ошибка/больше данных не нужно
+    go buf -- возвратить результат
+
+-- |Читаем всё, не пишем ничего, а CRC считается в другом месте ;)
+eat_data callback = do
+  allocaBytes aBUFFER_SIZE $ \buf -> do  -- используем `alloca`, чтобы автоматически освободить выделенный буфер при выходе
+    let go = do
+          len <- callback "read" buf aBUFFER_SIZE
+          if (len>0)
+            then go
+            else return len   -- Возвратим 0, если данные кончились, и отрицательное число, если произошла ошибка/больше данных не нужно
+    go  -- возвратить результат
+
+impossible_to_decompress callback = do
+  return CompressionLib.aFREEARC_ERRCODE_GENERAL   -- сразу возвратить ошибку, поскольку этот алгоритм (FAKE/CRC_ONLY) не подлежит распаковке
+
+{-# NOINLINE checkingCtrlBreak               #-}
+{-# NOINLINE copy_data                       #-}
+{-# NOINLINE eat_data                        #-}
+
+
+----------------------------------------------------------------------------------------------------
+----- CRC calculation ------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |CRC файла
+type CRC  = CUInt
+aINIT_CRC = 0xffffffff  :: CRC
+
+-- |CRC-32 polynomial lookup table (IEEE 802.3)
+{-# NOINLINE crcTable #-}
+crcTable :: UArray Int Word32
+crcTable = UA.listArray (0, 255) $ map buildEntry [0..255]
+  where
+    buildEntry :: Int -> Word32
+    buildEntry i = foldl step (fromIntegral i) ([0..7] :: [Int])
+    step c _ = if c .&. 1 /= 0
+                 then (c `shiftR` 1) `xor` 0xEDB88320
+                 else  c `shiftR` 1
+
+-- |Update a running CRC-32 over a memory buffer using a pure Haskell loop.
+-- Equivalent to the C UpdateCRC from Environment.cpp.
+-- Accepts any Integral length to match the original C signature.
+{-# NOINLINE updateCRC #-}
+updateCRC :: (Integral n) => Ptr a -> n -> CRC -> IO CRC
+updateCRC addr len startCRC = go 0 startCRC
+  where
+    !iLen = fromIntegral len :: Int
+    {-# INLINE step #-}
+    step !crc !b =
+      let idx = fromIntegral ((fromIntegral crc :: Word8) `xor` b) :: Int
+      in (crc `shiftR` 8) `xor` fromIntegral (crcTable `unsafeAt` idx)
+    go :: Int -> CRC -> IO CRC
+    go !k !crc
+      | k >= iLen = return crc
+      | otherwise = do
+          b <- peek (castPtr addr `plusPtr` k :: Ptr Word8)
+          go (k + 1) (step crc b)
+
+finishCRC = xor aINIT_CRC
+
+-- |Посчитать CRC данных в буфере (accepts any Integral length)
+calcCRC :: Integral n => Ptr a -> n -> IO CRC
+calcCRC addr len  =  updateCRC addr len aINIT_CRC  >>==  finishCRC
+
+-- |Посчитать CRC не-unicode строки (символы с кодами 0..255)
+crc32 str  =  unsafePerformIO$ withCStringLen str (uncurry calcCRC)
+
+
+-------------------------------------------------------------------------------------------------------------
+-- Encode/decode compression method for parsing options/printing info about selected compression method -----
+-------------------------------------------------------------------------------------------------------------
+
+-- |Parse command-line option that represents compression method.
+-- Декодировать запись метода сжатия в виде текстовой строки, превратив его в список ассоциаций
+-- "тип файла -> метод сжатия". Первый элемент этого списка описывает метод сжатия по умолчанию
+decode_method configuredMethodSubsts str =
+    str                       -- "3/$obj=2b/$iso=ecm+3b"
+    .$ subst list             -- "3b/3t/$obj=2b/$iso=ecm+3b"
+    .$ split_to_methods       -- [("","exe+3b"), ("$obj","3b"), ("$text","3t"), ("$obj","2b"), ("$iso","ecm+3b")]
+    .$ keepOnlyLastOn fst     -- [("","exe+3b"), ("$text","3t"), ("$obj","2b"), ("$iso","ecm+3b")]
+    .$ filter (not.null.snd)  -- "-m$bmp=" означает запретить использование специального алгоритма для группы $bmp
+    .$ mapSnds (subst2 list)  -- [("",["exe","lzma"]), ("$text",["ppmd"]), ("$obj",["lzma"]), ("$iso",["ecm","lzma"])]
+
+    where list = prepareSubsts (concatMap reorder [configuredMethodSubsts, builtinMethodSubsts])   -- сначала пользовательские замены, затем встроенные, чтобы дать первым приоритет
+          reorder list = a++b  where (a,b) = partition (notElem '#') list                          -- внутри этих групп: сначала строчки, не содержащие #, затем с # (сначала конкретные, затем общие замены)
+
+-- Замена по списку для метода сжатия (обобщённого обозначения для файлов всех типов)
+subst list method  =  joinWith "/" (main_methods:group_methods++user_methods)
+  where -- Из записи типа -m3/$obj=2b выделяем для расшифровки только первую часть, до слеша
+        main:user_methods = split '/' method
+        -- Расшифровка основных методов сжатия, типа 3x = 3xb/3xt
+        main_methods = case (lookup main list) of
+            Just x  -> subst list x   -- При успехе повторяем рекурсивно
+            Nothing -> main           -- Больше подстановок нет
+        -- Найдём в списке подстановок дополнительные методы сжатия для отдельных групп, типа 3x$iso = ecm+exe+3xb
+        group_methods = list .$ keepOnlyFirstOn fst                      -- удалим повторные определения (не очень эффективно делать это именно здесь, зато по месту использования)
+                             .$ mapMaybe (startFrom main . join2 "=")    -- оставим только определения, начинающиеся с 3x, удалив это 3x
+                             .$ filter (("$"==) . take 1)                  -- а из них - только начинающиеся с $
+
+-- Замена по списку для алгоритма сжатия (посл-ти компрессоров для конкретного типа файлов)
+subst2 list  =  concatMap f . split_compressor
+    where f method = let (head,params)  =  break (==':') method
+                     in case (lookup head list) of
+                          Just new_head -> subst2 list (new_head++params)
+                          Nothing       -> [decode_one_method method]
+
+-- |Декодировать явно описанный метод сжатия.
+decode_one_method method | isFakeMethod method = method
+                         | otherwise           = CompressionLib.canonizeCompressionMethod method
+
+-- Превращает длинную строку, описывающую методы сжатия для разных типов файлов,
+-- в массив ассоциаций (тип файла, метод сжатия)
+split_to_methods method = case (split '/' method) of
+    [_]                 ->  [("",method)]   -- один метод для файлов всех типов
+    x : xs@(('$':_):_) ->  ("",x) : map (split2 '=') xs   -- m1/$type=m2...
+    b : t : xs          ->  [("","exe+"++b), ("$obj",b), ("$text",t)] ++ map (split2 '=') xs   -- m1/m2/$type=m3...
+
+-- Подготовить список замен к использованию в lookup
+prepareSubsts x = x
+    -- Удалить пустые строки, пробелы и комментарии
+    .$ map (filter (not . isSpace) . fst . split2 ';') .$ filter (not . null)
+    -- Заменить каждую строку с символом # на 9 строк, где # пробегает значения от 1 до 9
+    .$ concatMap (\s -> if s `contains` '#'  then map (\d->replace '#' d s) ['1'..'9']  else [s])
+    -- Преобразовать список строк вида "a=b" в список для lookup
+    .$ map (split2 '=')
+
+-- Встроенные описания методов сжатия в формате, аналогичном используемому в arc.ini
+builtinMethodSubsts = [
+      ";High-level method definitions"
+    , "x  = 9            ;highest compression mode using only internal algorithms"
+    , "ax = 9p           ;highest compression mode involving external compressors"
+    , "0  = storing"
+    , "1  = 1b  / $exe=exe+1b"
+    , "1x = 1"
+    , "#  = #rep+exe+#xb / $obj=#b / $text=#t"
+    , "#x = #xb/#xt"
+    , ""
+    , ";Text files compression with slow decompression"
+    , "1t  = 1b"
+    , "2t  = grzip:m4:8m:32:h15"
+    , "3t  = dict:p: 64m:85% + lzp: 64m: 24:h20        :92% + grzip:m3:8m:l"
+    , "4t  = dict:p: 64m:80% + lzp: 64m: 65:d1m:s16:h20:90% + ppmd:8:96m"
+    , "5t  = dict:p: 64m:80% + lzp: 80m:105:d1m:s32:h22:92% + ppmd:12:192m"
+    , "6t  = dict:p:128m:80% + lzp:160m:145:d1m:s32:h23:92% + ppmd:16:384m"
+    , "7t  = dict:p:128m:80% + lzp:320m:185:d1m:s32:h24:92% + ppmd:20:768m"
+    , "8t  = dict:p:128m:80% + lzp:640m:225:d1m:s32:h25:92% + ppmd:24:1536m"
+    , "9t  = dict:p:128m:80% + lzp:800m:235:d1m:s32:h26:92% + ppmd:25:2047m"
+    , ""
+    , ";Binary files compression with slow and/or memory-expensive decompression"
+    , "1b  = 1xb"
+    , "#b  = #rep+#bx"
+    , "2rep  = rep:  96m"
+    , "3rep  = rep:  96m"
+    , "4rep  = rep:  96m"
+    , "5rep  = rep: 128m"
+    , "6rep  = rep: 256m"
+    , "7rep  = rep: 512m"
+    , "8rep  = rep:1024m"
+    , "9rep  = rep:2047m"
+    , ""
+    , ";Text files compression with fast decompression"
+    , "1xt = 1xb"
+    , "2xt = 2xb"
+    , "3xt = dict:  64m:80% + tor:7:96m:h64m"
+    , "4xt = dict:  64m:75% + 4binary"
+    , "#xt = dict: 128m:75% + #binary"
+    , ""
+    , ";Binary files compression with fast decompression"
+    , "1xb = tor:3"
+    , "2xb = tor:96m:h64m"
+    , "#xb = delta + #binary"
+    , ""
+    , ";Binary files compression with fast decompression"
+    , "1binary = tor:3"
+    , "2binary = tor:  96m:h64m"
+    , "3binary = lzma: 96m:h64m:fast  :mc8"
+    , "4binary = lzma: 96m:h64m:normal:mc16"
+    , "5binary = lzma: 16m:max"
+    , "6binary = lzma: 32m:max"
+    , "7binary = lzma: 64m:max"
+    , "8binary = lzma:128m:max"
+    , "9binary = lzma:255m:max"
+    , ""
+    , ";Synonyms"
+    , "bcj = exe"
+    , "#bx = #xb"
+    , "#tx = #xt"
+    , "x#  = #x"    -- принимаем опции типа "-mx7" для мимикрии под 7-zip
+    , ""
+    , ";Compression modes involving external PPMONSTR.EXE"
+    , "#p  = #rep+exe+#xb / $obj=#pb / $text=#pt"
+    , "5pt = dict:p: 64m:80% + lzp: 64m:32:h22:85% + pmm: 8:160m:r0"
+    , "6pt = dict:p: 64m:80% + lzp: 64m:64:h22:85% + pmm:16:384m:r1"
+    , "7pt = dict:p:128m:80% + lzp:128m:64:h23:85% + pmm:20:768m:r1"
+    , "8pt = dict:p:128m:80% + lzp:128m:64:h23:85% + pmm:24:1536m:r1"
+    , "9pt = dict:p:128m:80% + lzp:128m:64:h23:85% + pmm:25:2047m:r1"
+    , "#pt = #t"
+    , "#pb = #b"
+    , ""
+    , "#q  = #qb/#qt"
+    , "5qt = dict:p:64m:80% + lzp:64m:64:d1m:24:h22:85% + pmm:10:160m:r1"
+    , "5qb = rep: 128m      + delta                     + pmm:16:160m:r1"
+    , "6qb = rep: 256m      + delta                     + pmm:20:384m:r1"
+    , "7qb = rep: 512m      + delta                     + pmm:22:768m:r1"
+    , "8qb = rep:1024m      + delta                     + pmm:24:1536m:r1"
+    , "9qb = rep:2047m      + delta                     + pmm:25:2047m:r1"
+    , "#qt = #pt"
+    , "#qb = #pb"
+    , ""
+    , ";Sound wave files are compressed best with TTA"
+    , "wav     = tta      ;best compression"
+    , "wavfast = tta:m1   ;faster compression and decompression"
+    , "1$wav  = wavfast"
+    , "2$wav  = wavfast"
+    , "#$wav  = wav"
+    , "#x$wav = wavfast"
+    , "#p$wav = wav"
+    , ""
+    , ";Bitmap graphic files are compressed best with GRZip"
+    , "bmp        = mm    + grzip:m1:l:a  ;best compression"
+    , "bmpfast    = mm    + grzip:m4:l:a  ;faster compression"
+    , "bmpfastest = mm:d1 + tor:3:t0      ;fastest one"
+    , "1$bmp  = bmpfastest"
+    , "2$bmp  = bmpfastest"
+    , "3$bmp  = bmpfast"
+    , "#$bmp  = bmp"
+    , "1x$bmp = bmpfastest"
+    , "2x$bmp = bmpfastest"
+    , "#x$bmp = mm+#binary"
+    , "#p$bmp = bmp"
+    , ""
+    , ";Quick & dirty compression for data already compressed"
+    , "4$compressed   = rep:96m + tor:c3"
+    , "3$compressed   = rep:96m + tor:3"
+    , "2$compressed   = rep:96m + tor:3"
+    , "4x$compressed  = tor:8m:c3"
+    , "3x$compressed  = rep:8m  + tor:3"
+    , "2x$compressed  = rep:8m  + tor:3"
+    ]
+
+-- |Мультимедийный тип файлов?
+isMMType x  =  x `elem` words "$wav $bmp"
+
+-- |В некотором смысле обратная операция - угадывание типа файла по его компрессору
+typeByCompressor c  =  case (map method_name c) of
+  xs | xs `contains` "tta"        -> "$wav"
+     | xs `contains` "mm"         -> "$bmp"
+     | xs `contains` "grzip"      -> "$text"
+     | xs `contains` "ppmd"       -> "$text"
+     | xs `contains` "pmm"        -> "$text"
+     | xs `contains` "dict"       -> "$text"
+     | xs == aNO_COMPRESSION      -> "$compressed"
+     | xs == ["rep","tor"]        -> "$compressed"
+     | xs `contains` "ecm"        -> "$iso"
+     | xs `contains` "precomp"    -> "$precomp"
+     | xs == ["precomp","rep"]    -> "$jpgsolid"
+     | xs `contains` "jpg"        -> "$jpg"
+     | xs `contains` "exe"        -> "$binary"
+     | xs `contains` "lzma"       -> "$obj"
+     | xs `contains` "tor"        -> "$obj"
+     | otherwise                  -> "default"
+
+-- |Список всех типов файлов, обнаруживаемых подобным образом
+typesByCompressor = words "$wav $bmp $text $compressed $iso $precomp $jpgsolid $jpg $obj $binary $exe"
+
+
+-- |Human-readable description of compression method
+encode_method uc  =  joinWith ", " (map encode_one_method uc)
+encode_one_method (group,compressor)  =  between group " => " (join_compressor compressor)
+join_compressor   =  joinWith "+"
+
+-- |Opposite to join_compressor (used to read compression method from archive file)
+split_compressor  =  split '+'
+
+-- |Обработать алгоритмы в компрессоре императивной операцией process
+process_algorithms process compressor = do
+    return (split_compressor compressor)
+       >>=  mapM process
+       >>== join_compressor
+
+-- |Разбить метод сжатия на заголовок и отдельные параметры
+split_method = split ':'
+
+-- |Имя метода сжатия.
+method_name = head . split_method
+
+-- |Строка, информирующая пользователя об используемом объёме памяти
+showMem 0      = "0b"
+showMem mem    = showM [(gb,"gb"),(mb,"mb"),(kb,"kb"),(b,"b"),error"showMem"] mem
+
+showMemory 0   = "0 bytes"
+showMemory mem = showM [(gb," gbytes"),(mb," mbytes"),(kb," kbytes"),(b," bytes"),error"showMemory"] mem
+
+showM xs@( (val,str) : ~(nextval,_) : _) mem =
+  if mem `mod` val==0 || mem `div` nextval>=4096
+    then show((mem+val`div` 2) `div` val)++str
+    else showM (tail xs) mem
+
+-- |Округлить объём памяти вверх так, чтобы он приобрёл читабельность
+roundMemUp mem | mem>=4096*kb = mem `roundUp` mb
+               | otherwise    = mem `roundUp` kb
+
+{-# NOINLINE builtinMethodSubsts #-}
+{-# NOINLINE decode_method #-}
+{-# NOINLINE showMem #-}
+

--- a/Compression/CompressionLib.hs
+++ b/Compression/CompressionLib.hs
@@ -1,3 +1,356 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:26b8c70f1064d23c9580bc15d669b31b43614514a61ca4a08f32c14936b5e9a1
-size 18395
+{-# LANGUAGE CPP #-}
+----------------------------------------------------------------------------------------------------
+---- Упаковка и распаковка данных.                                                              ----
+---- Интерфейс с написанными на Си процедурами, выполняющими всю реальную работу.               ----
+----------------------------------------------------------------------------------------------------
+module CompressionLib where
+
+import Control.Concurrent
+import Control.Exception
+import Control.Monad
+import Data.Bits
+import Data.Char
+import Data.Int
+import Data.List
+import Data.Maybe
+import Data.Word
+import Foreign.C.String
+import Foreign.C.Types
+import Foreign.Marshal.Alloc
+import Foreign.Storable
+import Foreign.Ptr
+import System.IO.Unsafe
+
+----------------------------------------------------------------------------------------------------
+----- Main exported definitions --------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Useful definitions for kilobytes, megabytes and so on
+b  = 1
+kb = 1024*b
+mb = 1024*kb
+gb = 1024*mb
+tb = 1024*gb
+
+-- |Compress using callbacks
+compress             = runWithMethod c_compress
+-- |Decompress using callbacks
+decompress           = runWithMethod c_decompress
+-- |Compress using callbacks and save method name in compressed output
+compressWithHeader   = runWithMethod c_CompressWithHeader
+-- |Decompress data compressed with compressWithHeader (method name is read from compressed stream)
+decompressWithHeader = run           c_DecompressWithHeader
+
+-- |Compress memory block
+compressMem             :: Method -> Ptr CChar -> Int -> Ptr CChar -> Int -> IO Int
+compressMem             = withMethod c_CompressMem
+-- |Decompress memory block
+decompressMem           :: Method -> Ptr CChar -> Int -> Ptr CChar -> Int -> IO Int
+decompressMem           = withMethod c_DecompressMem
+-- |Compress memory block and save method name in compressed output
+compressMemWithHeader   :: Method -> Ptr CChar -> Int -> Ptr CChar -> Int -> IO Int
+compressMemWithHeader   = withMethod c_CompressMemWithHeader
+-- |Decompress memory block compressed with compressMemWithHeader (method name is read from compressed data)
+decompressMemWithHeader ::           Ptr CChar -> Int -> Ptr CChar -> Int -> IO Int
+decompressMemWithHeader a b c d = c_DecompressMemWithHeader a b c d
+
+-- |Return canonical representation of compression method
+canonizeCompressionMethod :: Method -> Method
+canonizeCompressionMethod = doWithMethod c_CanonizeCompressionMethod
+
+-- |Returns memory used to compress/decompress, dictionary or block size of method given
+getCompressionMem, getDecompressionMem, getDictionary, getBlockSize :: Method -> MemSize
+getCompressionMem      =  getWithMethod c_GetCompressionMem
+getDecompressionMem    =  getWithMethod c_GetDecompressionMem
+getDictionary          =  getWithMethod c_GetDictionary
+getBlockSize           =  getWithMethod c_GetBlockSize
+
+-- |Set memory used to compress/decompress, dictionary or block size of method given
+setCompressionMem, setDecompressionMem, setDictionary, setBlockSize :: MemSize -> Method -> Method
+setCompressionMem      =  setWithMethod c_SetCompressionMem
+setDecompressionMem    =  setWithMethod c_SetDecompressionMem
+setDictionary          =  setWithMethod c_SetDictionary
+setBlockSize           =  setWithMethod c_SetBlockSize
+
+-- |Put upper limit to memory used to compress/decompress, dictionary or block size of method given
+limitCompressionMem, limitDecompressionMem, limitDictionary, limitBlockSize :: MemSize -> Method -> Method
+limitCompressionMem    =  setWithMethod c_LimitCompressionMem
+limitDecompressionMem  =  setWithMethod c_LimitDecompressionMem
+limitDictionary        =  setWithMethod c_LimitDictionary
+limitBlockSize         =  setWithMethod c_LimitBlockSize
+
+-- |Adds new external compresion method to the table
+addExternalCompressor description =
+  withCString description $ \c_description -> do
+    c_AddExternalCompressor c_description
+
+----------------------------------------------------------------------------------------------------
+----- General compression services -----------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Check boolean property of compression method, returning FALSE if it's not implemented
+compressionIs :: Parameter -> Method -> Bool
+compressionIs param method  =  compressionQuery (const 0) param method /= 0
+
+-- |Get value of compression method parameter or raise error if this parameter isn't supported
+compressionGet :: Parameter -> Method -> Int
+compressionGet param method  =  compressionQuery (\e -> error$ "Error "++show e++" when querying "++method++":"++param) param method
+
+-- |Query compression method for some parameter
+compressionQuery :: (Int->Int) -> Parameter -> Method -> Int
+compressionQuery defaultVal param method =
+    case unsafePerformIO$ compressionService method param 0 nullPtr (error$ method++":"++param++" - callback undefined")
+      of x | x<0 -> defaultVal x
+         x       -> x
+
+-- |General function to call compression services
+compressionService :: Method -> String -> Int -> VoidPtr -> CALLBACK_FUNC -> IO Int
+compressionService method what param dat callback = do
+  withCString method $ \c_method -> do
+    withCString what $ \c_what -> do
+      bracket (mkCALL_BACK callback) (freeHaskellFunPtr)$ \c_callback -> do
+        res <- c_CompressionService c_method c_what (ii param) dat c_callback
+        return (ii res)
+
+----------------------------------------------------------------------------------------------------
+----- Internal auxiliary functions -----------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Run specified action with Haskell arguments converted to C equivalents
+runWithMethod action method callback = do
+  withCString method $ \c_method -> do
+    run (action c_method) callback
+
+-- |Execute C (de)compression routine `action` using read/write callbacks `read_f` & `write_f`
+run action callback = do
+  let callback2 :: CALLBACK_FUNC
+      callback2 cwhat buf size auxdata = do what <- peekCString cwhat
+                                            callback what buf (ii size) auxdata >>=return.ii
+  bracket (mkCALL_BACK callback2) (freeHaskellFunPtr)$ \c_callback -> do   -- convert Haskell routine to C-callable routine
+    -- GHC 9.12+ no longer sign-extends IO Int returns from C functions returning int (32-bit).
+    -- We must round-trip through CInt to restore the correct signed value.
+    signExtendCInt <$> action c_callback c_callback
+
+withMethod action method inp insize outp outsize = do
+  withCString method $ \c_method -> do
+    signExtendCInt <$> action c_method inp insize outp outsize
+
+-- |Correct GHC 9.12+ sign-extension: C functions imported as `IO Int` no longer
+-- sign-extend 32-bit int return values on 64-bit platforms.  Round-trip via CInt.
+signExtendCInt :: Int -> Int
+signExtendCInt x = fromIntegral (fromIntegral x :: CInt)
+
+
+getWithMethod c_get method  =  unsafePerformIO$ withCString method c_get
+
+setWithMethod c_action bytes = doWithMethod (\x y -> c_action x bytes y)
+
+doWithMethod c_action method = do
+  unsafePerformIO $ generalDoWithMethod "compression" c_action method
+
+generalDoWithMethod mType c_action method = do
+  withCString method $ \c_method -> do
+    allocaBytes aMAX_METHOD_STRLEN $ \c_out_method -> do
+      ret <- c_action c_method c_out_method
+      case ret of
+        0 -> peekCString c_out_method
+        _ -> fail$ "Unsupported "++mType++" method or error in parameters: "++method
+
+{-# NOINLINE run #-}
+{-# NOINLINE doWithMethod #-}
+
+----------------------------------------------------------------------------------------------------
+----- Error codes ----------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+aFREEARC_OK                            =  0
+aFREEARC_ERRCODE_GENERAL               = -1
+aFREEARC_ERRCODE_INVALID_COMPRESSOR    = -2
+aFREEARC_ERRCODE_ONLY_DECOMPRESS       = -3
+aFREEARC_ERRCODE_OUTBLOCK_TOO_SMALL    = -4
+aFREEARC_ERRCODE_NOT_ENOUGH_MEMORY     = -5
+aFREEARC_ERRCODE_IO                    = -6
+aFREEARC_ERRCODE_BAD_COMPRESSED_DATA   = -7
+aFREEARC_ERRCODE_NOT_IMPLEMENTED       = -8
+aFREEARC_ERRCODE_NO_MORE_DATA_REQUIRED = -9
+aFREEARC_ERRCODE_OPERATION_TERMINATED  = -10
+
+compressionErrorMessage x
+  | x==aFREEARC_OK                            = "All OK"
+  | x==aFREEARC_ERRCODE_GENERAL               = "0365 general (de)compression error in %1"
+  | x==aFREEARC_ERRCODE_INVALID_COMPRESSOR    = "0366 invalid compression method or parameters in %1"
+  | x==aFREEARC_ERRCODE_ONLY_DECOMPRESS       = "program build with FREEARC_DECOMPRESS_ONLY, so don't try to use compress"
+  | x==aFREEARC_ERRCODE_OUTBLOCK_TOO_SMALL    = "output block size in (de)compressMem is not enough for all output data in %1"
+  | x==aFREEARC_ERRCODE_NOT_ENOUGH_MEMORY     = "0367 can't allocate memory required for (de)compression in %1"
+  | x==aFREEARC_ERRCODE_IO                    = "0368 I/O error in compression algorithm %1"
+  | x==aFREEARC_ERRCODE_BAD_COMPRESSED_DATA   = "0369 bad compressed data in %1"
+  | x==aFREEARC_ERRCODE_NOT_IMPLEMENTED       = "requested feature isn't supported in %1"
+  | x==aFREEARC_ERRCODE_NO_MORE_DATA_REQUIRED = "required part of data was already decompressed"
+  | x==aFREEARC_ERRCODE_OPERATION_TERMINATED  = "operation terminated by user"
+  | otherwise                                 = "unknown (de)compression error "++show x++" in %1"
+
+
+----------------------------------------------------------------------------------------------------
+----- High-level compression/decompression routines working with callbacks -------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Compress using callbacks
+foreign import ccall safe  "Compression.h Compress"
+   c_compress             :: CMethod -> FunPtr CALLBACK_FUNC -> FunPtr CALLBACK_FUNC -> IO Int
+
+-- |Decompress using callbacks
+foreign import ccall safe  "Compression.h Decompress"
+   c_decompress           :: CMethod -> FunPtr CALLBACK_FUNC -> FunPtr CALLBACK_FUNC -> IO Int
+
+-- |Compress using callbacks and save method name in compressed output
+foreign import ccall safe  "Compression.h CompressWithHeader"
+   c_CompressWithHeader   :: CMethod -> FunPtr CALLBACK_FUNC -> FunPtr CALLBACK_FUNC -> IO Int
+
+-- |Decompress data compressed with c_CompressWithHeader (method name is read from compressed stream)
+foreign import ccall safe  "Compression.h DecompressWithHeader"
+   c_DecompressWithHeader ::            FunPtr CALLBACK_FUNC -> FunPtr CALLBACK_FUNC -> IO Int
+
+
+----------------------------------------------------------------------------------------------------
+----- High-level compression/decompression routines working with memory buffers --------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Compress memory block
+foreign import ccall safe  "Compression.h CompressMem"
+   c_CompressMem             :: CMethod -> Ptr CChar -> Int -> Ptr CChar -> Int -> IO Int
+
+-- |Decompress memory block
+foreign import ccall safe  "Compression.h DecompressMem"
+   c_DecompressMem           :: CMethod -> Ptr CChar -> Int -> Ptr CChar -> Int -> IO Int
+
+-- |Compress memory block and save method name in compressed output
+foreign import ccall safe  "Compression.h CompressMemWithHeader"
+   c_CompressMemWithHeader   :: CMethod -> Ptr CChar -> Int -> Ptr CChar -> Int -> IO Int
+
+-- |Decompress memory block compressed with c_CompressMemWithHeader (method name is read from compressed data)
+foreign import ccall safe  "Compression.h DecompressMemWithHeader"
+   c_DecompressMemWithHeader ::            Ptr CChar -> Int -> Ptr CChar -> Int -> IO Int
+
+
+----------------------------------------------------------------------------------------------------
+----- Functions to add/query/modify compression methods --------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Get/set number of threads used for (de)compression
+foreign import ccall unsafe  "Compression.h  GetCompressionThreads"
+   getCompressionThreads :: IO Int
+foreign import ccall unsafe  "Compression.h  SetCompressionThreads"
+   setCompressionThreads :: Int -> IO ()
+
+-- |Clear external compressors table
+foreign import ccall unsafe  "Compression.h  ClearExternalCompressorsTable"
+   clearExternalCompressorsTable  :: IO ()
+
+-- |Adds new external compresion method to the table
+foreign import ccall unsafe  "External/C_External.h  AddExternalCompressor"
+   c_AddExternalCompressor   :: CString -> IO Int
+
+-- |Returns canonical representation of compression method or error code
+foreign import ccall unsafe  "Compression.h  CanonizeCompressionMethod"
+   c_CanonizeCompressionMethod   :: CMethod -> CMethod -> IO Int
+
+foreign import ccall unsafe  "Compression.h CompressionService"
+   c_CompressionService :: CMethod -> CString -> CInt -> VoidPtr -> FunPtr CALLBACK_FUNC -> IO CInt
+
+foreign import ccall unsafe  "Compression.h compressionLib_cleanup"
+   compressionLib_cleanup :: IO ()
+
+-- |Returns memory used to compress/decompress, dictionary or block size of method given
+foreign import ccall unsafe  "Compression.h GetCompressionMem"   c_GetCompressionMem   :: CMethod -> IO MemSize
+foreign import ccall unsafe  "Compression.h GetDecompressionMem" c_GetDecompressionMem :: CMethod -> IO MemSize
+foreign import ccall unsafe  "Compression.h GetDictionary"       c_GetDictionary       :: CMethod -> IO MemSize
+foreign import ccall unsafe  "Compression.h GetBlockSize"        c_GetBlockSize        :: CMethod -> IO MemSize
+
+-- |Set memory used to compress/decompress, dictionary or block size of method given
+foreign import ccall unsafe  "Compression.h SetCompressionMem"   c_SetCompressionMem   :: CMethod -> MemSize -> CMethod -> IO Int
+foreign import ccall unsafe  "Compression.h SetDecompressionMem" c_SetDecompressionMem :: CMethod -> MemSize -> CMethod -> IO Int
+foreign import ccall unsafe  "Compression.h SetDictionary"       c_SetDictionary       :: CMethod -> MemSize -> CMethod -> IO Int
+foreign import ccall unsafe  "Compression.h SetBlockSize"        c_SetBlockSize        :: CMethod -> MemSize -> CMethod -> IO Int
+
+-- |Put upper limit to memory used to compress/decompress, dictionary or block size of method given
+foreign import ccall unsafe  "Compression.h LimitCompressionMem"   c_LimitCompressionMem   :: CMethod -> MemSize -> CMethod -> IO Int
+foreign import ccall unsafe  "Compression.h LimitDecompressionMem" c_LimitDecompressionMem :: CMethod -> MemSize -> CMethod -> IO Int
+foreign import ccall unsafe  "Compression.h LimitDictionary"       c_LimitDictionary       :: CMethod -> MemSize -> CMethod -> IO Int
+foreign import ccall unsafe  "Compression.h LimitBlockSize"        c_LimitBlockSize        :: CMethod -> MemSize -> CMethod -> IO Int
+
+
+----------------------------------------------------------------------------------------------------
+----- Direct calls to (de)compression routines -----------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+#if 0
+-- |PPMD compression
+foreign import ccall safe  "PPMD/C_PPMD.h ppmd_compress"
+   ppmd_compress   :: Int -> Int -> Int -> FunPtr CALLBACK_FUNC -> VoidPtr -> IO Int
+
+-- |PPMD decompression
+foreign import ccall safe  "PPMD/C_PPMD.h ppmd_decompress"
+   ppmd_decompress :: Int -> Int -> Int -> FunPtr CALLBACK_FUNC -> VoidPtr -> IO Int
+
+-- |LZP compression
+foreign import ccall safe  "LZP/C_LZP.h lzp_compress"
+   lzp_compress    :: Int -> Int -> Int -> Int -> Int -> Int -> FunPtr CALLBACK_FUNC -> VoidPtr -> IO Int
+
+-- |LZP decompression
+foreign import ccall safe  "LZP/C_LZP.h lzp_decompress"
+   lzp_decompress  :: Int -> Int -> Int -> Int -> Int -> Int -> FunPtr CALLBACK_FUNC -> VoidPtr -> IO Int
+
+-- |LZMA compression
+foreign import ccall safe  "LZMA/C_LZMA.h lzma_compress"
+   lzma_compress   :: Int -> Int -> Int -> Int -> Int -> Int -> Int -> Int -> Int -> FunPtr CALLBACK_FUNC -> VoidPtr -> IO Int
+
+-- |LZMA decompression
+foreign import ccall safe  "LZMA/C_LZMA.h lzma_decompress"
+   lzma_decompress :: Int -> Int -> Int -> Int -> Int -> Int -> Int -> Int -> Int -> FunPtr CALLBACK_FUNC -> VoidPtr -> IO Int
+
+-- |GRZip compression
+foreign import ccall safe  "GRZip/C_GRZip.h grzip_compress"
+   grzip_compress  :: Int -> Int -> Int -> Int -> Int -> Int -> Int -> Int -> FunPtr CALLBACK_FUNC -> VoidPtr -> IO Int
+
+-- |GRZip decompression
+foreign import ccall safe  "GRZip/C_GRZip.h grzip_decompress"
+   grzip_decompress:: Int -> Int -> Int -> Int -> Int -> Int -> Int -> Int -> FunPtr CALLBACK_FUNC -> VoidPtr -> IO Int
+#endif
+
+
+----------------------------------------------------------------------------------------------------
+----- Types and wrappers ---------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Boolean flag set when we need fastest buffer-to-buffer compression
+foreign import ccall "Compression.h & compress_all_at_once" compress_all_at_once :: Ptr CInt
+
+-- |General callback function type
+type CALLBACK_FUNC  =  CString -> Ptr CChar -> CInt -> VoidPtr -> IO CInt
+foreign import ccall safe "wrapper"
+   mkCALL_BACK :: CALLBACK_FUNC -> IO (FunPtr CALLBACK_FUNC)
+
+-- |Maximum length of string representing compression/encryption method
+aMAX_METHOD_STRLEN = 2048
+
+-- |Compression method representation
+type Method = String
+
+-- |Compression method representation in C
+type CMethod = CString
+
+-- |Compression method parameter
+type Parameter = String
+
+-- |Memory sizes
+type MemSize = CUInt
+
+-- |Unlimited memory usage
+aUNLIMITED_MEMORY = maxBound::MemSize
+
+-- |Typeless pointer
+type VoidPtr = Ptr ()
+
+-- |Universal integral types conversion routine
+ii x = fromIntegral x
+

--- a/Compression/EncryptionLib.hs
+++ b/Compression/EncryptionLib.hs
@@ -1,3 +1,52 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:368f95fc91542014236735aba7cd69b20ebe2a811f25471d197d4380a17a7be9
-size 2681
+{-# LANGUAGE CPP #-}
+----------------------------------------------------------------------------------------------------
+---- (Де)шифрование данных.                                                                     ----
+---- Интерфейс с написанными на Си процедурами, выполняющими всю реальную работу.               ----
+----------------------------------------------------------------------------------------------------
+module EncryptionLib where
+
+import Control.Monad
+import Foreign.C.String
+import Foreign.C.Types
+import Foreign.Marshal.Alloc
+import Foreign.Ptr
+import System.IO.Unsafe
+
+import CompressionLib
+
+----------------------------------------------------------------------------------------------------
+----- Encryption routines --------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Query encryption method for some parameter
+encryptionGet = compressionGet
+
+-- |Generate key based on password and salt using given number of hashing iterations
+pbkdf2Hmac :: String -> String -> Int -> Int -> String
+pbkdf2Hmac password salt iterations keySize = unsafePerformIO $
+  withCStringLen   password $ \(c_password, c_password_len) ->
+    withCStringLen salt     $ \(c_salt,     c_salt_len) ->
+    allocaBytes    keySize  $ \c_key -> do
+      c_Pbkdf2Hmac c_password (ii c_password_len) c_salt (ii c_salt_len) (ii iterations) c_key (ii keySize)
+      peekCStringLen (c_key, keySize)
+
+
+----------------------------------------------------------------------------------------------------
+----- External encryption/PRNG routines ------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Generate key based on password and salt using given number of hashing iterations
+foreign import ccall unsafe  "Compression.h  Pbkdf2Hmac"
+   c_Pbkdf2Hmac :: Ptr CChar -> CInt -> Ptr CChar -> CInt -> CInt -> Ptr CChar -> CInt -> IO ()
+
+-- PRNG
+foreign import ccall unsafe  "Compression.h  fortuna_size"
+   prng_size :: CInt
+foreign import ccall unsafe  "Compression.h  fortuna_start"
+   prng_start :: Ptr CChar -> IO CInt
+foreign import ccall unsafe  "Compression.h  fortuna_add_entropy"
+   prng_add_entropy :: Ptr CChar -> CULong -> Ptr CChar -> IO CInt
+foreign import ccall unsafe  "Compression.h  fortuna_ready"
+   prng_ready :: Ptr CChar -> IO CInt
+foreign import ccall unsafe  "Compression.h  fortuna_read"
+   prng_read :: Ptr CChar -> CULong -> Ptr CChar -> IO CULong

--- a/Compression/_Examples/4x4.hs
+++ b/Compression/_Examples/4x4.hs
@@ -1,3 +1,234 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:54893e224c7768d49bd76be9ed9daebc72efb7f0ba2c287117c726c8fce23b33
-size 11196
+{- Multithreading compression with overlapped I/O example
+4x4 version 0.2 - bigger, longer, stronger ;)
+* fast compression modes made even faster (direct i/o to compression buffers; larger blocks to avoid disk trashing; MM tables disabled in -2/-3 modes)
+* high compression modes made even higher (256mb dictionary, saving output to temp. files)
+* multi-threaded decompression with direct i/o  (lzma, увел. кол-во тредов декомпрессии при малом blocksize)
+* fast text compression modes 1t..4t using grzip - now 4x4 is 10x faster than lzturbo on ENWIK9!
+-}
+
+import Prelude hiding (catch)
+import Control.Concurrent
+import Control.Exception
+import Control.Monad
+import Data.Array
+import Data.Char
+import Data.Either
+import Data.IORef
+import Data.List
+import Data.Maybe
+import Data.Word
+import Foreign.Marshal
+import Foreign.Ptr
+import Foreign.Storable
+import Foreign.C.Types
+import System.Environment
+import System.Exit
+import System.IO
+
+import CompressionLib
+import Utils
+
+-- |Abbreviations for useful compression methods
+profiles = [("1t", "grzip:m4")
+           ,("2t", "grzip:m3")
+           ,("3t", "grzip:m2")
+           ,("4t", "grzip:m1:h18")
+
+           ,( "1", "tor:1:4m")
+           ,( "2", "tor:2:8m")
+           ,( "3", "tor:3:8m")
+           ,( "4", "tor:4:16m")
+           ,( "5", "tor:5:16m")
+           ,( "6", "tor:6:32m")
+           ,( "7", "tor:7:64m")
+
+           ,( "8", "lzma:fast:128m:ht4:mc8")
+           ,( "9", "lzma:128m:ht4:mc16")
+           ,("10", "lzma:128m:ht4:mc32")
+           ,("11", "lzma:128m:ht4:mc64")
+           ,("12", "lzma:128m:ht4:mc128")
+           ]
+
+-- |Describe builtin compression profile for help display
+describe (level, method)  =  "  "++level++": "++method
+
+
+data Mode = COMPRESS | DECOMPRESS  deriving (Eq)
+
+data Options = Options { workThreads :: Int
+                       , ioThreads   :: Int
+                       }
+
+-- |Parse options and return Options structure and rest of cmdline arguments
+parseOpt (('-':'p':n):args) opts  =  parseOpt args opts{workThreads=readInt n}
+parseOpt (('-':'i':n):args) opts  =  parseOpt args opts{ioThreads=readInt n}
+parseOpt ("--":args)        opts  =  (args, opts)
+parseOpt (arg:args)         opts  =  parseOpt args opts.$ mapFst (arg:)
+parseOpt []                 opts  =  ([], opts)
+
+
+main = do
+  poke compress_all_at_once 1     -- enables block-to-block compression mode in tornado and lzma
+  origArgs <- getArgs
+  let (args,options)  =  parseOpt origArgs Options {workThreads=0, ioThreads = -1}
+  case args of
+    [level] ->  do let method = level.$ changeTo profiles
+                   withStdio $ compressionDriver method options
+
+    [level,infile,outfile] ->  do
+                   let method = level.$ changeTo profiles
+                   withFiles infile outfile $ compressionDriver method options
+
+    _ -> putStr ("4x4 ver. 0.3 alpha - multithreaded compressor, Nov 15 2008  (http://haskell.org/bz)\n"++
+                 "\n"++
+                 "Compression:   4x4 M [options] [infile outfile]\n"++
+                 "                 where M is compression profile: 1..12 or 1t..4t\n"++
+                 "                         or compression method: lzma:../grzip:../tor:..\n"++
+                 "\n"++
+                 "Decompression: 4x4 d [options] [infile outfile]\n"++
+                 "\n"++
+                 "Options:\n"++
+                 "  -p#: number of (de)compression threads (default 4)\n"++
+                 "  -i#: number of I/O threads\n"++
+                 "\n"++
+                 "Built-in compression profiles:\n" ++ unlines (map describe profiles))
+  --
+  let result=0
+  exitWith (if result==0  then ExitSuccess  else ExitFailure result)
+
+
+----------------------------------------------------------------------------------------------------
+-- Compression/decompression driver ----------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Compression/decompression driver. Creates a pool of (de)compression threads and one writing thread
+compressionDriver method Options {workThreads=workThreads, ioThreads=ioThreads} fin fout = do
+  let mode       =  if method=="d"  then DECOMPRESS  else COMPRESS
+      blockSize  =  getDictionary method .$i
+  numThreads <- case workThreads of
+                  0 -> return 4  -- todo: autodetect
+                  _ -> return workThreads
+  let numBufs  =  numThreads + case () of  -- determine number of additional threads used only for i/o operations
+                    _ | ioThreads >= 0                     ->  ioThreads   -- explicitly specified by -i# option
+                      | mode == DECOMPRESS                 ->  2           -- maximum that can be used in decompression mode without overflowing 2gb memory when 128 mb data blocks are used
+                      | getCompressionMem method > 200*mb  ->  1           -- it's the maximum we can use with highest compresssion modes
+                      | otherwise                          ->  4           -- for smaller blocks use more i/o threads
+  seqChan <- newChan   -- used to order write operations in the same order as data was read
+  fin <- newMVar fin   -- fin locked until write operation slot will be sent into seqChan
+  compressionThreadsSem <- newQSemN 0     -- used to postpone program finishing until all compression threads (and C compression functions) will be finished
+  compressorsSem <- newQSem numThreads    -- number of threads that are allowed to perform actual (de)compression simultaneously
+  replicateM_ numBufs (forkOS$ compressionThread mode method blockSize fin fout seqChan compressorsSem compressionThreadsSem)
+  writingThread seqChan
+  waitQSemN compressionThreadsSem numBufs
+
+
+-- |Single compression thread: reads input blocks, compress them and sends compressed data to outfile
+compressionThread COMPRESS  method blockSize fin fout seqChan compressorsSem compressionThreadsSem = do
+  chan <- newChan   -- channel used to send write commands to the writing thread
+  bytes' <- ref 0   -- size of last input block
+  repeat_until $ do   -- repeat until EOF (bytes==0)
+    let reader buf size = do bytes <- withMVar fin $ \fin -> do
+                               bytes <- hGetBuf fin buf (min size blockSize)
+                               writeChan seqChan (chan,bytes)
+                               return bytes
+                             bytes' =: bytes
+                             when (bytes>0) $ waitQSem compressorsSem    -- wait for signal to start compression itself
+                             return (bytes ||| -1)    -- on EOF returns -1 in order to immediately stop compression
+    --
+    let writer buf size = do signalQSem compressorsSem  -- signal that compression finished
+                             sem <- newQSem 0  -- used to pause execution until data will be written
+                             writeChan chan $ \origsize -> do
+                               -- Put header before compressed data: origsize+compsize+method
+                               let compsize  =  length method + 1 + size
+                               with (i origsize::Word32) $ \header -> hPutBuf fout header 4
+                               with (i compsize::Word32) $ \header -> hPutBuf fout header 4
+                               hPutStr0 fout method
+                               --
+                               hPutBuf fout buf size
+                               signalQSem sem
+                             waitQSem sem
+                             return size
+    --
+    compress method (makeCallback reader writer)
+    val bytes' >>== (==0)
+  signalQSemN compressionThreadsSem 1
+
+
+-- |Single decompression thread: reads compressed blocks, decompress them and sends decompressed data to outfile
+compressionThread DECOMPRESS method blockSize finMVar fout seqChan compressorsSem compressionThreadsSem = do
+  chan <- newChan   -- channel used to send write commands to the writing thread
+  repeat_until $ do   -- repeat until EOF (x==0)
+    fin <- takeMVar finMVar
+    allocaArray 2 $ \header -> do
+    x <- hGetBuf fin header 8
+    when (x>0) $ do
+      [origsize,compsize]  <-  peekArray 2 header
+      method <- hGetStr0 fin
+      remainder' <- ref (compsize-length method-1)
+      --
+      let reader buf size = do remainder <- val remainder'
+                               bytes <- hGetBuf fin buf (min remainder size)
+                               when (remainder>0 && remainder==bytes) $ do  -- Now we've read all input data
+                                 writeChan seqChan (chan,13)   -- this should be done before releasing fin!
+                                 putMVar finMVar fin           -- now fin may be used in other threads
+                                 waitQSem compressorsSem       -- no more than T threads should be busy in actual compression
+                               remainder' -= bytes
+                               return bytes
+      --
+      let writer buf size = do signalQSem compressorsSem   -- signal that this thread was finished compression
+                               sem <- newQSem 0            -- used to pause execution until buffer contents will be written to disk
+                               writeChan chan $ \13 -> do
+                                 hPutBuf fout buf size
+                                 signalQSem sem
+                               waitQSem sem
+                               return size
+      --
+      decompress method (makeCallback reader writer)
+      return ()
+    when   (x==0) $ putMVar finMVar fin
+    return (x==0)
+  writeChan seqChan (chan,0)
+  signalQSemN compressionThreadsSem 1
+
+
+-- |The writing thread sequences write operations so they are performed in the same order as data was read from input stream
+writingThread seqChan = do
+  repeat_until $ do   -- repeat until EOF
+    (chan,origsize) <- readChan seqChan
+    when (origsize>0) $ do
+      cmd <- readChan chan
+      cmd origsize
+    return (origsize==0)
+
+
+----------------------------------------------------------------------------------------------------
+-- Auxiliary functions -----------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Perform action with stdin/stdout handles set to binary mode
+withStdio action = do
+  hSetBinaryMode stdin  True
+  hSetBinaryMode stdout True
+  action stdin stdout
+
+-- |Perform action with files specified
+withFiles infile outfile action = do
+  fin  <- openBinaryFile infile  ReadMode
+  fout <- openBinaryFile outfile WriteMode
+  action fin fout
+
+-- |Make callback function from reader & writer funcs
+makeCallback reader writer "read"  buf size _  =  reader buf size
+makeCallback reader writer "write" buf size _  =  writer buf size
+makeCallback reader writer _       _   _    _  =  return 0
+
+-- |Write string + NULL char
+hPutStr0 h str  =  hPutStr h (str++[chr 0])
+
+-- |Read NULL-terminated string
+hGetStr0 h  =  go ""
+  where go cs = do c <- hGetChar h
+                   case c of
+                     '\0' -> return (reverse cs)
+                     _    -> go (c:cs)
+

--- a/Compression/_Examples/Example-Haskell.hs
+++ b/Compression/_Examples/Example-Haskell.hs
@@ -1,3 +1,16 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3baa0d4439fbe382053648d5552cd960d2047914c4c70ca9f4d4eb12b78d6779
-size 653
+import System.Environment
+import System.Exit
+import System.IO
+import CompressionLib
+
+main = do
+  hSetBinaryMode stdin  True
+  hSetBinaryMode stdout True
+  let write_stdout buf size  =  hPutBuf stdout buf size  >>  return size
+  args <- getArgs
+  (result,time) <- case args of
+    ["d"]    -> decompressWithHeader        (hGetBuf stdin) write_stdout
+    [method] ->   compressWithHeader method (hGetBuf stdin) write_stdout
+    _        -> putStrLn ("Usage: Compressor method <infile >outfile\n"++
+                          "       Compressor d      <infile >outfile")  >> return (1,0)
+  exitWith (if result==0  then ExitSuccess  else ExitFailure result)

--- a/Encryption.hs
+++ b/Encryption.hs
@@ -1,3 +1,160 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6b5527c643d580f67a6a54e719a5959e490ceca8b92c7487fcd503b0f7abc237
-size 9760
+{-# OPTIONS_GHC -cpp #-}
+----------------------------------------------------------------------------------------------------
+---- Шифрование, дешифрование и криптографический PRNG.                                         ----
+---- Процедура generateEncryption добавляет к цепочке алгоритмов сжатия алгоритм(ы) шифрования. ----
+---- Процедура generateDecryption добавляет ключи к записи алгоритма сжатия+шифрования,         ----
+---- Процедура generateRandomBytes возвращает последовательность крипт. случайных байт          ----
+----------------------------------------------------------------------------------------------------
+module Encryption (generateEncryption, generateDecryption, generateRandomBytes) where
+
+import Prelude hiding (catch)
+import Control.Concurrent
+import Control.Monad
+import Data.Char
+import Foreign.C.String
+import Foreign.C.Types
+import Foreign.Marshal.Alloc
+import Foreign.Ptr
+import System.IO
+import System.IO.Unsafe
+
+import EncryptionLib
+import Utils
+import Errors
+import Compression
+
+---------------------------------------------------------------------------------------------------
+---- Шифрование и дешифрование --------------------------------------------------------------------
+---------------------------------------------------------------------------------------------------
+
+-- |Возвращает две функции, добавляющие к методу сжатия алгоритм шифрования:
+-- первая включает ключ шифрования (для реального использования)
+-- вторая только вспомогательные данные (для сохранения в архиве)
+generateEncryption encryption password = do
+    addRandomness
+    result <- foreach (split_compressor encryption) $ \algorithm -> do
+        initVector <- generateRandomBytes (encryptionGet "ivSize"  algorithm)
+        salt       <- generateRandomBytes (encryptionGet "keySize" algorithm)
+        let numIterations = encryptionGet "numIterations" algorithm
+            checkCodeSize = 2
+            (key, checkCode) = deriveKey algorithm password salt numIterations checkCodeSize
+        return (algorithm++":k"++encode16 key++":i"++encode16 initVector
+               ,algorithm++":s"++encode16 salt++":c"++encode16 checkCode
+                         ++":i"++encode16 initVector)
+    return ((++map fst result), (++map snd result))
+
+
+-- |Обработать compressor, прочитанный из архива, добавив к нему информацию,
+-- необходимую для расшифровки
+generateDecryption compressor decryption_info  =  mapM addKey compressor   where
+  -- Обработать алгоритм шифрования, добавив к нему key, выведенный
+  -- из заданного пользователем пароля и salt, сохранённого в параметрах алгоритма
+  addKey algorithm | not (isEncryption algorithm)
+                               = return (Just algorithm)    -- non-encryption algorithm stays untouched
+                   | otherwise = do
+    -- Выделим из записи алгоритма параметры, необходимые для вычисления и проверки ключа
+    let name:params   = split_method algorithm
+        param c       = params .$map (splitAt 1) .$lookup c   -- найти значение параметра с
+        salt          = param "s" `defaultVal` (error$ algorithm++" doesn't include salt") .$decode16
+        checkCode     = param "c" `defaultVal` "" .$decode16
+        numIterations = param "n" `defaultVal` (error$ algorithm++" doesn't include numIterations") .$readInt
+
+    -- Воспользуемся списком паролей распаковкии и, если придётся,
+    -- добавим в него новые пароли, введённые пользователем
+    let (dont_ask_passwords, mvar_passwords, keyfiles, ask_decryption_password, bad_decryption_password) = decryption_info
+    modifyMVar mvar_passwords $ \passwords -> do
+      passwords_list <- ref passwords
+
+      -- Попробовать расшифровку со всеми возможными keyfiles и затем без них
+      let checkPwd password  =  firstJust$ map doCheck (keyfiles++[""])
+            where -- Если верификация по checkCode успешна, то возвращаем найденный ключ алгоритма шифрования, иначе - Nothing
+                  doCheck keyfile  =  recheckCode==checkCode  &&&  Just key
+                    -- Вычислим ключ расшифровки key и recheckCode, используемый для быстрой проверки правильности пароля
+                    where (key, recheckCode) = deriveKey algorithm (password++keyfile) salt numIterations (length checkCode)
+
+      -- Процедура подбора пароля для расшифровки блока.
+      -- Каждый вероятный пароль проверяется с помощью checkPwd.
+      -- Если ни один из уже известных паролей не подошёл, то мы запрашиваем у пользователя новые
+      let findDecryptionKey (password:pwds) = do
+            case (checkPwd password) of            -- Если верификация в checkPwd прошла успешно
+              Just key -> return (Just key)        --   то возвращаем найденный ключ алгоритма шифрования
+              Nothing  -> findDecryptionKey pwds   --   иначе - пробуем следующие пароли
+
+          findDecryptionKey [] = do   -- Сюда мы попадаем если ни один старый пароль не подошёл
+            -- Если использована опция -p-/-op- или пользователь введёт пустую строку -
+            -- значит, этот блок расшифровать нам не удастся
+            if dont_ask_passwords  then return Nothing   else do
+              password <- ask_decryption_password
+              if password==""        then return Nothing   else do
+                -- Добавим новый пароль в список паролей, проверяемых при распаковке
+                passwords_list .= (password:)
+                case (checkPwd password) of               -- Если верификация в checkPwd прошла успешно
+                  Just key -> return (Just key)           --   то возвращаем найденный ключ алгоритма шифрования
+                  Nothing  -> do bad_decryption_password  --   иначе - запрашиваем другой пароль
+                                 findDecryptionKey []
+      --
+      key <- findDecryptionKey passwords
+      pl  <- val passwords_list
+      return (pl, key.$fmap (\key -> algorithm++":k"++encode16 key))
+
+
+-- |Вывести из password+salt ключ шифрования и код проверки
+deriveKey algorithm password salt numIterations checkCodeSize =
+    splitAt keySize $ pbkdf2Hmac password salt numIterations (keySize+checkCodeSize)
+    where   keySize = encryptionGet "keySize" algorithm
+
+
+-- |Check action result and abort on (internal) error
+check test msg action = do
+  res <- action
+  unless (test res) (fail$ "Error in "++msg)
+
+-- |OK return code for LibTomCrypt library
+aCRYPT_OK = 0
+
+
+---------------------------------------------------------------------------------------------------
+---- Криптографический генератор случайных последовательностей байт -------------------------------
+---------------------------------------------------------------------------------------------------
+
+-- |Добавить случайную информацию, полученную от ОС, в PRNG
+addRandomness = withMVar prng_state addRandomnessTo
+addRandomnessTo prng = do
+  let size = 4096
+  allocaBytes size $ \buf -> do
+    bytes <- systemRandomData buf (i size)
+    check (==aCRYPT_OK) "prng_add_entropy" $
+      prng_add_entropy buf (i bytes) prng
+
+-- |Сгенерить случайную последовательность байт указанной длины
+generateRandomBytes bytes = do
+  withMVar prng_state $ \prng -> do
+    allocaBytes bytes $ \buf -> do
+      check (==i bytes) "prng_read" $
+        prng_read buf (i bytes) prng
+      peekCAStringLen (buf, bytes)
+
+-- |Переменная, хранящая состояние PRNG
+{-# NOINLINE prng_state #-}
+prng_state :: MVar (Ptr CChar)
+prng_state = unsafePerformIO $ do
+   prng <- mallocBytes (i prng_size)
+   prng_start prng
+   addRandomnessTo prng
+   newMVar prng
+
+-- |Fill buffer with system-generated pseudo-random data.
+-- Reads from /dev/urandom on Unix; falls back to Windows CryptGenRandom on Windows.
+systemRandomData :: Ptr CChar -> CInt -> IO CInt
+#if defined(FREEARC_WIN)
+systemRandomData buf size = c_systemRandomData buf size
+
+foreign import ccall unsafe "Environment.h systemRandomData"
+  c_systemRandomData :: Ptr CChar -> CInt -> IO CInt
+#else
+systemRandomData buf size = do
+  withFile "/dev/urandom" ReadMode $ \h -> do
+    n <- hGetBuf h buf (fromIntegral size)
+    return (fromIntegral n)
+#endif
+

--- a/Errors.hs
+++ b/Errors.hs
@@ -1,3 +1,481 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d996bd9006c68c4019f71f0d4e43a2842d69f953eac39b2d520991166ffebc50
-size 21051
+{-# OPTIONS_GHC -cpp #-}
+---------------------------------------------------------------------------------------------------
+---- Регистрация ошибок/предупреждений и печать сообщений о них. ----------------------------------
+---------------------------------------------------------------------------------------------------
+module Errors where
+
+import Prelude hiding (catch)
+import Control.Concurrent
+import Control.Exception
+import Control.Monad
+import Data.Char
+import Data.Maybe
+import Data.IORef
+import System.Exit
+import System.IO
+import System.IO.Unsafe
+#if defined(FREEARC_WIN)
+import GHC.ConsoleHandler
+#else
+import System.Posix.Signals
+import Foreign.C (CInt(..))
+#endif
+
+import CompressionLib   (compressionLib_cleanup)
+import Utils
+import Files
+import Charsets
+
+-- |Коды возврата программы
+aEXIT_CODE_SUCCESS      = 0
+aEXIT_CODE_WARNINGS     = 1
+aEXIT_CODE_FATAL_ERROR  = 2
+aEXIT_CODE_BAD_PASSWORD = 21
+aEXIT_CODE_USER_BREAK   = 255
+
+-- |Все возможные типы ошибок и предупреждений
+data ErrorTypes = GENERAL_ERROR                 [String]
+                | CMDLINE_GENERAL               [String]
+                | CMDLINE_SYNTAX                String
+                | CMDLINE_INCOMPATIBLE_OPTIONS  String String
+                | CMDLINE_NO_COMMAND            [String]
+                | CMDLINE_NO_ARCSPEC            [String]
+                | CMDLINE_NO_FILENAMES          [String]
+                | UNKNOWN_CMD                   String [String]
+                | CMDLINE_UNKNOWN_OPTION        String
+                | CMDLINE_AMBIGUOUS_OPTION      String [String]
+                | CMDLINE_BAD_OPTION_FORMAT     String
+                | INVALID_OPTION_VALUE          String String [String]
+                | CANT_READ_DIRECTORY           String
+                | CANT_GET_FILEINFO             String
+                | CANT_OPEN_FILE                String
+                | BAD_CRC                       String
+                | BAD_CFG_SECTION               String [String]
+                | OP_TERMINATED
+                | TERMINATED
+                | NOFILES
+                | SKIPPED_FAKE_FILES            Int
+                | BROKEN_ARCHIVE                FilePath [String]
+                | INTERNAL_ERROR                String
+                | COMPRESSION_ERROR             [String]
+                | BAD_PASSWORD                  FilePath FilePath
+
+--foreign import "&errCounter" :: Ptr Int
+{-
+data SqliteException = SqliteException Int String
+  deriving (Typeable)
+
+catchSqlite :: IO a -> (SqliteException -> IO a) -> IO a
+catchSqlite = catchDyn
+
+throwSqlite :: SqliteException -> a
+throwSqlite = throwDyn
+-}
+
+---------------------------------------------------------------------------------------------------
+---- Обработка Ctrl-Break, Close и т.п. внешних событий -------------------------------------------
+---------------------------------------------------------------------------------------------------
+
+setCtrlBreakHandler action = do
+  --myThread <- myThreadId
+  -- При выходе или возникновении исключения восстановим предыдущий обработчик событий
+#if defined(FREEARC_WIN)
+  bracket (installHandler$ Catch onBreak) (installHandler) $  \oldHandler -> do
+    action
+#else
+  let catchSignals a  =  installHandler sigINT (CatchOnce$ onBreak undefined) Nothing
+  bracket (catchSignals (CatchOnce$ onBreak (error "onBreak"))) (catchSignals) $  \oldHandler -> do
+    action
+#endif
+
+-- |Вызвать fail, если установлен флаг аварийного завершения программы
+failOnTerminated = do
+  whenM (val operationTerminated) $ do
+    fail ""
+
+-- |Обработка Ctrl-Break и нажатия на Cancel сводится к выполнению финализаторов и
+-- установке спец. флага, который проверяется коллбэками, вызываемыми из Си
+onBreak event = terminateOperation
+terminateOperation = do
+  isFM <- val fileManagerMode
+  registerError$ iif isFM OP_TERMINATED TERMINATED
+
+-- |Принудительно завершает выполнение программы с заданным exitCode и печатью сообщения msg
+shutdown msg exitCode = do
+  separator' =: ("","\n")
+  log_separator' =: "\n"
+  fin <- val finalizers
+  for fin $ \(name,id,action) -> do
+    action
+  compressionLib_cleanup
+
+  w <- val warnings
+  case w of
+    0 -> when (exitCode==aEXIT_CODE_SUCCESS) $ ignoreErrors$ condPrintLineLn "k" "All OK"
+    _ -> ignoreErrors$ condPrintLineLn "n"$ "There were "++show w++" warning(s)"
+  ignoreErrors (msg &&& condPrintLineLn "n" msg)
+  ignoreErrors$ condPrintLineLn "e" ""
+#if !defined(FREEARC_WIN) && !defined(FREEARC_GUI)
+  ignoreErrors$ putStrLn ""  -- в Unix отсутствует автоматический перевод строки в терминале по завершению программы
+#endif
+  ignoreErrors$ closeLogFile
+  ignoreErrors$ hFlush stdout
+  ignoreErrors$ hFlush stderr
+  --killThread myThread
+  exit (exitCode  |||  (w &&& aEXIT_CODE_WARNINGS))
+#if 0
+  -- Более корректный способ завершения программы, к сожалению arc.exe с ним иногда виснет
+  exitWith$ case () of
+   _ | exitCode>0 -> ExitFailure exitCode
+     | w>0        -> ExitFailure aEXIT_CODE_WARNINGS
+     | otherwise  -> ExitSuccess
+#endif
+  return undefined
+
+-- |"handle" с выполнением "onException" также при ^Break
+handleCtrlBreak name onException action = do
+  failOnTerminated
+  id <- newId
+  handle (\(e :: SomeException) -> do onException; throwIO e) $ do
+    bracket_ (addFinalizer name id onException)
+             (removeFinalizer id)
+             (action)
+
+-- |"bracket" с выполнением "close" также при ^Break
+bracketCtrlBreak name init close action = do
+  failOnTerminated
+  id <- newId
+  bracket (do x<-init; addFinalizer name id (close x); return x)
+          (\x -> do removeFinalizer      id; close x)
+          action
+
+-- |bracketCtrlBreak, выполняющий fail при возврате Nothing из init
+bracketCtrlBreakMaybe name init fail close action = do
+  bracketCtrlBreak name (do x<-init; when (isNothing x) fail; return x)
+                        (`whenJust_` close)
+                        (`whenJust`  action)
+
+-- |Выполнить close-действие по завершению action
+ensureCtrlBreak name close action  =  bracketCtrlBreak name (return ()) (\_->close) (\_->action)
+
+-- Добавить/удалить finalizer в список
+addFinalizer name id action  =  finalizers .= ((name,id,action):)
+removeFinalizer id           =  finalizers .= filter ((/=id) . snd3)
+newId                        =  do curId+=1; id<-val curId; return id
+
+-- |Уникальный номер
+curId :: IORef Int
+curId = unsafePerformIO (ref 0)
+{-# NOINLINE curId #-}
+
+-- |Список действий, которые надо выполнить перед аварийным завершением программы
+finalizers :: IORef [(String, Int, IO ())]
+finalizers = unsafePerformIO (ref [])
+{-# NOINLINE finalizers #-}
+
+-- |Флаг, показывающий что мы находимся в режиме прерывания текущей операции
+operationTerminated = unsafePerformIO (ref False)
+{-# NOINLINE operationTerminated #-}
+
+-- |Режим работы файл-менеджера: при этом registerError обрабатывается по-другому - мы дожидаемся завершения всех тредов упаковки и распаковки
+fileManagerMode = unsafePerformIO (ref False)
+{-# NOINLINE fileManagerMode #-}
+
+
+---------------------------------------------------------------------------------------------------
+---- Тексты сообщений о различных типах ошибок. Подходящий ресурс для интернализации --------------
+---------------------------------------------------------------------------------------------------
+
+errormsg (GENERAL_ERROR msgs) =
+  i18fmt msgs
+
+errormsg (BROKEN_ARCHIVE arcname msgs) = do
+  msg <- i18fmt msgs
+  i18fmt ["0341 %1 isn't archive or this archive is corrupt: %2. Please recover it using 'r' command or use -tp- option to ignore Recovery Record", arcname, msg]
+
+errormsg (INTERNAL_ERROR msg) =
+  return$ "FreeArc internal error: "++msg
+
+errormsg (COMPRESSION_ERROR msgs) =
+  i18fmt msgs
+
+errormsg (CMDLINE_GENERAL msgs) =
+  i18fmt msgs
+
+errormsg (CMDLINE_SYNTAX syntax) =
+  i18fmt ["0318 command syntax is \"%1\"", syntax]
+
+errormsg (CMDLINE_INCOMPATIBLE_OPTIONS option1 option2) =
+  i18fmt ["0319 options %1 and %2 can't be used together", option1, option2]
+
+errormsg (UNKNOWN_CMD cmd known_cmds) =
+  i18fmt ["0320 unknown command \"%1\". Supported commands are: %2", cmd, joinWith ", " known_cmds]
+
+errormsg (CMDLINE_UNKNOWN_OPTION option) =
+  i18fmt ["0321 unknown option \"%1\"", option]
+
+errormsg (CMDLINE_AMBIGUOUS_OPTION option variants) = do
+  or <- i18n"0323 or"
+  i18fmt ["0322 ambiguous option \"%1\" - is that %2?", option, enumerate or variants]
+
+errormsg (CMDLINE_BAD_OPTION_FORMAT option) =
+  i18fmt ["0325 option \"%1\" have illegal format", option]
+
+errormsg (INVALID_OPTION_VALUE fullname shortname valid_values) = do
+  or <- i18n"0323 or"
+  i18fmt ["0326 %1 option must be one of: %2", fullname, enumerate or (map (('-':shortname)++) valid_values)]
+
+errormsg (CMDLINE_NO_COMMAND args) =
+  i18fmt ["0327 no command name in command: %1", unwords args]
+
+errormsg (CMDLINE_NO_ARCSPEC args) =
+  i18fmt ["0328 no archive name in command: %1", unwords args]
+
+errormsg (CMDLINE_NO_FILENAMES args) =
+  i18fmt ["0329 no filenames in command: %1", unwords args]
+
+errormsg (CANT_READ_DIRECTORY dir) =
+  i18fmt ["0330 can't read directory \"%1\"", dir]
+
+errormsg (CANT_GET_FILEINFO filename) =
+  i18fmt ["0331 can't get info about file \"%1\"", filename]
+
+errormsg (CANT_OPEN_FILE filename) =
+  i18fmt ["0332 can't open file \"%1\"", filename]
+
+errormsg (BAD_CRC filename) =
+  i18fmt ["0333 CRC error in file \"%1\"", filename]
+
+errormsg (BAD_CFG_SECTION cfgfile section) =
+  i18fmt ["0334 bad section %1 in %2", head section, cfgfile]
+
+errormsg (OP_TERMINATED) =
+  i18fmt ["0335 operation terminated!"]
+
+errormsg (TERMINATED) =
+  i18fmt ["0336 program terminated!"]
+
+errormsg (NOFILES) =
+  i18fmt ["0337 no files, erasing empty archive"]
+
+errormsg (SKIPPED_FAKE_FILES n) =
+  i18fmt ["0338 skipped %1 fake files", show n]
+
+errormsg (BAD_PASSWORD archive "") =
+  i18fmt ["0339 bad password for archive %1", archive]
+
+errormsg (BAD_PASSWORD archive file) =
+  i18fmt ["0340 bad password for %1 in archive %2", file, archive]
+
+
+-- |Перечислить список значений
+enumerate s list  =  joinWith2 ", " (" "++s++" ") (map quote list)
+
+{-# NOINLINE errormsg #-}
+
+
+----------------------------------------------------------------------------------------------------
+---- Коды выхода для различных ошибок --------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+errcode BAD_PASSWORD{} = aEXIT_CODE_BAD_PASSWORD
+errcode _              = aEXIT_CODE_FATAL_ERROR
+
+
+----------------------------------------------------------------------------------------------------
+---- Ввод/вывод на экран в кодировке, заданной опцией -sct -----------------------------------------
+----------------------------------------------------------------------------------------------------
+
+#ifdef FREEARC_GUI
+myPutStr      = doNothing
+myPutStrLn    = doNothing
+myFlushStdout = doNothing0
+#else
+myGetLine     = getLine >>= terminal2str
+myPutStr      = putStr   =<<. str2terminal
+myPutStrLn    = putStrLn =<<. str2terminal
+myFlushStdout = hFlush stdout
+#endif
+
+
+----------------------------------------------------------------------------------------------------
+---- Работа с логфайлом и управление объёмом вывода на экран в соответствии с опцией --display -----
+----------------------------------------------------------------------------------------------------
+
+-- Напечатать заданную строку, отделив её при необходимости от предыдущей команды/обработанного архива
+-- Кроме того, первая буква печатаемой строки переводится в нижний регистр,
+-- если она печатается непосредственно после заголовка программы
+printLine = printLineC ""
+printLineC c str = do
+  (oldc,separator) <- val separator'
+  let makeLower (x:y:zs) | isLower y  =  toLower x:y:zs
+      makeLower xs                    =  xs
+  let handle "w" = stderr
+      handle _   = stdout
+#ifndef FREEARC_GUI
+  hPutStr (handle oldc) =<< str2terminal separator
+  hPutStr (handle c)    =<< str2terminal ((oldc=="h" &&& makeLower) str)
+  hFlush  (handle c)
+#endif
+  separator' =: (c,"")
+
+-- |Напечатать строку с разделителем строк после неё
+printLineLn str = do
+  printLine str
+  printLineNeedSeparator "\n"
+
+-- Отделить последующий вывод заданной строкой. Не выводим эту строку сразу,
+-- поскольку никакого последующего вывода может и не быть :)))
+printLineNeedSeparator str = do
+  separator' =: ("",str)
+
+-- Записать строку в логфайл.
+-- Вывести её на экран при условии, что её вывод не запрещён опцией --display
+condPrintLine c line = do
+  display_option <- val display_option'
+  when (c/="$" || (display_option `contains` '#')) $ do
+      printLog line
+  when (display_option `contains_one_of` c) $ do
+      printLineC c line
+
+-- |Напечатать строку с разделителем строк после неё
+condPrintLineLn c line = do
+  condPrintLine c line
+  condPrintLineNeedSeparator c "\n"
+
+-- Отделить последующий вывод заданной строкой при условии разрешения вывода класса c
+condPrintLineNeedSeparator c str = do
+  display_option <- val display_option'
+  when (c/="$" || (display_option `contains` '#')) $ do
+      log_separator' =: str
+  when (c=="" || (display_option `contains_one_of` c)) $ do
+      separator' =: (c,str)
+
+-- Открыть логфайл
+openLogFile logfilename = do
+  closeLogFile  -- закрыть предыдущий, если был
+  logfile <- case logfilename of
+                 ""  -> return Nothing
+                 log -> fileAppendText log >>== Just
+  logfile' =: logfile
+
+-- Вывести строку в логфайл
+printLog line = do
+  separator <- val log_separator'
+  whenJustM_ (val logfile') $ \log -> do
+      fileWrite log =<< str2logfile (separator ++ line); fileFlush log
+      log_separator' =: ""
+
+-- Закрыть логфайл
+closeLogFile = do
+  whenJustM_ (val logfile') fileClose
+  logfile' =: Nothing
+
+-- Переменная, хранящая Handle логфайла
+logfile'        = unsafePerformIO$ newIORef Nothing
+-- Переменные, используемые для украшения печати
+separator'      = unsafePerformIO$ newIORef ("","") :: IORef (String,String)
+log_separator'  = unsafePerformIO$ newIORef "\n"    :: IORef String
+display_option' = unsafePerformIO$ newIORef$ (error "undefined display_option" :: String)
+
+{-# NOINLINE printLine #-}
+{-# NOINLINE printLineNeedSeparator #-}
+{-# NOINLINE condPrintLine #-}
+{-# NOINLINE condPrintLineNeedSeparator #-}
+{-# NOINLINE separator' #-}
+{-# NOINLINE log_separator' #-}
+{-# NOINLINE display_option' #-}
+
+----------------------------------------------------------------------------------------------------
+---- Печать сообщений об ошибках и предупреждений
+----------------------------------------------------------------------------------------------------
+
+-- |Запись сообщения об ошибке в логфайл и аварийное завершение программы с этим сообщением
+registerError err = do
+  msg <- errormsg err
+  msg <- i18fmt ["0316 ERROR: %1", msg]
+  -- Catch exceptions from individual error handlers (e.g. Lua handler before Lua is initialised)
+  -- so that we always reach shutdown and exit cleanly.
+  val errorHandlers >>= mapM_ (\h -> h msg `catch` (\(_::SomeException) -> return ()))
+  -- Если мы в режиме файл-менеджера, то придётся ждать завершения всех тредов компрессии,
+  -- иначе - просто совершаем аварийный выход из программы
+  unlessM (val fileManagerMode) $ do
+    -- Safety net: if shutdown itself throws (e.g. uninitialised display_option'), fall back to
+    -- a direct _exit() so the exception never escapes the handler and triggers GHC's hs_exit()
+    -- deadlock (hs_exit sends ThreadKilled to the main thread which is masked inside withMVar).
+    shutdown msg (errcode err)
+      `catch` \(_::SomeException) -> exit (errcode err)
+  operationTerminated =: True
+  fail ""
+
+-- |Запись предупреждения в логфайл и вывод его на экран
+registerWarning warn = do
+  warnings += 1
+  msg <- errormsg warn
+  msg <- i18fmt ["0317 WARNING: %1", msg]
+  val warningHandlers >>= mapM_ ($msg)
+  condPrintLineLn "w" msg
+
+-- |Выполнить операцию и возвратить количество возникших при этом warning'ов
+count_warnings action = do
+  w0 <- val warnings
+  action
+  w  <- val warnings
+  return (w-w0)
+
+-- |Счётчик ошибок, возникших в ходе работы программы
+warnings = unsafePerformIO$ newIORef 0 :: IORef Int
+
+-- В зависимости от режима зарегистрировать ошибку или предупреждение
+registerThreadError err = do
+  isFM <- val fileManagerMode
+  (iif isFM registerWarning registerError) err
+
+-- Операции, выполняемые при появлении ошибки/предупреждения (регистрируются в других частях программы)
+errorHandlers   = unsafePerformIO$ newIORef [] :: IORef [String -> IO ()]
+warningHandlers = unsafePerformIO$ newIORef [] :: IORef [String -> IO ()]
+
+{-# NOINLINE registerError #-}
+{-# NOINLINE registerWarning #-}
+{-# NOINLINE warnings #-}
+{-# NOINLINE errorHandlers #-}
+{-# NOINLINE warningHandlers #-}
+
+----------------------------------------------------------------------------------------------------
+---- Работа с файлами
+----------------------------------------------------------------------------------------------------
+
+-- |Возвратить Nothing и напечатать сообщение об ошибке, если файл не удалось открыть
+tryOpen filename = (fileOpen filename >>== Just)
+                     `catch` (\(e::IOError) -> do registerWarning$ CANT_OPEN_FILE filename; return Nothing)
+
+-- |Скопировать файл
+fileCopy srcname dstname = do
+  bracketCtrlBreak "fileClose1:fileCopy" (fileOpen srcname) (fileClose) $ \srcfile -> do
+    handleCtrlBreak "fileRemove1:fileCopy" (ignoreErrors$ fileRemove dstname) $ do
+      bracketCtrlBreak "fileClose2:fileCopy" (fileCreate dstname) (fileClose) $ \dstfile -> do
+        size <- fileGetSize srcfile
+        fileCopyBytes srcfile size dstfile
+
+
+----------------------------------------------------------------------------------------------------
+----- External functions ---------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Stop program execution.
+-- On Windows the C exit() is used to avoid a known hang with exitWith in arc.exe.
+-- On Unix we use POSIX _exit() which terminates immediately without running atexit
+-- handlers (unlike exit()).  Using exit() would invoke GHC's hs_exit() atexit handler
+-- which sends ThreadKilled to all threads and waits for them; but threads blocked
+-- inside 'withMVar' (masked mode) defer async exceptions, causing a deadlock.
+-- exitWith throws ExitCode, which also escapes setUncaughtExceptionHandler.
+#if defined(FREEARC_WIN)
+foreign import ccall unsafe "stdlib.h exit"
+  exit :: Int -> IO ()
+#else
+foreign import ccall unsafe "unistd.h _exit"
+  c_posix_exit :: CInt -> IO ()
+exit :: Int -> IO ()
+exit n = c_posix_exit (fromIntegral n)
+#endif
+

--- a/FileInfo.hs
+++ b/FileInfo.hs
@@ -1,3 +1,427 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a5ce2b0abe39b046dea55603a03b3886c4555e1be1f242426695989b07fe9154
-size 25622
+{-# OPTIONS_GHC -cpp #-}
+----------------------------------------------------------------------------------------------------
+---- Получение и хранение информации о файлах, поиск файлов на диске.                           ----
+----------------------------------------------------------------------------------------------------
+module FileInfo where
+
+import Prelude hiding (catch)
+import Control.Exception
+import Control.Monad
+import Data.Char
+import Data.IORef
+import qualified Data.Map.Strict as Hash
+import Data.Int
+import Data.IORef
+import Data.List
+import Data.Maybe
+import Data.Word
+import Foreign.C
+import System.IO.Unsafe
+import System.Posix.Internals
+
+import Utils
+import Process
+import Files
+import Errors
+#ifdef FREEARC_PACKED_STRINGS
+import UTF8Z
+#endif
+#if defined(FREEARC_WIN)
+import Win32Files
+import System.Win32.File
+#endif
+
+
+----------------------------------------------------------------------------------------------------
+---- Компактное представление имени файла ----------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Хранение имён файлов в компактном виде с представлением быстрого доступа
+-- к имени каталога, имени файла без каталога и расширению файла
+data PackedFilePath = PackedFilePath
+  { fpPackedDirectory       :: !MyPackedString     -- Имя каталога
+  , fpPackedBasename        :: !MyPackedString     -- Имя файла без каталога, но с расширением
+  , fpLCExtension           :: !String             -- Расширение, переведённое в нижний регистр
+  , fpHash   :: {-# UNPACK #-} !Int32              -- Хеш от имени файла
+  , fpParent                :: !PackedFilePath     -- Структура PackedFilePath родительского каталога
+  }
+  | RootDir
+
+instance Eq PackedFilePath where
+  (==)  =  map2eq$ map3 (fpHash,fpPackedBasename,fpPackedDirectory)
+
+#ifdef FREEARC_PACKED_STRINGS
+-- Использование упакованных строк уменьшает расход памяти в 2 раза
+type MyPackedString = PackedString
+myPackStr           = packString
+myUnpackStr         = unpackPS
+
+-- |Заменяет повторения одинаковых расширений одной и той же строкой
+packext ext = unsafePerformIO$ do
+  m <- readIORef extsHash
+  case Hash.lookup ext m of
+    Nothing      -> do writeIORef extsHash (Hash.insert ext ext m)
+                       return ext
+    Just oldext  -> return oldext
+
+extsHash = unsafePerformIO$ newIORef (Hash.empty :: Hash.Map String String)
+
+#else
+type MyPackedString = String
+myPackStr           = id
+myUnpackStr         = id
+packext             = id
+#endif
+
+fpDirectory  =  myUnpackStr . fpPackedDirectory
+fpBasename   =  myUnpackStr . fpPackedBasename
+
+-- |Виртуальное поле: полное имя файла, включая каталог и расширение
+fpFullname fp  =  fpDirectory fp </> fpBasename fp
+
+-- |Ускоренное вычисление упакованного полного имени
+fpPackedFullname fp  =  if fpPackedDirectory fp == myPackStr ""
+                          then fpPackedBasename fp
+                          else myPackStr (fpFullname fp)
+
+
+-- |Создание упакованного представления из имени файла
+packFilePath parent fullname  =  packFilePath2 parent dir name
+  where (dir,name) = splitDirFilename fullname
+
+-- |Создание упакованного представления из имени каталога и имени файла без каталога
+packFilePath2       parent dir        name  =  packFilePathPacked2 parent (myPackStr dir) name
+packFilePathPacked2 parent packed_dir name  =  packFilePathPacked3 parent packed_dir name (packext$ filenameLower$ getFileSuffix name)
+
+-- |Создание упакованного представления из имени каталога, имени файла без каталога и расширения.
+packFilePath3 parent dir name lcext              =  packFilePathPacked3 parent (myPackStr dir) name lcext
+packFilePathPacked3 parent packed_dir name lcext =
+  PackedFilePath { fpPackedDirectory    =  packed_dir
+                 , fpPackedBasename     =  myPackStr name
+                 , fpLCExtension        =  lcext
+                 , fpHash               =  filenameHash (fpHash parent) name
+                 , fpParent             =  parent
+                 }
+
+-- |Создать структуру для базового каталога при поиске файлов
+packParentDirPath dir  =
+  PackedFilePath { fpPackedDirectory    =  myPackStr ""   -- Чтобы не тратить зря время,
+                 , fpPackedBasename     =  myPackStr dir  -- помещаем имя каталога целиком в Basename
+                 , fpLCExtension        =  ""
+                 , fpHash               =  filenameHash 0 (filter (not . isPathSeparator) dir)
+                 , fpParent             =  RootDir
+                 }
+
+-- |Хеш по полному имени файла (без разделителей каталога!).
+-- Для ускорения его вычисления используется `dirhash` - хеш имени каталога, содержащего файл,
+-- и `basename` - имя файла без имени каталога
+filenameHash {-dirhash basename-}  =  foldl (\h c -> h*37+i(ord c))
+
+{-# INLINE filenameHash #-}
+
+
+----------------------------------------------------------------------------------------------------
+---- Сопоставление имён файлов с регулярными выражениями -------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Сопоставить имя файла с маской `filespec`.
+-- Маски "*", "*.ext" или имя файла без каталога - обрабатываются особо
+match_FP getName filespec =
+  if filespec==reANY_FILE  then const True  else
+    case (splitFilename3 filespec) of
+      ("", "*", ext) -> match  (filenameLower ext)      . fpLCExtension
+      ("", _,   _  ) -> match  (filenameLower filespec) . filenameLower . getName
+      _              -> match  (filenameLower filespec) . filenameLower . fpFullname
+
+-- |Соответствует ли путь к файлу `filepath` хоть одной из масок `filespecs`?
+match_filespecs getName {-filespecs filepath-}  =  anyf . map (match_FP getName)
+
+-- |Маска, которой соответствует любое имя файла
+reANY_FILE = "*"
+
+
+----------------------------------------------------------------------------------------------------
+---- Информация о файле ----------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- Типы данных для..
+type FileCount = Int              -- количества файлов
+type FileSize  = Integer          -- размера файла или позиции чтения/записи в нём
+aFILESIZE_MIN  = -(2^63)          -- очень маленькое значение типа FileSize
+type FileTime  = CTime            -- времени создания/модификации/чтения файла
+type FileAttr  = FileAttributes   -- досовских атрибутов файла
+type FileGroup = Int              -- номера группы в arc.groups
+
+-- |Структура, хранящая всю необходимую нам информацию о файле
+data FileInfo = FileInfo
+  { fiFilteredName         :: !PackedFilePath  -- Имя файла, сопоставляемое с указанными в командной строке
+  , fiDiskName             :: !PackedFilePath  -- "Внешнее" имя файла - для чтения/записи файлов на диске
+  , fiStoredName           :: !PackedFilePath  -- "Внутреннее" имя файла - сохраняемое в оглавлении архива
+  , fiSize  :: {-# UNPACK #-} !FileSize        -- Размер файла (0 для каталогов)
+  , fiTime  :: {-# UNPACK #-} !FileTime        -- Дата/время создания файла
+  , fiAttr  :: {-# UNPACK #-} !FileAttr        -- Досовские атрибуты файла
+  , fiIsDir :: {-# UNPACK #-} !Bool            -- Это каталог?
+  , fiGroup :: {-# UNPACK #-} !FileGroup       -- Номер группы в arc.groups
+  }
+
+-- |Преобразовать FileInfo в имя файла на диске
+diskName     = fpFullname . fiDiskName
+storedName   = fpFullname . fiStoredName
+filteredName = fpFullname . fiFilteredName
+
+-- |Преобразовать FileInfo в базовое имя файла
+baseName     = fpBasename . fiStoredName
+
+-- |Специальные файлы (каталоги, симлинки и тому подобное) не требуют упаковки
+fiSpecialFile = fiIsDir
+
+-- |Номер группы, проставляемый там, где он не используется.
+fiUndefinedGroup = -1
+
+-- |Создать структуру FileInfo для каталога с заданным именем
+createParentDirFileInfo fiFilteredName fiDiskName fiStoredName =
+  FileInfo { fiFilteredName  =  packParentDirPath fiFilteredName
+           , fiDiskName      =  packParentDirPath fiDiskName
+           , fiStoredName    =  packParentDirPath fiStoredName
+           , fiSize          =  0
+           , fiTime          =  aMINIMAL_POSSIBLE_DATETIME
+           , fiAttr          =  0
+           , fiIsDir         =  True
+           , fiGroup         =  fiUndefinedGroup
+           }
+
+-- |Перечитать информацию о файле после его открытия (на случай, если файл успел измениться).
+--  Возвращает некорректные fiAttr (под юниксом) и fiGroup
+rereadFileInfo fi file = do
+  getFileInfo (fiFilteredName fi) (fiDiskName fi) (fiStoredName fi)
+
+-- |Создать структуру FileInfo с информацией о заданном файле.
+--  Возвращает некорректные fiAttr (под юниксом) и fiGroup
+getFileInfo fiFilteredName fiDiskName fiStoredName  =
+    let filename = fpFullname fiDiskName in do
+    fileWithStatus "getFileInfo" filename $ \p_stat -> do
+      fiIsDir  <-  stat_mode  p_stat  >>==  s_isdir
+      fiTime   <-  stat_mtime p_stat
+      fiSize   <-  if fiIsDir then return 0
+                              else stat_size p_stat
+      return$ Just$ FileInfo fiFilteredName fiDiskName fiStoredName fiSize fiTime 0 fiIsDir fiUndefinedGroup
+  `catch`
+    \(e::SomeException) -> do
+             registerWarning$ CANT_GET_FILEINFO filename
+             return Nothing  -- В случае ошибки при выполнении stat возвращаем Nothing
+
+-- |Restore date/time/attrs saved in FileInfo structure
+setFileDateTimeAttr filename fileinfo  =  setFileDateTime filename (fiTime fileinfo)
+
+{-# NOINLINE getFileInfo #-}
+
+
+----------------------------------------------------------------------------------------------------
+---- Процесс поиска файлов на диске ----------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Настройки для процесса поиска файлов на диске
+data FindFiles = FindFiles
+    { ff_disk_eq_filtered   :: Bool
+    , ff_stored_eq_filtered :: Bool
+    , ff_recursive          :: Bool
+    , ff_parent_or_root     :: FileInfo -> FileInfo
+    , ff_accept_f           :: FileInfo -> Bool
+    , ff_process_f          :: [FileInfo] -> IO ()
+    }
+
+
+-- |Вернуть FileInfo файлов и каталогов (исключая "." и ".."), находящихся в каталоге `parent`
+getDirectoryContents_FileInfo ff parent{-родительская структура FileInfo-} = do
+  let -- Полное дисковое имя род. каталога
+      diskDirName = fpFullname$ fiDiskName parent
+      -- Упакованные строки с дисковым, фильтруемым и запоминаемым именем род. каталога
+      -- Эти имена могут совпадать при отсутствии -ap/-dp, что позволяет нам экономить память в этих случаях
+      packedDisk  = myPackStr diskDirName
+      packedFiltered = if ff.$ff_disk_eq_filtered
+                          then packedDisk
+                          else myPackStr$ fpFullname$ fiFilteredName parent
+      packedStored   = if ff.$ff_stored_eq_filtered
+                          then packedFiltered
+                          else myPackStr$ fpFullname$ fiStoredName   parent_or_root
+      -- Выбрать parent или root в качестве родительской записи (последнее - только при -ep0)
+      parent_or_root = (ff.$ff_parent_or_root) parent
+
+      -- Вызвать функцию f, передав ей объекты фильтруемого, дискового и запомненного имени
+      make_names f name = f (packFilePathPacked3 (fiFilteredName parent)          packedFiltered  name lcext)
+                            (packFilePathPacked3 (fiDiskName     parent)          packedDisk      name lcext)
+                            (packFilePathPacked3 (fiStoredName   parent_or_root)  packedStored    name lcext)
+                          where lcext  =  packext$ filenameLower$ getFileSuffix name
+
+#if !defined(FREEARC_WIN)
+  (dirList (diskDirName|||".")) .$handleFindErrors diskDirName  -- Получим список файлов в каталоге, обрабатывая ошибки чтения каталога,
+    >>== filter exclude_special_names                           -- Исключим из списка "." и ".."
+    >>= (mapMaybeM $! make_names getFileInfo)                   -- Превратим имена файлов в структуры FileInfo и уберём из списка файлы, на которых споткнулся `stat`
+#else
+  withList $ \list -> do
+    handleFindErrors diskDirName $ do
+      wfindfiles (diskDirName </> reANY_FILE) $ \find -> do
+        name <- w_find_name find
+        when (exclude_special_names name) $ do
+          fiAttr  <- w_find_attrib     find
+          fiSize  <- w_find_size       find
+          fiTime  <- w_find_time_write find
+          fiIsDir <- w_find_isDir      find
+          (list <<=) $! make_names FileInfo name fiSize fiTime fiAttr fiIsDir fiUndefinedGroup
+#endif
+
+
+-- |Добавить exception handler, вызываемый при ошибках получения списка файлов в каталоге
+handleFindErrors dir =
+  handle $ \(e::IOError) -> do
+    -- Сообщение об ошибке не печатается для каталогов "/System Volume Information"
+    d <- myCanonicalizePath dir
+    unless (stripRoot d `strLowerEq` "System Volume Information") $ do
+      registerWarning$ CANT_READ_DIRECTORY dir
+    return defaultValue
+
+-- |Создать список файлов в `dir`, удовлетворяющих `accept_f` и отослать результат в `process_f`.
+-- Если recursive==True - повторить эти действия рекурсивно в каждом найденном подкаталоге
+findFiles_FileInfo dir ff@FindFiles{ff_accept_f=accept_f, ff_process_f=process_f, ff_recursive=recursive} = do
+  if recursive  then recursiveM processDir dir  else do processDir dir; return ()
+    where processDir dir = do
+            dirContents  <-  getDirectoryContents_FileInfo ff dir
+            process_f `unlessNull` (filter accept_f dirContents)   -- Обработать отфильтрованные файлы, если их список непуст
+            return                 (filter fiIsDir  dirContents)   -- Возвратить список подкаталогов для рекурсивной обработки
+
+{-# NOINLINE getDirectoryContents_FileInfo #-}
+{-# NOINLINE findFiles_FileInfo #-}
+
+
+----------------------------------------------------------------------------------------------------
+---- Поиск и обработка файлов, удовлетворяющих заданным критериям ----------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Условия поиска файлов на диске
+data FileFind = FileFind
+    { ff_ep             :: !Int
+    , ff_scan_subdirs   :: !Bool
+    , ff_include_dirs   :: !(Maybe Bool)
+    , ff_no_nst_filters :: !Bool
+    , ff_filter_f       :: !(FileInfo -> Bool)
+    , ff_group_f        :: !(Maybe (FileInfo -> FileGroup))
+    , ff_arc_basedir    :: !String
+    , ff_disk_basedir   :: !String
+    }
+
+-- |Найти [рекурсивно] все файлы, удовлетворяющие маске `filespec`, и вернуть их список
+find_files scan_subdirs filespec  =  find_and_filter_files [filespec] doNothing $
+    FileFind { ff_ep             = -1
+             , ff_scan_subdirs   = scan_subdirs
+             , ff_include_dirs   = Just False
+             , ff_no_nst_filters = True
+             , ff_filter_f       = const True
+             , ff_group_f        = Nothing
+             , ff_arc_basedir    = ""
+             , ff_disk_basedir   = ""
+             }
+
+-- |Составить список всех файлов и подкаталогов в каталоге
+dir_list directory  =  find_and_filter_files [directory </> reANY_FILE] doNothing $
+    FileFind { ff_ep             = 0
+             , ff_scan_subdirs   = False
+             , ff_include_dirs   = Just True
+             , ff_no_nst_filters = True
+             , ff_filter_f       = const True
+             , ff_group_f        = Nothing
+             , ff_arc_basedir    = ""
+             , ff_disk_basedir   = ""
+             }
+
+
+-- |Найти все файлы, удовлетворяющие критерию отбора `ff`,
+-- и вернуть их список
+find_and_filter_files filespecs process_f ff = do
+  concat ==<< withList (\list -> do  -- Сконкатенировать списки файлов, найденных в каждом подкаталоге
+    find_filter_and_process_files filespecs ff $ \files -> do
+      process_f files
+      list <<= files)
+
+-- |Найти все файлы, удовлетворяющие критерию отбора `ff`,
+-- и послать их список по частям в выходной канал процесса
+find_and_filter_files_PROCESS filespecs ff pipe = do
+  find_filter_and_process_files filespecs ff (sendP pipe)
+  sendP pipe []  -- сигнал "А кино-то уже кончилось!" :)
+
+
+-- |Найти [рекурсивно] все файлы, описываемые масками `filespecs` и критерием отбора `filter_f`,
+-- и выполнить над каждым списком файлов, найденных в одном каталоге, операцию `process_f`
+find_filter_and_process_files filespecs ff@FileFind{ ff_ep=ep, ff_scan_subdirs=scan_subdirs, ff_include_dirs=include_dirs, ff_filter_f=filter_f, ff_group_f=group_f, ff_arc_basedir=arc_basedir, ff_disk_basedir=disk_basedir, ff_no_nst_filters=no_nst_filters} process_f
+
+  -- Сгруппировать маски по имени каталога, и обработать каждую из этих групп отдельно
+  = do curdir  <-  getCurrentDirectory >>== translatePath
+{-
+       -- Поиск файлов как в RAR
+       let doit f = do
+             let re = isRegExp f
+             isdir <- isDirExists f
+             if not re && isdir  then findRecursively f  else do
+             if not re && -r-    then getStat f `catch` "WARNING: file %s not found"
+             else                     find (re || !-r-) f
+-}
+       -- Заменить имена каталогов dir на две маски "dir dir/" чтобы охватить сам каталог и все файлы в нём
+       filespecs1 <- foreach filespecs $ \filespec -> do
+         isDir <- case hasTrailingPathSeparator filespec of
+                    True  -> return True
+                    False -> dirExist filespec
+         when isDir $ do
+           find_files_in_one_dir curdir True [dropTrailingPathSeparator filespec]
+         return$ (isDir &&& addTrailingPathSeparator) filespec
+       --
+       mapM_ (find_files_in_one_dir curdir False) $ sort_and_groupOn (filenameLower . takeDirectory) filespecs1 where
+
+    -- Обработать группу масок, относящихся к одному каталогу
+    find_files_in_one_dir curdir addDir filespecs = do
+      findFiles_FileInfo root FindFiles{ff_process_f=process_f . map_group_f, ff_recursive=recursive, ff_disk_eq_filtered=disk_eq_filtered, ff_stored_eq_filtered=stored_eq_filtered, ff_parent_or_root=parent_or_root, ff_accept_f=accept_f}
+
+      where dirname  =  takeDirectory (head filespecs)  -- Общий для всех масок каталог
+            masks    =  map takeFileName filespecs      -- Маски без этого имени каталога
+            root     =  createParentDirFileInfo         -- Базовый FileInfo для этого поиска:
+                            dirname                     --   базовый каталог для фильтрации файлов
+                            diskdir                     --   базовый каталог на диске
+                            arcdir                      --   базовый каталог в архиве
+
+            -- Базовый каталог на диске
+            diskdir           =  disk_basedir </> dirname
+            -- Имена файлов на диске и в ком. строке совпадают?
+            disk_eq_filtered  =  diskdir==dirname
+            -- Полный путь к базовому каталогу на диске для -ep2/-ep3
+            full_dirname      =  curdir </> diskdir
+
+            -- Базовый каталог в архиве
+            arcdir  =  arc_basedir </> case ep of
+               0 -> ""                        -- -ep:  exclude any paths from names
+               1 -> ""                        -- -ep1: exclude base dir from names
+               2 -> full_dirname.$stripRoot   -- -ep2: full absolute path without "d:\"
+               3 -> full_dirname              -- -ep3: full absolute path with "d:\"
+               _ -> dirname.$stripRoot        -- Default: full relative path
+            -- Выбирает parent или root каталог в зависимости от опции -ep
+            parent_or_root      =  if ep==0  then const root  else id
+            -- Имена файлов внутри архива и в ком. строке совпадают?
+            stored_eq_filtered  =  arcdir==dirname && ep/=0
+
+            -- Одно из имён указано как "dir/"?
+            dir_slash    =  dirname>"" && masks `contains` ""
+            -- Сканировать подкаталоги если указана опция "-r" или одно из имён указано как "dir/"
+            recursive    =  scan_subdirs || dir_slash
+            -- Включить в список все файлы/каталоги, если одно из имён указано как "dir/" или "*" или "dir/*"
+            include_all  =  dir_slash || masks `contains` reANY_FILE
+            -- Предикат, определяющий какие файлы и каталоги будут включены в создаваемый список:
+            --   для каталогов это зависит от опций --[no]dirs, by default - при условии "[dir/]* -r" || "dir/" и отсутствии фильтров отбора файлов -n/-s../-t..
+            --   для файлов проверяется соответствие предикату `filter_f` и одной из масок
+            accept_f fi | fiIsDir fi  =  include_dirs `defaultVal` (addDir && baseName fi `elem` masks  ||  no_nst_filters && recursive && include_all)
+                        | otherwise   =  filter_f fi && (include_all || match_filespecs fpBasename masks (fiFilteredName fi))
+            -- Устанавливает в [FileInfo] номера групп fiGroup функцией, переданной в group_f
+            map_group_f = case group_f of
+                            Nothing -> id
+                            Just f  -> map (\x -> x {fiGroup = f x})
+
+{-# NOINLINE find_files #-}
+{-# NOINLINE find_and_filter_files #-}
+{-# NOINLINE find_and_filter_files_PROCESS #-}
+{-# NOINLINE find_filter_and_process_files #-}

--- a/FileManDialogAdd.hs
+++ b/FileManDialogAdd.hs
@@ -1,3 +1,310 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d7d877e58629d5d968457134582532f5cc62520d4a87004fe9ec462158e52a38
-size 17731
+{-# OPTIONS_GHC -cpp #-}
+----------------------------------------------------------------------------------------------------
+---- FreeArc archive manager: Add dialog                                                      ------
+----------------------------------------------------------------------------------------------------
+module FileManDialogAdd where
+
+import Prelude hiding (catch)
+import Control.Concurrent
+import Control.Exception
+import Control.Monad
+import Data.Char
+import Data.IORef
+import Data.List
+import Data.Maybe
+import System.IO.Unsafe
+import System.Cmd
+#if defined(FREEARC_WIN)
+import System.Win32
+#endif
+import System.Time
+
+import Graphics.UI.Gtk
+import Graphics.UI.Gtk.ModelView as New
+
+import Utils
+import Errors
+import Files
+import FileInfo
+import Charsets            (i18n)
+import Compression
+import Encryption
+import Options
+import UI
+import ArhiveStructure
+import ArhiveDirectory
+import ArcExtract
+import ArcCreate
+import FileManPanel
+import FileManUtils
+import FileManDialogs
+
+----------------------------------------------------------------------------------------------------
+---- Диалог упаковки файлов и модификации/слияния архивов ------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+addDialog fm' exec cmd mode = do
+  --start_time  <- getClockTime
+  fm <- val fm'
+  if isFM_Archive fm && cmd=="a"  then fmErrorMsg fm' "0133 You can't compress files directly from archive!" else do
+  if isFM_Archive fm && cmd=="j"  then fmErrorMsg fm' "0145 You can't join archives directly from archive!" else do
+  files <- if isFM_Archive fm then return [fm_arcname fm]
+                              else getSelection fm' addCmdFiles  -- todo: j/ch когда Selection включает каталоги
+  title <- i18n$ case (cmd,files) of
+                   ("a" , []    ) -> "0136 Add all files to archive"
+                   ("a" , [file]) -> "0134 Add %1 to archive"
+                   ("a" , _     ) -> "0135 Add %2 files to archive"
+                   ("ch", []    ) -> "0146 Modify all archives"
+                   ("ch", [file]) -> "0147 Modify %1"
+                   ("ch", _     ) -> "0148 Modify %2 archives"
+                   ("j" , []    ) -> "0149 Join all archives"
+                   ("j" , [file]) -> "0150 Join %1 with another archive"
+                   ("j" , _     ) -> "0151 Join %2 archives"
+  let wintitle  =  formatn title [head files, show3$ length files]
+  -- Создадим диалог со стандартными кнопками OK/Cancel
+  fmDialog fm' wintitle $ \(dialog,okButton) -> do
+    fmCacheConfigFile fm' $ do
+    (nb,newPage) <- startNotebook dialog
+
+------ Главная закладка ----------------------------------------------------------------------
+    vbox <- newPage "0182 Main";  let pack x = boxPackStart vbox x PackNatural 1
+    ------ Архив и каталог в нём ----------------------------------------------------------------------
+    (hbox, _, arcname) <- fmOutputArchiveFileBox fm' dialog;  pack hbox  `on`  cmd/="ch"
+    (hbox,    arcpath) <- fmLabeledEntryWithHistory fm' "arcpath" "0141 Base directory inside archive:";  pack hbox  `on`  cmd=="a"
+    ep                 <- fmExcludePaths;  pack (widget ep)          `on`  cmd=="a"
+    updateMode         <- fmUpdateMode;    pack (widget updateMode)  `on`  cmd=="a"
+    ------ Compression/Encryption/Protection ----------------------------------------------------------------------
+    (hbox, compression, compressionMethod) <- fmCheckedEntryWithHistory fm' "compression" "0183 Compression:";  pack hbox
+    (hbox, encryption,  encryptionMethod)  <- fmCheckedEntryWithHistory fm' "encryption"  "0184 Encryption:" ;  pack hbox
+    (hbox, protection,  protectionMethod)  <- fmCheckedEntryWithHistory fm' "protection"  "0185 Protection:" ;  pack hbox
+    (hbox, comment,     commentFile)       <- fmCheckedEntryWithHistory fm' "comment"     "0186 Comment:"    ;  pack hbox
+    (hbox, makeSFX,     sfxFile)           <- fmCheckedEntryWithHistory fm' "sfx"         "0227 Make EXE:"   ;  pack hbox
+    -- The rest
+    testAfter   <- checkBox "0128 Test archive after operation";        pack (widget testAfter)
+    deleteFiles <- checkBox "0122 Delete files successfully archived";  pack (widget deleteFiles)  `on`  cmd=="a"
+    lock        <- checkBox "0187 Finalize archive";                    pack (widget lock)
+    (hbox, options, optionsStr) <- fmCheckedEntryWithHistory fm' "options" "0072 Additional options:";  pack hbox
+
+
+------ Закладка архивных опций ----------------------------------------------------------------------
+    vbox <- newPage "0200 Archive";  let pack x = boxPackStart vbox x PackNatural 1
+    separate <- checkBox "0201 Compress each marked file/directory into separate archive";  pack (widget separate)  `on`  cmd=="a"
+    (hbox, ag, agTemplate) <- fmCheckedEntryWithHistory fm' "ag"  "0202 Add to archive name:";  pack hbox  `on`  cmd/="ch"
+    archiveTimeMode <- comboBox "0203 Set archive time to:"
+                                [ "0204 Current system time"
+                                , "0205 Original archive time"
+                                , "0206 Latest file time" ];  pack (widget archiveTimeMode)
+
+    create <- checkBox "0207 Delete previous archive contents";  pack (widget create)  `on`  cmd/="ch"
+    (hbox, sort, sortOrder)  <- fmCheckedEntryWithHistory fm' "sort" "0208 Order of files in archive:";  pack hbox  `on`  cmd=="a"
+    recompressMode <- comboBox "0209 Recompression mode:"
+                               [ "0210 Quickly append new files"
+                               , "0211 Smart recompression of solid blocks (default)"
+                               , "0212 Recompress all files"
+                               , "0213 Store only fileinfo"
+                               , "0214 Store only fileinfo & crcs"
+                               , "0215 No archive headers" ];  pack (widget recompressMode)
+    backupMode <- comboBox "0216 Backup mode:"
+                               [ "0217 No (default)"
+                               , "0218 Full: clear \"Archive\" attribute of files succesfully archived"
+                               , "0219 Differential: select only files with \"Archive\" attribute set"
+                               , "0220 Incremental: select by \"Archive\" attribute & clear it after compression" ];  pack (widget backupMode)  `on`  cmd/="ch"
+
+
+------ Закладка отбора файлов ----------------------------------------------------------------------
+    vbox <- newPage "0221 Files";  let pack x = boxPackStart vbox x PackNatural 1
+    (hbox, include, includeMasks) <- fmCheckedEntryWithHistory fm' "include" "0222 Include only files:";  pack hbox
+    (hbox, exclude, excludeMasks) <- fmCheckedEntryWithHistory fm' "exclude" "0223 Exclude files:";  pack hbox
+    (hbox, larger,  largerSize)   <- fmCheckedEntryWithHistory fm' "larger"  "0224 Include only files larger than:";  pack hbox
+    (hbox, smaller, smallerSize)  <- fmCheckedEntryWithHistory fm' "smaller" "0225 Include only files smaller than:";  pack hbox
+    --times: -tn/to/ta/tb
+
+------ Закладка сжатия ------------------------------------------------------------------------
+    (onCompressionChanged, saveCompressionHistories)  <-  compressionPage fm' =<< newPage "0106 Compression"
+    onCompressionChanged (compressionMethod =:)
+
+------ Закладка шифрования ------------------------------------------------------------------------
+    (onEncryptionChanged, encryptionOnOk)  <-  encryptionPage fm' dialog okButton =<< newPage "0119 Encryption"
+    onEncryptionChanged (encryptionMethod =:)
+
+------ Закладка архивного комментария --------------------------------------------------------------------------
+    vbox <- newPage "0199 Comment";  let pack x = boxPackStart vbox x PackGrow 1
+    commentText <- scrollableTextView "" [];  pack (widget commentText)
+
+
+------ Инициализация полей --------------------------------------------------------------------------
+    compression     =: mode==RecompressMode || cmd=="a"
+    encryption      =: mode==EncryptionMode
+    protection      =: mode==ProtectionMode
+    comment         =: mode==CommentMode
+    makeSFX         =: mode==MakeSFXMode
+    ep              =: 2
+    updateMode      =: 0
+    archiveTimeMode =: 0
+    recompressMode  =: 1
+    backupMode      =: 0
+
+    -- Имя создаваемого по умолчанию архива зависит от имён архивируемых файлов/сливаемых архивов
+    let arcnameBase = case files of
+          [file] -> let base = dropTrailingPathSeparator file
+                    in if base==file  then dropExtension file  -- один файл    - избавимся от расширения
+                                      else base                -- один каталог - избавимся от слеша в конце
+          _      -> takeFileName (fm_curdir fm)                -- много файлов - используем имя текущего каталога
+    arcname =: if isFM_Archive fm then fm_arcname fm
+                                  else (arcnameBase ||| "archive") ++ aDEFAULT_ARC_EXTENSION
+    arcpath =: ""
+
+
+------ Чтение значений полей и сохранение их для истории ------------------------------------------
+    widgetShowAll dialog
+    --current_time  <- getClockTime;  debugMsg (show$ diffTimes current_time start_time)
+    choice <- fmDialogRun fm' dialog "AddDialog"
+    windowPresent (fm_window fm)
+    when (choice==ResponseOk) $ do
+      -- Main settings
+      arcname' <- val arcname;  saveHistory arcname   `on`  cmd/="ch"
+      arcpath' <- val arcpath;  saveHistory arcpath   `on`  cmd=="a"
+      -- Если "имя архива" на самом деле указывает каталог внутри архива, то не ударим в грязь лицом :)
+      x <- splitArcPath fm' arcname'
+      (arcname', arcpath') <- return$ case x of
+          ArcPath arc path -> (arc, path </> arcpath')
+          _                -> (arcname', arcpath')
+      ep'          <- val ep
+      updateMode'  <- val updateMode
+      testAfter'   <- val testAfter
+      deleteFiles' <- val deleteFiles
+      optionsEnabled     <- val options
+      ; optionsStr'        <- val optionsStr;         saveHistory optionsStr        `on` optionsEnabled
+      compressionEnabled <- val compression
+      ; compressionMethod' <- val compressionMethod;  saveHistory compressionMethod `on` compressionEnabled
+      encryptionEnabled  <- val encryption
+      ; encryptionMethod'  <- val encryptionMethod;   saveHistory encryptionMethod  `on` encryptionEnabled
+      protectionEnabled  <- val protection
+      ; protectionMethod'  <- val protectionMethod;   saveHistory protectionMethod  `on` protectionEnabled
+      commentEnabled     <- val comment
+      ; commentFile'       <- val commentFile;        saveHistory commentFile       `on` commentEnabled
+      ; commentText'       <- val commentText
+      sfxEnabled  <- val makeSFX
+      ; sfxFile'  <- val sfxFile;   saveHistory sfxFile  `on` sfxEnabled
+      -- Archive settings
+      separate'  <- val separate
+      agEnabled  <- val ag
+      ; agTemplate' <- val agTemplate;      saveHistory agTemplate   `on` agEnabled
+      archiveTimeMode' <- val archiveTimeMode
+      lock'      <- val lock
+      create'    <- val create
+      sortEnabled  <- val sort
+      ; sortOrder' <- val sortOrder;        saveHistory sortOrder    `on` sortEnabled
+      recompressMode' <- val recompressMode
+      backupMode'     <- val backupMode
+      -- File selection settings
+      includeEnabled  <- val include
+      ; includeMasks' <- val includeMasks;  saveHistory includeMasks `on` includeEnabled
+      excludeEnabled  <- val exclude
+      ; excludeMasks' <- val excludeMasks;  saveHistory excludeMasks `on` excludeEnabled
+      largerEnabled   <- val larger
+      ; largerSize'   <- val largerSize;    saveHistory largerSize   `on` largerEnabled
+      smallerEnabled  <- val smaller
+      ; smallerSize'  <- val smallerSize;   saveHistory smallerSize  `on` smallerEnabled
+      -- Compression/encryption/decryption settings
+      saveCompressionHistories
+      encryptionOptions <- encryptionOnOk (encryptionEnabled &&& encryptionMethod')
+      -- Global settings
+      logfile'        <- fmGetHistory1 fm' "logfile" ""
+{-
+      -- Запомним настройки в истории
+      fmAddHistory fm' "acmd"$ joinWith "," [ "simpleMethod="  ++simpleMethod'
+                                            , "akeyfile="      ++keyfile'
+                                            , "xkeyfile="      ++xkeyfile'
+                                            , "encryptHeaders="++show encryptHeaders'
+                                            , "testAfter="     ++show testAfter']
+-}
+      -- Отобразим изменение имени архива
+      when sfxEnabled $ do
+        when (isFM_Archive fm) $ do
+        let newname' = changeSfxExt True (clear sfxFile') arcname'
+        when (newname'/=arcname') $ do
+          fmChangeArcname fm' newname'
+
+------ Формирование выполняемой команды/команд ----------------------------------------------------
+      let msgs = case cmd of
+                  "ch"-> ["0237 Modifying %1",
+                          "0238 SUCCESFULLY MODIFIED %1",
+                          "0239 %2 WARNINGS WHILE MODIFYING %1"]
+                  "j" -> ["0240 Joining archives to %1",
+                          "0241 SUCCESFULLY JOINED ARCHIVES TO %1",
+                          "0242 %2 WARNINGS WHILE JOINING ARCHIVES TO %1"]
+                  _   -> ["0243 Adding to %1",
+                          "0244 FILES SUCCESFULLY ADDED TO %1",
+                          "0245 %2 WARNINGS WHILE ADDING TO %1"]
+      let command archive filelist =
+           (msgs, [takeFileName archive],
+            [if create' then "create" else cmd]++
+            -- Main page settings
+            (compressionEnabled &&&  cvt "-m"   compressionMethod')++
+            (encryptionEnabled  &&&  cvt "-ae=" encryptionMethod')++encryptionOptions++
+            (protectionEnabled  &&&  cvt "-rr"  protectionMethod')++
+            (commentEnabled     &&&  [((clear commentFile' !~ "-z*" &&& "--archive-comment=")++) (clear commentFile' ||| commentText')])++
+            (sfxEnabled         &&&  cvt "-sfx" sfxFile')++
+            (testAfter'         &&&  ["-t"])++
+            (deleteFiles'       &&&  ["-d"])++
+            (null files         &&&  ["-r"])++
+            (arcpath'           &&&  ["-ap"++clear arcpath'])++
+            (ep'            `select`  "-ep,-ep1,,-ep2,-ep3")++
+            (updateMode'    `select`  ",-u,-f,--sync")++
+            -- Archive settings
+            (lock'                &&&   ["-k"])++
+            (agEnabled            &&&   ["-ag"++clear agTemplate'])++
+            (sortEnabled          &&&   ["-ds"++clear sortOrder'])++
+            (archiveTimeMode' `select`  ",-tk,-tl")++
+            (backupMode'      `select`  ",-ac,-ao,-ac -ao")++
+            (recompressMode'  `select`  "--append,,--recompress,--nodata,--crconly,--nodir")++
+            (cmd/="a" &&& (compressionEnabled || encryptionEnabled)  &&&  ["--recompress"])++
+            -- File selection settings
+            (includeEnabled   &&&  cvt1 "-n" includeMasks')++
+            (excludeEnabled   &&&  cvt1 "-x" excludeMasks')++
+            (largerEnabled    &&&  ["-sm"++clear largerSize'])++
+            (smallerEnabled   &&&  ["-sl"++clear smallerSize'])++
+            -- Other
+            ["-dp"++fm_curdir fm]++
+            (logfile'         &&&  ["--logfile="++clear logfile'])++
+            (cmd=="ch"        &&&  ["--noarcext"])++
+            (optionsEnabled   &&&  words (clear optionsStr'))++
+            ["--", clear archive]++filelist)
+      --
+      exec$ if cmd=="ch" then map (\archive -> command (fm_curdir fm </> archive) []) (files ||| ["*"])
+       else if separate' then files.$map (\file -> command (fm_curdir fm </> dropTrailingPathSeparator file++aDEFAULT_ARC_EXTENSION) [file])
+                         else [command arcname' files]
+
+
+----------------------------------------------------------------------------------------------------
+---- Вспомогательные определения -------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Поле выбора имени выходного архива
+fmOutputArchiveFileBox fm' dialog =
+  fmFileBox fm' dialog
+            "arcname" FileChooserActionSave
+     (label "0131 Output archive:")
+            "0132 Select output archive"
+            aARCFILE_FILTER
+            (const$ return True)
+            (fmCanonicalizeDiskPath fm')
+
+-- |Поле выбора опции -ep
+fmExcludePaths =
+  comboBox "0188 Store file paths:"
+           [ "0189 No"
+           , "0190 Relative to compressed dir"
+           , "0191 Relative to curdir (default)"
+           , "0192 Absolute (relative to root dir)"
+           , "0193 Full (including drive letter)" ]
+
+-- |Поле выбора режима обновления.
+fmUpdateMode =
+  comboBox "0194 Update mode:"
+           [ "0195 Add and replace files (default)"
+           , "0196 Add and update files"
+           , "0197 Fresh existing files"
+           , "0198 Synchronize archive with disk contents" ]
+

--- a/FileManDialogs.hs
+++ b/FileManDialogs.hs
@@ -1,3 +1,697 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c6ad56a9ada00b39224b80b28305316ed8407c5724b2afee50c23298dc8c73b8
-size 37887
+{-# OPTIONS_GHC -cpp #-}
+----------------------------------------------------------------------------------------------------
+---- FreeArc archive manager: Extract/ArcInfo/Settings dialogs                                ------
+----------------------------------------------------------------------------------------------------
+module FileManDialogs where
+
+import Prelude hiding (catch)
+import Control.Concurrent
+import Control.Exception
+import Control.Monad
+import Data.Char
+import Data.IORef
+import Data.List
+import Data.Maybe
+import System.IO.Unsafe
+import System.Cmd
+#if defined(FREEARC_WIN)
+import System.Win32
+#endif
+
+import Graphics.UI.Gtk
+import Graphics.UI.Gtk.ModelView as New
+
+import Utils
+import Errors
+import Files
+import FileInfo
+import Charsets
+import Compression
+import Encryption
+import Options
+import UIBase
+import UI
+import ArhiveStructure
+import ArhiveDirectory
+import ArcExtract
+import FileManPanel
+import FileManUtils
+
+----------------------------------------------------------------------------------------------------
+---- Диалог распаковки файлов ----------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+extractDialog fm' exec cmd arcnames arcdir files = do
+  fm <- val fm'
+  title <- i18n$ case (cmd, files, arcnames) of
+                   ("t", [],     [])        -> "0157 Test all archives"
+                   ("t", [],     [arcname]) -> "0152 Test %3"
+                   ("t", [file], [arcname]) -> "0153 Test %1 from %3"
+                   ("t", files,  [arcname]) -> "0154 Test %2 files from %3"
+                   ("t", files,  arcnames)  -> "0155 Test %4 archives"
+                   (_,   [],     [])        -> "0158 Extract all archives"
+                   (_,   [],     [arcname]) -> "0024 Extract files from %3"
+                   (_,   [file], [arcname]) -> "0025 Extract %1 from %3"
+                   (_,   files,  [arcname]) -> "0026 Extract %2 files from %3"
+                   (_,   files,  arcnames)  -> "0027 Extract files from %4 archives"
+  let wintitle  =  formatn title [head files, show3$ length files, takeFileName$ head arcnames, show3$ length arcnames]
+  -- Создадим диалог со стандартными кнопками OK/Cancel
+  fmDialog fm' wintitle $ \(dialog,okButton) -> do
+    upbox <- dialogGetUpper dialog
+    overwrite <- radioFrame "0005 Overwrite mode"
+                            [ "0001 Ask before overwrite",
+                              "0002 Overwrite without prompt",
+                              "0003 Update old files",
+                              "0051 Skip existing files" ]
+    ; boxPackStart upbox (widget overwrite) PackNatural 5         `on` cmd/="t"
+
+    ; outFrame <- frameNew
+    ; boxPackStart upbox outFrame           PackNatural 5         `on` cmd/="t"
+    ;   vbox <- vBoxNew False 0
+    ;   set outFrame [containerChild := vbox, containerBorderWidth := 5]
+    (hbox, _, dir) <- fmFileBox fm' dialog
+                                "dir" FileChooserActionSelectFolder
+                         (label "0004 Output directory:")
+                                "0021 Select output directory"
+                                []
+                                (const$ return True)
+                                (fmCanonicalizeDiskPath fm')
+    ; boxPackStart vbox hbox                  PackNatural 0
+    addDirButton <- checkBox "0014 Append archive name to the output directory"
+    ; boxPackStart vbox (widget addDirButton) PackNatural 0
+
+    (decryption, decryptionOnOK) <- decryptionBox fm' dialog   -- Настройки расшифровки
+    ; boxPackStart upbox decryption           PackNatural 5
+
+    (hbox, options, optionsStr)  <- fmCheckedEntryWithHistory fm' "xoptions" "0072 Additional options:"
+    ; boxPackStart upbox hbox                 PackNatural 5
+
+
+    -- Установим выходной каталог в значение по умолчанию
+    case arcnames of
+      [arcname] -> dir =: takeBaseName arcname
+      _         -> do dir=:"."; addDirButton=:True
+
+
+    widgetShowAll upbox
+    choice <- fmDialogRun fm' dialog (if cmd/="t" then "ExtractDialog" else "TestDialog")
+    windowPresent (fm_window fm)
+    when (choice==ResponseOk) $ do
+      overwriteOption    <- val overwrite
+      dir'               <- val dir;         saveHistory dir
+      isAddDir           <- val addDirButton
+      decryptionOptions  <- decryptionOnOK
+      logfile'           <- fmGetHistory1 fm' "logfile" ""
+      optionsEnabled     <- val options
+      ; optionsStr'        <- val optionsStr;  saveHistory optionsStr  `on`  optionsEnabled
+      let msgs = case cmd of
+                  "t" -> ["0231 Testing %1",
+                          "0232 SUCCESFULLY TESTED %1",
+                          "0233 %2 WARNINGS WHILE TESTING %1"]
+                  _   -> ["0234 Extracting files from %1",
+                          "0235 FILES SUCCESFULLY EXTRACTED FROM %1",
+                          "0236 %2 WARNINGS WHILE EXTRACTING FILES FROM %1"]
+      exec$ (arcnames ||| ["*"]) .$map (\arcname ->
+            (msgs, [takeFileName arcname],
+             [cmd]++
+             (cmd/="t" &&& (
+               ["-dp"++clear dir']++
+               (isAddDir &&& ["-ad"])++
+               (arcdir &&& files &&& ["-ap"++clear arcdir])++
+               (overwriteOption  `select`  ",-o+,-u -o+,-o-")))++
+             decryptionOptions++
+             (logfile'         &&&  ["--logfile="++clear logfile'])++
+             ["--fullnames"]++
+             ["--noarcext"]++
+             (optionsEnabled   &&&  words (clear optionsStr'))++
+             ["--", clear arcname]++files))
+
+
+----------------------------------------------------------------------------------------------------
+---- Диалог информации об архиве -------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+arcinfoDialog fm' exec mode arcnames arcdir files = do
+  handle (\e -> fmErrorMsg fm' "0013 There are no archives selected!") $ do
+  fm <- val fm'
+  let arcname = head arcnames
+  fm_arc <- case () of _ | isFM_Archive fm -> return (subfm fm)
+                         | otherwise       -> with' (newFMArc fm' arcname "") (return) closeFMArc
+  let archive = subfm_archive fm_arc
+  title <- i18n"0085 All about %1"
+  let wintitle  =  format title (takeFileName arcname)
+  -- Создадим диалог со стандартными кнопками OK/Cancel
+  fmDialog fm' wintitle $ \(dialog,okButton) -> do
+    (nb,newPage) <- startNotebook dialog
+------ Главная закладка ----------------------------------------------------------------------------
+    vbox <- newPage "0174 Main";  let pack n makeControl = do control <- makeControl
+                                                              boxPackStart vbox control PackNatural n
+
+    let filelist    = map (cfFileInfo)$ arcDirectory archive
+        footer      = arcFooter archive
+        dataBlocks  = arcDataBlocks archive        -- список солид-блоков
+        numOfBlocks = length dataBlocks
+        empty       = "-"
+    ;   yes        <- i18n"0101 Yes" >>== replaceAll "_" ""
+
+    let origsize = sum$ map blOrigSize dataBlocks  -- суммарный объём файлов в распакованном виде
+        compsize = sum$ map blCompSize dataBlocks  -- суммарный объём файлов в упакованном виде
+        getCompressors = partition isEncryption.blCompressor  -- разделить алг-мы шифрования и сжатия для блока
+        (encryptors, compressors) = unzip$ map getCompressors dataBlocks  -- список алг. шифрования и сжатия.
+        header_encryptors = deleteIf null$ map (fst.getCompressors) (ftBlocks footer)  -- алгоритмы шифрования служебных блоков
+        all_encryptors = deleteIf null encryptors ++ header_encryptors   -- а теперь все вместе :)
+        ciphers = joinWith "\n"$ removeDups$ map (join_compressor.map method_name) all_encryptors   -- имена алг. шифрования.
+        formatMem s  =  x++" "++y  where (x,y) = span isDigit$ showMem s
+
+    let -- Максимальные словари основных и вспомогательных алгоритмов
+        dicts = compressors.$ map (splitAt 1.reverse.map getDictionary)  -- [([mainDict],[auxDict1,auxDict2..])...]
+                           .$ map (\([x],ys) -> (x, maximum(0:ys)))      -- [(mainDict,maxAuxDict)...]
+                           .$ ((0,0):) .$ sort .$ last                   -- Выбираем строчку с макс. основным и вспом. словарём
+        dictionaries  =  case dicts of
+                           (0,0)                     -> empty
+                           (maxMainDict, 0)          -> formatMem maxMainDict
+                           (maxMainDict, maxAuxDict) -> showMem maxAuxDict++" + "++showMem maxMainDict
+
+    pack 10 $twoColumnTable [("0173 Directories:",      show3$ ftDirs$  subfm_filetree fm_arc)
+                            ,("0088 Files:",            show3$ ftFiles$ subfm_filetree fm_arc)
+                            ,("0089 Total bytes:",      show3$ origsize)
+                            ,("0090 Compressed bytes:", show3$ compsize)
+                            ,("0091 Ratio:",            ratio3 compsize origsize++"%")]
+
+    pack  0 $twoColumnTable [("0104 Directory blocks:", show3$ length$ filter ((DIR_BLOCK==) . blType) (ftBlocks footer))
+                            ,("0092 Solid blocks:",     show3$ numOfBlocks)
+                            ,("0093 Avg. blocksize:",   formatMem$ origsize `div` i(max numOfBlocks 1))]
+
+    pack 10 $twoColumnTable [("0099 Compression memory:",    formatMem$ maximum$ 0: map compressionGetShrinkedCompressionMem   compressors)
+                            ,("0100 Decompression memory:",  formatMem$ maximum$ 0: map compressionGetShrinkedDecompressionMem compressors)
+                            ,("0105 Dictionary:",            dictionaries)]
+
+    pack  0 $twoColumnTable [("0094 Archive locked:",    ftLocked footer   &&& yes ||| empty)
+                            ,("0098 Archive comment:",   ftComment footer  &&& yes ||| empty)
+                            ,("0095 Recovery info:",     ftRecovery footer ||| empty)
+                            ,("0096 SFX size:",          ftSFXSize footer .$show3 .$changeTo [("0", empty)])
+                            ,("0156 Headers encrypted:", header_encryptors &&& yes ||| empty)]
+
+    table <- twoColumnTable [("0097 Encryption algorithms:",  ciphers ||| empty)]
+    boxPackStart vbox table PackNatural (ciphers &&& 10)
+
+
+------ Закладка комментария архива -----------------------------------------------------------------
+    vbox <- newPage "0199 Comment"
+
+    comment <- scrollableTextView (ftComment footer) []
+    boxPackStart vbox (widget comment) PackGrow 0
+
+    widgetShowAll dialog
+    notebookSetCurrentPage nb 1    `on` mode==CommentMode
+    choice <- fmDialogRun fm' dialog "ArcInfoDialog"
+    windowPresent (fm_window fm)
+    when (choice==ResponseOk) $ do
+      newComment <- val comment
+      when (newComment /= ftComment footer) $ do
+        let msgs = ["0237 Modifying %1",
+                    "0238 SUCCESFULLY MODIFIED %1",
+                    "0239 %2 WARNINGS WHILE MODIFYING %1"]
+        let cmd  = ["ch"
+                   ,"--noarcext"
+                   ,newComment &&& ("--archive-comment="++newComment)
+                               ||| "-z-"
+                   ,"--"
+                   ,arcname]
+        --
+        exec [(msgs, [takeFileName arcname], cmd)]
+
+
+----------------------------------------------------------------------------------------------------
+---- Диалог настроек программы ---------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+settingsDialog fm' = do
+  fm <- val fm'
+  fmDialog fm' "0067 Settings" $ \(dialog,okButton) -> do
+    (nb,newPage) <- startNotebook dialog
+------ Главная закладка ----------------------------------------------------------------------
+    vbox <- newPage "0174 Main";  let pack x = boxPackStart vbox x PackNatural 1
+    aboutLabel         <- labelNewWithMnemonic aARC_HEADER_WITH_DATE
+    langLabel          <- label "0068 Language:"
+    langComboBox       <- New.comboBoxNewText
+    editLangButton     <- button "0069 Edit"
+    convertLangButton  <- button "0070 Import"
+    -- Логфайл
+    (logfileBox, _, logfile) <- fmFileBox fm' dialog
+                                          "logfile" FileChooserActionSave
+                                   (label "0166 Logfile:")
+                                          "0167 Select logfile"
+                                          []
+                                          (const$ return True)
+                                          (fmCanonicalizeDiskPath fm')
+    ; viewLogfileButton <- button "0292 View"
+    -- Прочее
+    toolbarTextButton   <- fmCheckButtonWithHistory fm' "ToolbarCaptions" True "0361 Add captions to toolbar buttons"
+    checkNewsButton     <- fmCheckButtonWithHistory fm' "CheckNews"       True "0370 Watch for new versions via Internet"
+    registerButton      <- button "0172 Associate FreeArc with .arc files"
+    notes               <- label . joinWith "\n" =<<
+      i18ns["0168 You should restart FreeArc in order for a language settings to take effect.",
+            "0169 Passwords need to be entered again after restart."]
+
+-----------------------------------------------------------------------------------------------
+    -- Информация о текущем языке локализации
+    langTable <- tableNew 2 2 False
+    let dataset = [("0170 Full name:", "0000 English"), ("0171 Copyright:", "0159 ")]
+    labels <- foreach [0..1] $ \y -> do
+      -- Первая колонка
+      label1 <- labelNew Nothing;  let x=0
+      tableAttach langTable label1 (x+0) (x+1) y (y+1) [Fill] [Fill] 5 5
+      miscSetAlignment label1 0 0
+      -- Вторая колонка
+      label2 <- labelNew Nothing
+      tableAttach langTable label2 (x+1) (x+2) y (y+1) [Expand, Fill] [Expand, Fill] 5 5
+      set label2 [labelSelectable := True]
+      miscSetAlignment label2 0 0
+      return (label1, label2)
+    --
+    let showLang i18n = do
+          for (zip labels dataset) $ \((l1,l2),(s1,s2)) -> do
+            labelSetTextWithMnemonic l1      =<< i18n s1
+            labelSetMarkup           l2.bold =<< i18n s2
+    --
+    showLang i18n
+
+    -- Текущие настройки
+    inifile  <- io$ findFile configFilePlaces aINI_FILE
+    settings <- inifile  &&&  io(readConfigFile inifile) >>== map (split2 '=')
+    let langFile =  settings.$lookup aINITAG_LANGUAGE `defaultVal` ""
+
+    -- Заполнить список языков именами файлов в каталоге arc.languages и выбрать активный язык
+    langDir   <- io$ findDir libraryFilePlaces aLANG_DIR
+    langFiles <- langDir &&& (io(dir_list langDir) >>== map baseName >>== sort >>== filter (match "arc.*.txt"))
+    -- Отобразим языки в 5 столбцов, с сортировкой по столбцам
+    let cols = 5
+    ;   langComboBox `New.comboBoxSetWrapWidth` cols
+    let rows = (length langFiles) `divRoundUp` cols;  add = rows*cols - length langFiles
+        sortOnColumn x  =  r*cols+c  where (c,r) = x `divMod` rows  -- пересчитать из поколоночных позиций в построчные
+    ;   langFiles <- return$ map snd $ sort $ zip (map sortOnColumn [0..]) (langFiles ++ replicate add "")
+    --
+    for langFiles (New.comboBoxAppendText langComboBox . mapHead toUpper . replace '_' ' ' . dropEnd 4 . drop 4)
+    whenJust_ (elemIndex (takeFileName langFile) langFiles)
+              (New.comboBoxSetActive langComboBox)
+
+    -- Определить файл локализации, соответствующий выбранному в комбобоксе языку
+    let getCurrentLangFile = do
+          lang <- New.comboBoxGetActive langComboBox
+          case lang of
+            Just lang -> myCanonicalizePath (langDir </> (langFiles !! lang))
+            Nothing   -> return ""
+
+    -- При выборе другого языка локализации вывести информацию о нём
+    langComboBox `New.onChanged` do
+      whenJustM_ (New.comboBoxGetActive langComboBox) $ \_ -> do
+        langFile   <- getCurrentLangFile
+        localeInfo <- parseLocaleFile langFile
+        showLang (i18n_general (return localeInfo) .>>== fst)
+
+    -- Редактирование текущего файла локализации/логфайла
+    editLangButton    `onClick` (runEditCommand =<< getCurrentLangFile)
+    viewLogfileButton `onClick` (runViewCommand =<< val logfile)
+
+#if defined(FREEARC_WIN)
+    registerButton `onClick` do
+      exe <- getExeName                                -- Name of FreeArc.exe file
+      let ico   =  exe `replaceExtension` ".ico"       -- Name of FreeArc.ico file
+          empty =  exe `replaceFileName` "empty.arc"   -- Name of empty archive file
+          register = registrySetStr hKEY_CLASSES_ROOT
+          regCmd name msg cmdline = do
+              register ("FreeArc.arc\\shell\\"++name) "" msg
+              register ("FreeArc.arc\\shell\\"++name++"\\command") "" ("\""++exe++"\" "++cmdline++" --noarcext -- \"%1\"")
+      register ".arc" "" "FreeArc.arc"
+      register ".arc\\ShellNew" "FileName" empty
+      register "FreeArc.arc" "" "FreeArc archive"
+      register "FreeArc.arc\\DefaultIcon" "" (ico++",0")
+      register "FreeArc.arc\\shell" "" "open"
+      register "FreeArc.arc\\shell\\open\\command" "" ("\""++exe++"\" \"%1\"")
+      regCmd   "extract-folder" "Extract to new folder" "x -ad"
+      regCmd   "extract-here"   "Extract here"          "x"
+      regCmd   "test"           "Test"                  "t"
+      -- todo: extract to ...;    *: add to archive; add to ...; выбор надписи и профайла/опций пользователя
+      return ()
+#endif
+
+    ; langFrame <- frameNew
+    ;   vbox1 <- vBoxNew False 0
+    ;   set langFrame [containerChild := vbox1, containerBorderWidth := 5]
+    ;     langbox <- hBoxNew False 0
+    boxPackStart langbox    (widget  langLabel)          PackNatural 0
+    boxPackStart langbox             langComboBox        PackGrow    5
+    boxPackStart langbox    (widget  editLangButton)     PackNatural 5
+    --boxPackStart langbox    (widget  convertLangButton)  PackNatural 5
+    boxPackStart vbox1               langbox             PackNatural 5
+    boxPackStart vbox1               langTable           PackNatural 5
+    boxPackStart logfileBox (widget  viewLogfileButton)  PackNatural 5
+    boxPackStart vbox                aboutLabel          PackNatural 5
+    boxPackStart vbox                langFrame           PackNatural 5
+    boxPackStart vbox                logfileBox          PackNatural 5
+    boxPackStart vbox       (widget  toolbarTextButton)  PackNatural 5
+    boxPackStart vbox       (widget  checkNewsButton)    PackNatural 5
+    boxPackStart vbox       (widget  registerButton)     PackNatural 5   `on` isWindows
+    boxPackStart vbox       (widget  notes)              PackNatural 5
+
+------ Закладка сжатия ------------------------------------------------------------------------
+    (_, saveCompressionHistories) <- compressionPage fm' =<< newPage "0106 Compression"
+
+------ Закладка шифрования --------------------------------------------------------------------
+    (_, saveEncryptionHistories)  <-  encryptionPage fm' dialog okButton =<< newPage "0119 Encryption"
+
+------ Закладка информации о системе ----------------------------------------------------------
+    vbox <- newPage "0388 Info";  let pack n makeControl = do control <- makeControl
+                                                              boxPackStart vbox control PackNatural n
+
+    maxBlock <- getMaxMemToAlloc
+    pack 10 $twoColumnTable [("0389 Largest contiguous free memblock:", showMem (maxBlock `roundDown` mb))]
+
+
+-----------------------------------------------------------------------------------------------
+    widgetShowAll dialog
+    choice <- fmDialogRun fm' dialog "SettingsDialog"
+    windowPresent (fm_window fm)
+    when (choice==ResponseOk) $ do
+      -- Сохраняем настройки в INI-файл, пароли - в глоб. переменных, keyfile - в истории
+      langFile <- getCurrentLangFile
+      inifile  <- io$ findOrCreateFile configFilePlaces aINI_FILE
+      io$ buildPathTo inifile
+      io$ saveConfigFile inifile$ map (join2 "=") [(aINITAG_LANGUAGE, takeFileName langFile)]
+      logfile' <- val logfile;  saveHistory logfile
+      saveHistory `mapM_` [toolbarTextButton, checkNewsButton]
+      saveCompressionHistories
+      saveEncryptionHistories ""
+      return ()
+
+
+----------------------------------------------------------------------------------------------------
+---- Закладка сжатия -------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+compressionPage fm' vbox = do
+  let pack x = boxPackStart vbox x PackNatural 1
+  -- Алгоритм сжатия.
+  (hbox, cmethod) <- fmLabeledEntryWithHistory fm' "compression" "0175 Compression profile:";  pack hbox
+  ; save <- button "0178 Save";  boxPackStart hbox (widget save) PackNatural 5
+
+  -- Настройки алгоритма сжатия.
+  hbox <- hBoxNew False 0;  pack hbox
+  ; vbox1 <- vBoxNew False 0
+  ;   method <- radioFrame "0107 Compression level" levels
+  ;     boxPackStart vbox1 (widget method)  PackNatural 0
+  ;   xMethod <- checkBox "0113 Fast, low-memory decompression"
+  ;     boxPackStart vbox1 (widget xMethod) PackNatural 0
+  ;   autodetect <- checkBox "0176 Filetype auto-detection"
+  ;     boxPackStart vbox1 (widget autodetect) PackNatural 1
+  ;   boxPackStart hbox vbox1 PackNatural 5
+  ; methodText <- labelNew Nothing
+  ;   boxPackStart hbox methodText PackGrow 0
+
+  -- Настройки размера солид-блока
+  vbox1 <- vBoxNew False 0;  let pack1 x = boxPackStart vbox1 x PackNatural 1
+  ; (hbox, solidBytesOn, solidBytes) <- fmCheckedEntryWithHistory fm' "bytes" "0138 Bytes, no more than:";  pack1 hbox
+  ; (hbox, solidFilesOn, solidFiles) <- fmCheckedEntryWithHistory fm' "files" "0139 Files, no more than:";  pack1 hbox
+  ; solidByExtension                 <- checkBox                              "0140 Split by extension" ;  pack1 (widget solidByExtension)
+  solidBlocksFrame <- frameNew;  pack solidBlocksFrame;  s <- i18n"0177 Limit solid blocks"
+  set solidBlocksFrame [containerChild := vbox1, frameLabel := s, containerBorderWidth := 5]
+
+  -- Инициализация полей
+  let m=4; x=False
+  method  =: (6-m) .$ clipTo 0 5
+  xMethod =: x
+  autodetect =: True
+
+  -- Опубликовать описание первоначально выбранного метода сжатия и обновлять его при изменениях настроек
+  let parsePhysMem = parseMemWithPercents (toInteger getPhysicalMemory `roundTo` (4*mb))
+  let getSimpleMethod = do
+        m <- val method
+        x <- val xMethod
+        return$ show(if m==0 then 9 else 6-m)++(x.$bool "" "x")
+  let describeMethod = do
+        m <- val method
+        x <- val xMethod
+        methodName <- getSimpleMethod
+        let compressor = methodName.$ decode_method []
+                                   .$ limitCompressionMem   (parsePhysMem "75%")
+                                   .$ limitDecompressionMem (1*gb)
+            cmem = compressor.$ compressorGetShrinkedCompressionMem
+            dmem = compressor.$ compressorGetShrinkedDecompressionMem
+        let level  =         "      ccm      uharc     7-zip        rar        ace      zip"
+            cspeed = x.$bool "    3mb/s      3mb/s     4mb/s     10mb/s     20mb/s   50mb/s" --m9,m5..m1
+                             "  2.5mb/s    2.5mb/s     4mb/s      8mb/s     15mb/s   50mb/s" --m9x,m5x..m1x
+            dspeed = x.$bool " 4-40mb/s   4-40mb/s  4-40mb/s     25mb/s     40mb/s  100mb/s" --m9,m5..m1
+                             "   40mb/s     40mb/s    40mb/s     40mb/s     60mb/s  100mb/s" --m9x,m5x..m1x
+        labelSetMarkup methodText . deleteIf (=='_') . unlines =<< mapM i18fmt
+            [ ["0114 Compression level: %1",               bold((words level!!m).$replace '_' ' ')]
+            , ["0115 Compression speed: %1, memory: %2",   bold(words cspeed!!m), bold(showMem cmem)]
+            , ["0116 Decompression speed: %1, memory: %2", bold(words dspeed!!m), bold(showMem dmem)]
+            , [""]
+            , ["0390 All speeds were measured on 3GHz Core2Duo"]]
+        w1 <- i18n (levels!!m)
+        w2 <- i18n "0226 (fast, low-memory decompression)"
+        autodetect'   <- val autodetect
+        solidBytesOn' <- val solidBytesOn
+        solidBytes'   <- val solidBytes
+        solidFilesOn' <- val solidFilesOn
+        solidFiles'   <- val solidFiles
+        solidByExtension' <- val solidByExtension
+        let s = (solidBytesOn'     &&&  solidBytes')++
+                (solidFilesOn'     &&& (solidFiles'++"f"))++
+                (solidByExtension' &&&  "e")
+        cmethod =: w1++(x&&&" "++w2)++": "++"-m"++(methodName.$changeTo [("9","x")])++(not autodetect' &&& " -ma-")++(s &&& " -s"++s)
+  --
+  describeMethod
+  describeMethod .$ setOnUpdate xMethod
+  describeMethod .$ setOnUpdate method
+  describeMethod .$ setOnUpdate autodetect
+  describeMethod .$ setOnUpdate solidBytesOn
+  describeMethod .$ setOnUpdate solidBytes
+  describeMethod .$ setOnUpdate solidFilesOn
+  describeMethod .$ setOnUpdate solidFiles
+  describeMethod .$ setOnUpdate solidByExtension
+
+  -- Сохранение истории строковых полей и обработка нажатия на Save
+  let saveHistories = do
+        whenM (val solidBytesOn) $ do saveHistory solidBytes
+        whenM (val solidFilesOn) $ do saveHistory solidFiles
+  save `onClick` do saveHistories; saveHistory cmethod
+
+  -- Возвратим метод назначения реакции на изменение настройки сжатия и процедуру, выполняемую при нажатии на OK
+  return (\act -> setOnUpdate cmethod (val cmethod >>= act), saveHistories)
+
+{-
+    let simpleMethod = initSetting "simpleMethod" `defaultVal` "4"
+        m =  case (take 1 simpleMethod) of [d] | isDigit d -> digitToInt d
+                                           _               -> 4
+        x =  drop 1 simpleMethod == "x"
+
+      ; solidBytes'        <- val solidBytes;  solidBytes' !~ "*b"   &&&   solidBytes =: solidBytes'++"b"
+      simpleMethod' <- getSimpleMethod
+-}
+
+-- |Compression level names
+levels = [ "0108 Maximum",
+           "0109 High",
+           "0110 Normal",
+           "0111 Fast",
+           "0112 Very fast",
+           "0127 HDD-speed"]
+
+
+----------------------------------------------------------------------------------------------------
+---- Закладка шифрования -------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+encryptionPage fm' dialog okButton vbox = do
+  let pack x = boxPackStart vbox x PackNatural 1
+  (hbox, pwds)  <-  pwdBox 2;  pack hbox   -- Создаёт таблицу с полями для ввода двух паролей
+
+  -- Фрейм шифрования.
+  vbox1 <- vBoxNew False 0
+  frame <- frameNew;  s <- i18n"0119 Encryption"
+  set frame [containerChild := vbox1, frameLabel := s, containerBorderWidth := 5]
+  let pack1 x = boxPackStart vbox1 x PackNatural 1
+  boxPackStart vbox frame        PackNatural 10
+
+  -- Алгоритм шифрования.
+  (hbox, method) <- fmLabeledEntryWithHistory fm' "encryption" "0179 Encryption profile:";  pack1 hbox
+  ; save <- button "0180 Save";  boxPackStart hbox (widget save) PackNatural 0
+
+  -- Настройки шифрования.
+  encryptHeaders <- checkBox "0120 Encrypt archive directory";  pack1 (widget encryptHeaders)
+  usePwd <- checkBox "0181 Use password";  pack1 (widget usePwd)
+  (hbox, keyfileOn, keyfile) <- fmFileBox fm' dialog
+                                          "akeyfile" FileChooserActionOpen
+                                (checkBox "0123 Keyfile:")
+                                          "0124 Select keyfile"
+                                          []
+                                          (const$ return True)
+                                          (fmCanonicalizeDiskPath fm')
+  ; createKeyfile <- button "0125 Create"
+  ; boxPackStart hbox (widget createKeyfile) PackNatural 0;  pack1 hbox
+  (hbox, encAlg) <- fmLabeledEntryWithHistory fm' "encryptor" "0121 Encryption algorithm:";  pack1 hbox
+
+  -- Настройки расшифровки
+  (decryption, decryptionOnOK) <- decryptionBox fm' dialog
+  ; boxPackStart vbox decryption        PackNatural 10
+
+  -- Разрешаем нажать OK только если оба введённых пароля одинаковы
+  let [pwd1,pwd2] = pwds
+  for pwds $ flip afterKeyRelease $ \e -> do
+    [pwd1', pwd2'] <- mapM val pwds
+    okButton `widgetSetSensitivity` (pwd1'==pwd2')
+    return False
+
+  -- Создать новый файл-ключ, записав криптографически случайные данные в указанный пользователем файл
+  createKeyfile `onClick` do
+    title <- i18n "0126 Create new keyfile"
+    bracketCtrlBreak "createKeyfile" (fileChooserDialogNew (Just title) (Just$ castToWindow dialog) FileChooserActionSave [("OK",ResponseOk), ("Cancel",ResponseCancel)]) widgetDestroy $ \chooserDialog -> do
+      fileChooserSetFilename    chooserDialog =<< (fmCanonicalizeDiskPath fm' "new.key" >>== unicode2utf8)
+      fileChooserSetCurrentName chooserDialog "new.key"
+      fileChooserSetFilename    chooserDialog =<< (fmCanonicalizeDiskPath fm' "new.key" >>== unicode2utf8)
+      fileChooserSetDoOverwriteConfirmation chooserDialog True
+      choice <- dialogRun chooserDialog
+      windowPresent dialog
+      when (choice==ResponseOk) $ do
+        whenJustM_ (fileChooserGetFilename chooserDialog) $ \fn8 -> do
+          let filename = utf8_to_unicode fn8
+          filePutBinary filename =<< generateRandomBytes 1024
+          keyfile   =: filename
+          keyfileOn =: True
+
+  -- Инициализация: прочитаем пароли из глобальных переменных
+  pwd1 =:: val encryptionPassword
+  pwd2 =:: val encryptionPassword
+
+  -- Сохранение истории строковых полей и обработка нажатия на Save
+  let saveHistories = do
+        whenM (val keyfileOn) $ do saveHistory keyfile
+        saveHistory encAlg
+  save `onClick` do saveHistories; saveHistory method
+
+  -- Действия, выполняемые при нажатии на OK. Возвращает опции, которые нужно добавить в командную строку
+  let onOK encryption = do
+        saveHistories
+        pwd' <- val pwd1;  encryptionPassword =: pwd'
+        decryptionOptions <- decryptionOnOK
+        return$ decryptionOptions ++ ((words encryption `contains` "-p?") &&& pwd' &&& ["-p"++pwd'])
+
+  -- Формирует профиль шифрования и вызывается при изменении любых опций в этом фрейме
+  let makeProfile = do
+        usePwd'         <- val usePwd
+        keyfileOn'      <- val keyfileOn
+        keyfile'        <- val keyfile
+        encAlg'         <- val encAlg
+        encryptHeaders' <- val encryptHeaders
+        method =: unwords( (encryptHeaders' &&& ["-hp"])++
+                           (usePwd'         &&& ["-p?"])++
+                                                ["--encryption="++clear encAlg']++
+                           (keyfileOn'      &&& ["--keyfile="   ++clear keyfile']))
+  --
+  makeProfile
+  makeProfile .$ setOnUpdate usePwd
+  makeProfile .$ setOnUpdate keyfileOn
+  makeProfile .$ setOnUpdate keyfile
+  makeProfile .$ setOnUpdate encAlg
+  makeProfile .$ setOnUpdate encryptHeaders
+
+  -- Возвратим метод назначения реакции на изменение настроек шифрования и процедуру, выполняемую при нажатии на OK
+  return (\act -> setOnUpdate method (val method >>= act), onOK)
+
+
+----------------------------------------------------------------------------------------------------
+---- Фрейм расшифровки -----------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+decryptionBox fm' dialog = do
+  vbox <- vBoxNew False 0
+  decryptionFrame <- frameNew;  s <- i18n"0144 Decryption"
+  set decryptionFrame [containerChild := vbox, frameLabel := s, containerBorderWidth := 5]
+
+  lbl <- label "0074 Enter password:"
+  pwd <- entryNew   --newTextViewWithText
+  ; set pwd [entryVisibility := False, entryActivatesDefault := True]
+  (keyfileBox, _, keyfile) <- fmFileBox fm' dialog
+                                        "keyfile" FileChooserActionOpen
+                                 (label "0123 Keyfile:")
+                                        "0124 Select keyfile"
+                                        []
+                                        (const$ return True)
+                                        (fmCanonicalizeDiskPath fm')
+  hbox <- hBoxNew False 0
+  ; boxPackStart hbox (widget lbl) PackNatural 0
+  ; boxPackStart hbox pwd          PackGrow    5
+  boxPackStart vbox hbox       PackNatural 0
+  boxPackStart vbox keyfileBox PackNatural 5
+  -- Прочитаем пароли из глобальных переменных
+  pwd =:: val decryptionPassword
+  -- Действие, выполняемое при нажатии на OK. Возвращает опции, которые нужно добавить к командной строке
+  let onOK = do
+        pwd'     <- val pwd;      decryptionPassword =: pwd'
+        keyfile' <- val keyfile;  saveHistory keyfile
+        return$ (pwd'      &&&  ["-op"++pwd'])++
+                (keyfile'  &&&  ["--OldKeyfile="++clear keyfile'])
+
+  return (decryptionFrame, onOK)
+
+
+----------------------------------------------------------------------------------------------------
+---- Вспомогательные определения -------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Выполнить операцию над выбранными файлами в архиве/всеми файлами в выбранных архивах
+archiveOperation fm' action = do
+  fm <- val fm'
+  files <- getSelection fm' (if isFM_Archive fm  then xCmdFiles  else const [])
+  if isFM_Archive fm
+    then action [fm_arcname fm] (fm_arcdir fm) files
+    else do fullnames <- mapM (fmCanonicalizePath fm') files
+            action fullnames "" []
+
+-- |Выполняет операцию, которой нужно передать только имена архивов
+multiArchiveOperation fm' action = do
+  fm <- val fm'
+  if isFM_Archive fm
+    then action [fm_arcname fm]
+    else do files <- getSelection fm' (const [])
+            fullnames <- mapM (fmCanonicalizePath fm') files
+            action fullnames
+
+-- |Обновить содержимое панели файл-менеджера актуальными данными
+refreshCommand fm' = do
+  fm <- val fm'
+  curfile <- fmGetCursor fm'
+  selected <- getSelection fm' (:[])
+  -- Обновим содержимое каталога/архива и восстановим текущий файл и список отмеченных
+  chdir fm' (fm_current fm)
+  when (selected>[]) $ do
+    fmSetCursor fm' curfile
+  fmUnselectFilenames fm' (const True)
+  fmSelectFilenames   fm' ((`elem` selected) . fmname)
+
+-- |Просмотреть файл
+runViewCommand           = runEditCommand
+
+-- |Редактировать файл
+runEditCommand filename  = run (iif isWindows "notepad" "gedit") [filename]
+  where run cmd params = forkIO (rawSystem cmd params >> return ()) >> return ()
+  -- edit filename | isWindows && takeExtension filename == "txt"  =  todo: direct shell open command
+
+-- |Определяет то, как имена каталогов подставляются в команды
+addCmdFiles dirname =  [dirname++"/"]
+xCmdFiles   dirname =  [dirname++"/*"]
+
+-- Поместим все контролы в симпатичный notebook и получим процедуру создания новых страниц в нём
+startNotebook dialog = do
+  upbox <- dialogGetUpper dialog
+  nb <- notebookNew;  boxPackStart upbox nb PackGrow 0
+  let newPage name = do hbox <- hBoxNew False 0; notebookAppendPage nb hbox =<< i18n name
+                        vbox <- vBoxNew False 0; boxPackStart hbox vbox PackGrow 5
+                        return vbox
+  return (nb,newPage)
+
+-- |Режимы диалогов
+data DialogMode = EncryptionMode | ProtectionMode | RecompressMode | CommentMode | MakeSFXMode | NoMode  deriving Eq
+

--- a/FileManPanel.hs
+++ b/FileManPanel.hs
@@ -1,3 +1,618 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6d750f094fdfff429c0f22910983469b903b66519a06824803cc4e83d22f80c8
-size 29910
+----------------------------------------------------------------------------------------------------
+---- FreeArc archive manager: file manager panel                                              ------
+----------------------------------------------------------------------------------------------------
+module FileManPanel where
+
+import Prelude hiding (catch)
+import Control.Concurrent
+import Control.Exception
+import Control.Monad
+import Data.Char
+import Data.IORef
+import Data.List
+import Data.Maybe
+import System.IO.Unsafe
+
+import Graphics.UI.Gtk
+import Graphics.UI.Gtk.ModelView as New
+
+import Utils
+import Errors
+import Files
+import FileInfo
+import Charsets
+import Options
+import Cmdline
+import UIBase
+import UI
+import ArhiveDirectory
+import ArcExtract
+import FileManUtils
+
+
+-- |Пароли шифрования и расшифровки
+encryptionPassword  =  unsafePerformIO$ newIORef$ ""
+decryptionPassword  =  unsafePerformIO$ newIORef$ ""
+
+----------------------------------------------------------------------------------------------------
+---- Операции файл-менеджера -----------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Создать переменную для хранения состояния файл-менеджера
+newFM window view model selection statusLabel messageCombo = do
+  historyFile <- findOrCreateFile configFilePlaces aHISTORY_FILE >>= mvar
+  curdir <- io$ getCurrentDirectory
+  counterCombo <- ref 0  -- number of last message + 1 in combobox
+  fm' <- mvar FM_State { fm_window       = window
+                       , fm_view         = view
+                       , fm_model        = model
+                       , fm_selection    = selection
+                       , fm_statusLabel  = statusLabel
+                       , fm_messageCombo = (messageCombo, counterCombo)
+                       , fm_filelist     = error "undefined FM_State::fm_filelist"
+                       , fm_history_file = historyFile
+                       , fm_history      = Nothing
+                       , fm_onChdir      = []
+                       , fm_sort_order   = ""
+                       , subfm           = FM_Directory {subfm_dir=curdir}}
+  selection `New.onSelectionChanged` fmStatusBarTotals fm'
+  return fm'
+
+-- |Открыть архив и возвратить его как объект состояния файл-менеджера
+newFMArc fm' arcname arcdir = do
+  xpwd'     <- val decryptionPassword
+  xkeyfile' <- fmGetHistory1 fm' "keyfile" ""
+  [command] <- io$ parseCmdline$ ["l", arcname]++(xpwd' &&& ["-op"++xpwd'])
+                                               ++(xkeyfile' &&& ["--OldKeyfile="++xkeyfile'])
+  command <- (command.$ opt_cook_passwords) command ask_passwords  -- подготовить пароли в команде к использованию
+  archive <- io$ archiveReadInfo command "" "" (const True) doNothing2 arcname
+  let filetree = buildTree$ map (fiToFileData.cfFileInfo)$ arcDirectory archive
+  io$ arcClose archive
+  return$ FM_Archive archive arcname arcdir filetree
+
+-- |Закрыть файл архива чтобы другие операции смогли модифицировать его
+closeFMArc fm' = do
+  return ()
+  --fm <- val fm'
+  --io$ arcClose (fm_archive fm)
+  --fm' .= \fm -> fm {subfm = (subfm fm) {subfm_archive = phantomArc}}
+
+-- Перейти в архив/каталог filename
+chdir fm' filename' = do
+  fm <- val fm'
+  filename <- fmCanonicalizePath fm' filename'
+  res <- splitArcPath fm' filename
+  msg <- i18n"0071 %1: no such file or directory!"
+  if res==Not_Exists  then fmErrorMsg fm' (format msg filename)  else do
+  (files, sub) <- case res of
+    -- Список файлов в каталоге на диске
+    DiskPath dir -> do filelist <- io$ dir_list dir
+                       return (map fiToFileData filelist, FM_Directory dir)
+    -- Список файлов в архиве
+    ArcPath arcname arcdir -> do
+                       arc <- if isFM_Archive fm && arcname==fm_arcname fm
+                                then return ((fm.$subfm) {subfm_arcdir=arcdir})
+                                else newFMArc fm' arcname arcdir
+                       return (arc.$subfm_filetree.$ftFilesIn arcdir fdArtificialDir, arc)
+  -- Запишем текущий каталог/архив в fm и выведем на экран новый список файлов
+  fm' =: fm {subfm = sub}
+  fmSetFilelist fm' (files.$ sortOnColumn (fm_sort_order fm))
+  -- Обновим статусбар и выполним все остальные запрограммированные действия.
+  sequence_ (fm_onChdir fm)
+  widgetGrabFocus (fm_view fm)
+
+-- Отобразить изменение имени архива
+fmChangeArcname fm' newname = do
+  fm' .= fm_changeArcname newname
+  fm <- val fm'
+  sequence_ (fm_onChdir fm)
+
+-- |Добавить action в список операций, выполняемых при переходе в другой каталог/архив
+fmOnChdir fm' action = do
+  fm' .= \fm -> fm {fm_onChdir = action : fm_onChdir fm}
+
+-- |Вывести в строку сообщений информацию об общем объёме файлов и сколько из них выбрано
+fmStatusBarTotals fm' = do
+  fm <- val fm'
+  selected <- getSelectionFileInfo fm'
+  [sel,total] <- i18ns ["0022 Selected %1 bytes in %2 file(s)", "0023 Total %1 bytes in %2 file(s)"]
+  let format msg files  =  formatn msg [show3$ sum$ map fdSize files,  show3$ length files]
+  fmStatusBarMsg fm' $ (selected &&& (format sel   selected++"     "))
+                                 ++   format total (fm_filelist fm)
+
+-- |Вывести сообщение в строку сообщений
+fmStatusBarMsg fm' msg = do
+  fm <- val fm'
+  labelSetText (fm_statusLabel fm) msg
+  return ()
+
+-- |Добавить сообщение в pop-up список сообщений
+fmStackMsg fm' msg = do
+  fm <- val fm'
+  let (box,n')  =  fm_messageCombo fm
+  n <- val n';  n' += 1
+  New.comboBoxAppendText box =<< i18n msg
+  New.comboBoxSetActive  box n
+  return ()
+
+-- |Имя файла, находящегося по заданному пути
+fmFilenameAt fm' path  =  fmname `fmap` fmFileAt fm' path
+
+-- |Файл, находящийся по заданному пути
+fmFileAt fm' path = do
+  fm <- val fm'
+  let fullList = fm_filelist fm
+  return$ fullList!!head path
+
+-- |Возвратить файл под курсором
+fmGetCursor fm' = do
+  fm <- val fm'
+  let fullList  = fm_filelist  fm
+  (cursor,_) <- New.treeViewGetCursor (fm_view fm)
+  case cursor of
+    [i] -> return (fdBasename$ fullList!!i)
+    _   -> return ""
+
+-- |Установить курсор на заданный файл
+fmSetCursor fm' filename = do
+  fm <- val fm'
+  whenJustM_ (fmFindCursor fm' filename)
+             (\cursor -> New.treeViewSetCursor (fm_view fm) cursor Nothing)
+
+-- |Возвратить курсор для файла с заданным именем
+fmFindCursor fm' filename = do
+  fm <- val fm'
+  let fullList  =  fm_filelist  fm
+  return (fmap (:[])$  findIndex ((filename==) . fmname) fullList)
+
+-- |Вывести на экран новый список файлов
+fmSetFilelist fm' files = do
+  fm <- val fm'
+  fm' =: fm {fm_filelist = files}
+  changeList (fm_model fm) (fm_selection fm) files
+
+-- |Вывести сообщение об ошибке
+fmErrorMsg fm' msg = do
+  fm <- val fm'
+  msgBox (fm_window fm) MessageError msg
+
+-- |Вывести информационное сообщение
+fmInfoMsg fm' msg = do
+  fm <- val fm'
+  msgBox (fm_window fm) MessageInfo msg
+
+
+----------------------------------------------------------------------------------------------------
+---- Выделение файлов ------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Отметить/разотметить файлы, удовлетворяющие заданному предикату
+fmSelectFilenames   = fmSelUnselFilenames New.treeSelectionSelectPath
+fmUnselectFilenames = fmSelUnselFilenames New.treeSelectionUnselectPath
+fmSelUnselFilenames selectOrUnselect fm' filter_p = do
+  fm <- val fm'
+  let fullList  = fm_filelist  fm
+  let selection = fm_selection fm
+  for (findIndices filter_p fullList)
+      (selectOrUnselect selection.(:[]))
+
+-- |Отметить/разотметить все файлы
+fmSelectAll   fm' = New.treeSelectionSelectAll   . fm_selection =<< val fm'
+fmUnselectAll fm' = New.treeSelectionUnselectAll . fm_selection =<< val fm'
+
+-- |Инвертировать выделение
+fmInvertSelection fm' = do
+  fm <- val fm'
+  let files     = length$ fm_filelist fm
+  let selection = fm_selection fm
+  for [0..files-1] $ \i -> do
+    selected <- New.treeSelectionPathIsSelected selection [i]
+    (if selected  then New.treeSelectionUnselectPath  else New.treeSelectionSelectPath) selection [i]
+
+-- |Список имён избранных файлов + имён каталогов в отображении mapDirName
+getSelection fm' mapDirName = do
+  let mapFilenames fd | fdIsDir fd = mapDirName$ fmname fd
+                      | otherwise  = [fmname fd]
+  getSelectionFileInfo fm' >>== concatMap mapFilenames
+
+-- |Список FileInfo избранных файлов
+getSelectionFileInfo fm' = do
+  fm <- val fm'
+  let fullList = fm_filelist fm
+  getSelectionRows fm' >>== map (fullList!!)
+
+-- |Список номеров избранных файлов
+getSelectionRows fm' = do
+  fm <- val fm'
+  let selection = fm_selection fm
+  New.treeSelectionGetSelectedRows selection >>== map head
+
+-- |Удалить из модели выбранные файлы
+fmDeleteSelected fm' = do
+  rows <- getSelectionRows fm'
+  fm <- val fm'
+  fmSetFilelist fm' (fm_filelist fm `deleteElems` rows)     -- O(n^2)!
+
+
+----------------------------------------------------------------------------------------------------
+---- Сортировка списка файлов ----------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Возвратить текущий порядок сортировки
+fmGetSortOrder fm'  =  fm_sort_order `fmap` val fm'
+-- |Установить порядок сортировки
+fmSetSortOrder fm' showSortOrder  =  fmModifySortOrder fm' showSortOrder . const
+-- |Модифицировать порядок сортировки в fm' и показать индикатор сортировки над соответствующим столбцом
+fmModifySortOrder fm' showSortOrder f_order = do
+  fm <- val fm'
+  let sort_order = f_order (fm_sort_order fm)
+  fm' =: fm {fm_sort_order = sort_order}
+  -- Модифицируем индикатор сортировки
+  let (column, order)  =  break1 isUpper sort_order
+  showSortOrder column (if order == "Asc"  then SortAscending  else SortDescending)
+
+-- |Сохранить порядок сортировки в историю
+fmSaveSortOrder    fm'  =  fmReplaceHistory fm' "SortOrder"
+-- |Восстановить порядок сортировки из истории
+fmRestoreSortOrder fm'  =  fmGetHistory1    fm' "SortOrder" "NameAsc"
+
+-- | (ClickedColumnName, OldSortOrder) -> NewSortOrder
+calcNewSortOrder "Name"     "NameAsc"      = "NameDesc"
+calcNewSortOrder "Name"     _              = "NameAsc"
+calcNewSortOrder "Size"     "SizeDesc"     = "SizeAsc"
+calcNewSortOrder "Size"     _              = "SizeDesc"
+calcNewSortOrder "Modified" "ModifiedDesc" = "ModifiedAsc"
+calcNewSortOrder "Modified" _              = "ModifiedDesc"
+
+-- |Выбор функции сортировки по имени колонки
+sortOnColumn "NameAsc"       =  sortOn (\fd -> (not$ fdIsDir fd, strLower$ fmname fd))
+sortOnColumn "NameDesc"      =  sortOn (\fd -> (     fdIsDir fd, strLower$ fmname fd))  >>> reverse
+--
+sortOnColumn "SizeAsc"       =  sortOn (\fd -> if fdIsDir fd  then -1             else  fdSize fd)
+sortOnColumn "SizeDesc"      =  sortOn (\fd -> if fdIsDir fd  then aFILESIZE_MIN  else -fdSize fd)
+--
+sortOnColumn "ModifiedAsc"   =  sortOn (\fd -> (not$ fdIsDir fd,  fdTime fd))
+sortOnColumn "ModifiedDesc"  =  sortOn (\fd -> (not$ fdIsDir fd, -fdTime fd))
+--
+sortOnColumn _               =  id
+
+
+----------------------------------------------------------------------------------------------------
+---- Операции с файлом истории ---------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Добавить значение в список истории (удалив предыдущие точно такие же строки)
+fmAddHistory fm' tags text     =   fmModifyHistory fm' tags text (\tag line -> (line==))
+-- |Заменить значение в списке истории (удалив предыдущие значения с этим тегом)
+fmReplaceHistory fm' tags text  =  fmModifyHistory fm' tags text (\tag line -> (tag==) . fst.split2 '=')
+-- |Добавить/Заменить значение в списке истории
+fmModifyHistory fm' tags text deleteCond = ignoreErrors $ do
+  fm <- val fm'
+  -- Занесём новый элемент в голову списка и избавимся от дублирующих значений
+  let newItem  =  join2 "=" (mainTag, text)
+      mainTag  =  head (split '/' tags)
+  withMVar (fm_history_file fm) $ \history_file -> do
+    modifyConfigFile history_file ((newItem:) . deleteIf (deleteCond mainTag newItem))
+
+-- |Удалить тег из списка истории
+fmDeleteTagFromHistory fm' tag = ignoreErrors $ do
+  fm <- val fm'
+  withMVar (fm_history_file fm) $ \history_file -> do
+    modifyConfigFile history_file (deleteIf ((tag==) . fst.split2 '='))
+
+-- |Извлечь список истории по заданному тэгу/тэгам
+fmGetHistory1 fm' tags deflt = do x <- fmGetHistory fm' tags; return (head (x++[deflt]))
+fmGetHistory  fm' tags       = handle (\_ -> return []) $ do
+  fm <- val fm'
+  hist <- fmGetConfigFile fm'
+  hist.$ map (split2 '=')                           -- разбить каждую строку на тэг+значение
+      .$ filter ((split '/' tags `contains`) . fst)   -- отобрать строки с тэгом из списка tags
+      .$ map snd                                    -- оставить только значения.
+      .$ map (splitCmt "")                          -- разбить каждое значение на описание+опции
+      .$ mapM (\x -> case x of                      -- локализовать описание и слить их обратно
+                       ("",b) -> return b
+                       (a ,b) -> do a <- i18n a; return$ join2 ": " (a,b))
+
+-- Чтение/запись в историю булевского значения
+fmGetHistoryBool     fm' tag deflt  =  fmGetHistory1 fm' tag (bool2str deflt)  >>==  (==bool2str True)
+fmReplaceHistoryBool fm' tag x      =  fmReplaceHistory fm' tag (bool2str x)
+bool2str True  = "1"
+bool2str False = "0"
+
+
+-- |Получить содержимое файла истории
+fmGetConfigFile fm' = do
+  fm <- val fm'
+  case fm_history fm of
+    Nothing      -> withMVar (fm_history_file fm) readConfigFile
+    Just history -> return history
+
+-- |На время выполнения этих скобок содержимое файла истории читается из поля fm_history
+fmCacheConfigFile fm' =
+  bracket_ (do history <- fmGetConfigFile fm'
+               fm' .= \fm -> fm {fm_history = Just history})
+           (do fm' .= \fm -> fm {fm_history = Nothing})
+
+-- |Сохранить размеры и положение окна в истории
+saveSizePos fm' window name = do
+    (x,y) <- windowGetPosition window
+    (w,h) <- widgetGetSize     window
+    fmReplaceHistory fm' (name++"Coord") (unwords$ map show [x,y,w,h])
+
+-- |Запомним, было ли окно максимизировано
+saveMaximized fm' name = fmReplaceHistoryBool fm' (name++"Maximized")
+
+-- |Восстановить размеры и положение окна из истории
+restoreSizePos fm' window name deflt = do
+    coord <- fmGetHistory1 fm' (name++"Coord") deflt
+    let a  = coord.$split ' '
+    when (length(a)==4  &&  all isSignedInt a) $ do  -- проверим что a состоит ровно из 4 чисел
+      let [x,y,w,h] = map readSignedInt a
+      windowMove   window x y  `on` x/= -10000
+      windowResize window w h  `on` w/= -10000
+    whenM (fmGetHistoryBool fm' (name++"Maximized") False) $ do
+      windowMaximize window
+
+
+----------------------------------------------------------------------------------------------------
+---- Вспомогательные определения -------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- Выбирает один из нескольких вариантов по индексу
+opt `select` variants  =  words (split ',' variants !! opt)
+-- Преобразует текст настройки в список опций, предварительно удаляя комментарий в её начале
+cvt1 opt  =  map (opt++) . (||| [""]) . words . clear
+-- То же самое, только имя опции добавляется только к словам, не начинающимся с "-"
+cvt  opt  =  map (\w -> (w!~"-?*" &&& opt)++w) . (||| [""]) . words . clear
+-- Удаляет комментарий вида "*: " в начале строки
+clear     =  trim . snd . splitCmt ""
+-- |Разбивает значение на описание+опции
+splitCmt xs ""           = ("", reverse xs)
+splitCmt xs ":"          = (reverse xs, "")
+splitCmt xs (':':' ':ws) = (reverse xs, ws)
+splitCmt xs (w:ws)       = splitCmt (w:xs) ws
+
+
+----------------------------------------------------------------------------------------------------
+---- GUI controls, взаимодействующие с FM ----------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Комбинированный виджет, представляющий строку ввода с сохраняемой историей
+data EntryWithHistory = EntryWithHistory
+  { ehGtkWidget   :: GtkWidget ComboBoxEntry String
+  , entry         :: Entry
+  }
+
+instance GtkWidgetClass EntryWithHistory ComboBoxEntry String where
+  widget        = widget        . ehGtkWidget
+  getTitle      = getTitle      . ehGtkWidget
+  setTitle      = setTitle      . ehGtkWidget
+  getValue      = getValue      . ehGtkWidget
+  setValue      = setValue      . ehGtkWidget
+  setOnUpdate   = setOnUpdate   . ehGtkWidget
+  onClick       = onClick       . ehGtkWidget
+  saveHistory   = saveHistory   . ehGtkWidget
+  rereadHistory = rereadHistory . ehGtkWidget
+
+
+{-# NOINLINE fmEntryWithHistory #-}
+-- |Создать комбо-бокс с историей под тегом tag;
+-- перед запоминанием в истории пропускать введённый текст через операцию process
+fmEntryWithHistory fm' tag filter_p process = do
+  -- Create GUI controls
+  comboBox <- New.comboBoxEntryNewText
+  Just entry <- binGetChild comboBox >>== fmap castToEntry
+  set entry [entryActivatesDefault := True]
+  -- Define callbacks
+  last <- fmGetHistory fm' (tag++"Last")
+  let fixedOrder  =  (last>[])   -- True - keep order of dropdown "menu" elements fixed
+  history' <- mvar []
+  let readHistory = do
+        history' .<- \oldHistory -> do
+          replicateM_ (1+length oldHistory) (New.comboBoxRemoveText comboBox 0)
+          history <- fmGetHistory fm' tag >>= Utils.filterM filter_p
+          for history (New.comboBoxAppendText comboBox)
+          return history
+  let getText = do
+        val entry >>= process
+  let setText text = do
+        entry =: text
+  let saveHistory = do
+        text <- getText
+        history <- val history'
+        when fixedOrder $ do
+          fmReplaceHistory fm' (tag++"Last") text
+        unless (fixedOrder && (text `elem` history)) $ do
+          New.comboBoxPrependText comboBox text
+          fmAddHistory fm' tag text
+  readHistory
+  -- Установить текст в поле ввода
+  case last of
+    last:_ -> entry =: last
+    []     -> do history <- val history'
+                 when (history > []) $ do
+                   New.comboBoxSetActive comboBox 0
+  --
+  return EntryWithHistory
+           {                           entry           = entry
+           , ehGtkWidget = gtkWidget { gwWidget        = comboBox
+                                     , gwGetValue      = getText
+                                     , gwSetValue      = setText
+                                     , gwSetOnUpdate   = \action -> New.onChanged comboBox action >> return ()
+                                     , gwSaveHistory   = saveHistory
+                                     , gwRereadHistory = readHistory
+                                     }
+           }
+
+
+{-# NOINLINE fmLabeledEntryWithHistory #-}
+-- |Ввод строки с историей под тэгом tag и меткой слева
+fmLabeledEntryWithHistory fm' tag title = do
+  hbox  <- hBoxNew False 0
+  title <- label title
+  inputStr <- fmEntryWithHistory fm' tag (const$ return True) (return)
+  boxPackStart  hbox  (widget title)     PackNatural 0
+  boxPackStart  hbox  (widget inputStr)  PackGrow    5
+  return (hbox, inputStr)
+
+
+{-# NOINLINE fmCheckedEntryWithHistory #-}
+-- |Ввод строки с историей под тэгом tag и чекбоксом слева
+fmCheckedEntryWithHistory fm' tag title = do
+  hbox  <- hBoxNew False 0
+  checkBox <- checkBox title
+  inputStr <- fmEntryWithHistory fm' tag (const$ return True) (return)
+  boxPackStart  hbox  (widget checkBox)  PackNatural 0
+  boxPackStart  hbox  (widget inputStr)  PackGrow    5
+  --checkBox `onToggled` do
+  --  on <- val checkBox
+  --  (if on then widgetShow else widgetHide) (widget inputStr)
+  return (hbox, checkBox, inputStr)
+
+
+{-# NOINLINE fmFileBox #-}
+-- |Ввод имени файла/каталога с историей под тэгом tag и поиском по диску через вызываемый диалог
+fmFileBox fm' dialog tag dialogType makeControl dialogTitle filters filter_p process = do
+  hbox     <- hBoxNew False 0
+  control  <- makeControl
+  filename <- fmEntryWithHistory fm' tag filter_p process
+  chooserButton <- button "9999 ..."
+  chooserButton `onClick` do
+    chooseFile dialog dialogType dialogTitle filters (val filename) (filename =:)
+  boxPackStart  hbox  (widget control)        PackNatural 0
+  boxPackStart  hbox  (widget filename)       PackGrow    5
+  boxPackStart  hbox  (widget chooserButton)  PackNatural 0
+  return (hbox, control, filename)
+
+{-# NOINLINE fmInputString #-}
+-- |Запросить у пользователя строку (с историей ввода)
+fmInputString fm' tag title filter_p process = do
+  fm <- val fm'
+  -- Создадим диалог со стандартными кнопками OK/Cancel
+  fmDialog fm' title $ \(dialog,okButton) -> do
+    x <- fmEntryWithHistory fm' tag filter_p process
+
+    upbox <- dialogGetUpper dialog
+    --boxPackStart  upbox label    PackGrow 0
+    boxPackStart  upbox (widget x) PackGrow 0
+    widgetShowAll upbox
+
+    choice <- dialogRun dialog
+    case choice of
+      ResponseOk -> do saveHistory x; val x >>== Just
+      _          -> return Nothing
+
+
+{-# NOINLINE fmCheckButtonWithHistory #-}
+-- |Создать чекбокс с историей под тегом tag
+fmCheckButtonWithHistory fm' tag deflt title = do
+  control <- checkBox title
+  let rereadHistory = do
+        control =:: fmGetHistoryBool fm' tag deflt
+  let saveHistory = do
+        fmReplaceHistoryBool fm' tag =<< val control
+  rereadHistory
+  return$ control
+           { gwSaveHistory   = saveHistory
+           , gwRereadHistory = rereadHistory
+           }
+
+{-# NOINLINE fmDialog #-}
+-- |Диалог со стандартными кнопками OK/Cancel
+fmDialog fm' title action = do
+  fm <- val fm'
+  title <- i18n title
+  bracketCtrlBreak "fmDialog" dialogNew widgetDestroy $ \dialog -> do
+    set dialog [windowTitle          := title,
+                windowTransientFor   := fm_window fm,
+                containerBorderWidth := 0]
+    addStdButton dialog ResponseOk      >>= \okButton -> do
+    addStdButton dialog ResponseCancel
+    dialogSetDefaultResponse dialog ResponseOk
+    tooltips =:: tooltipsNew
+    action (dialog,okButton)
+
+{-# NOINLINE fmDialogRun #-}
+-- |Отработать диалог с сохранением его положения и размера в истории
+fmDialogRun fm' dialog name = do
+    inside (restoreSizePos fm' dialog name "")
+           (saveSizePos    fm' dialog name)
+      (dialogRun dialog)
+
+
+----------------------------------------------------------------------------------------------------
+---- Список файлов в архиве ------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+createFilePanel = do
+  -- Scrolled window where this list will be put
+  scrwin <- scrolledWindowNew Nothing Nothing
+  scrolledWindowSetPolicy scrwin PolicyAutomatic PolicyAutomatic
+  -- Create a new ListView
+  view  <- New.treeViewNew
+  set view [ {-New.treeViewSearchColumn := 0, -} New.treeViewRulesHint := True]
+  New.treeViewSetHeadersVisible view True
+  -- Создаём и устанавливаем модель
+  model <- New.listStoreNew []
+  set view [New.treeViewModel := model]
+  -- Создаём колонки для её отображения.
+  let columnTitles = ["0015 Name", "0016 Size", "0017 Modified", "0018 DIRECTORY"]
+      n = map (drop 5) columnTitles
+  s <- i18ns columnTitles
+  onColumnTitleClicked <- ref doNothing
+  columns <- fmap (dropEnd 1) $ sequence [
+     addColumn view model onColumnTitleClicked (n!!0) (s!!0) fmname                                                       []
+    ,addColumn view model onColumnTitleClicked (n!!1) (s!!1) (\fd -> if (fdIsDir fd) then (s!!3) else (show3$ fdSize fd)) [cellXAlign := 1]
+    ,addColumn view model onColumnTitleClicked (n!!2) (s!!2) (guiFormatDateTime.fdTime)                                   []
+    ,addColumn view model onColumnTitleClicked ("")   ("")   (const "")                                                   [] ]
+  -- Включаем поиск по первой колонке
+  New.treeViewSetEnableSearch view True
+  New.treeViewSetSearchColumn view 0
+  New.treeViewSetSearchEqualFunc view $ \col str iter -> do
+    (i:_) <- New.treeModelGetPath model iter
+    row <- New.listStoreGetValue model i
+    return (strLower(fmname row) ~= strLower(str)++"*")
+  -- Enable multiple selection
+  selection <- New.treeViewGetSelection view
+  set selection [New.treeSelectionMode := SelectionMultiple]
+  -- Pack list into scrolled window and return window
+  containerAdd scrwin view
+  return (scrwin, view, model, selection, columns, onColumnTitleClicked)
+
+-- |Задать новый список отображаемых файлов
+changeList model selection filelist = do
+  New.treeSelectionUnselectAll selection
+  -- Удалить старые данные из модели и заполнить её новыми
+  New.listStoreClear model
+  for filelist (New.listStoreAppend model)
+
+-- |Добавить во view колонку, отображающую field, с заголовком title
+addColumn view model onColumnTitleClicked colname title field attrs = do
+  col1 <- New.treeViewColumnNew
+  New.treeViewColumnSetTitle col1 title
+  renderer1 <- New.cellRendererTextNew
+  New.cellLayoutPackStart col1 renderer1 False
+  -- Попытки сделать поле имени автоматически увеличивающимся при увеличении окна программы
+  -- (bool New.cellLayoutPackStart New.cellLayoutPackEnd expand) col1 renderer1 expand
+  -- set col1 [New.treeViewColumnSizing := TreeViewColumnAutosize] `on` expand
+  -- set col1 [New.treeViewColumnSizing := TreeViewColumnFixed] `on` not expand
+  -- cellLayoutSetAttributes  [New.cellEditable := True, New.cellEllipsize := EllipsizeEnd]
+  when (colname/="") $ do
+    set col1 [ New.treeViewColumnResizable   := True
+             , New.treeViewColumnSizing      := TreeViewColumnFixed
+             , New.treeViewColumnClickable   := True
+             , New.treeViewColumnReorderable := True ]
+  -- При нажатии на заголовок столбца вызвать колбэк
+  col1 `New.onColClicked` do
+    val onColumnTitleClicked >>= ($colname)
+  New.cellLayoutSetAttributes col1 renderer1 model $ \row -> [New.cellText := field row] ++ attrs
+  New.treeViewAppendColumn view col1
+  return (colname,col1)
+
+-- |Показать индикатор сортировки над столбцом colname в направлении order
+showSortOrder columns colname order = do
+  for (map snd columns) (`New.treeViewColumnSetSortIndicator` False)
+  let Just col1  =  colname `lookup` columns
+  New.treeViewColumnSetSortIndicator col1 True
+  New.treeViewColumnSetSortOrder     col1 order
+

--- a/FileManUtils.hs
+++ b/FileManUtils.hs
@@ -1,3 +1,211 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dd04ebe6cf54dfab4b45a9c46ac155b1a10a1afb0a6150675751e86e64e93ca8
-size 11929
+----------------------------------------------------------------------------------------------------
+---- FreeArc archive manager: utility functions                                               ------
+----------------------------------------------------------------------------------------------------
+module FileManUtils where
+
+import Prelude hiding (catch)
+import Control.Concurrent
+import Control.Exception
+import Control.Monad
+import Data.Char
+import Data.IORef
+import Data.List
+import Data.Maybe
+
+import Graphics.UI.Gtk
+import Graphics.UI.Gtk.ModelView as New
+
+import Utils
+import Errors
+import Files
+import FileInfo
+import Options
+import UIBase
+import UI
+import ArhiveDirectory
+import ArcExtract
+
+----------------------------------------------------------------------------------------------------
+---- Текущее состояние файл-менеджера --------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Текущее состояние файл-менеджера: список выбранных файлов, общий список файлов и прочая информация
+data FM_State = FM_State { fm_window       :: Window
+                         , fm_view         :: TreeView
+                         , fm_model        :: New.ListStore FileData
+                         , fm_selection    :: TreeSelection
+                         , fm_statusLabel  :: Label
+                         , fm_messageCombo :: (New.ComboBox, IORef Int)
+                         , fm_filelist     :: [FileData]
+                         , fm_history_file :: MVar FilePath
+                         , fm_history      :: Maybe [String]
+                         , fm_onChdir      :: [IO()]
+                         , fm_sort_order   :: String
+                         , subfm           :: SubFM_State
+                         }
+
+-- |Текущее состояние файл-менеджера: информация об отображаемом архиве или каталоге диска
+data SubFM_State = FM_Archive   { subfm_archive  :: ArchiveInfo
+                                , subfm_arcname  :: FilePath
+                                , subfm_arcdir   :: FilePath
+                                , subfm_filetree :: FileTree FileData
+                                }
+                 | FM_Directory { subfm_dir      :: FilePath
+                                }
+
+-- |True, если FM сейчас показывает архив
+isFM_Archive (FM_State {subfm=FM_Archive{}}) = True
+isFM_Archive _                               = False
+
+fm_archive = subfm_archive.subfm
+fm_arcname = subfm_arcname.subfm
+fm_arcdir  = subfm_arcdir .subfm
+fm_dir     = subfm_dir    .subfm
+
+-- |Текущий архив+каталог в нём или каталог на диске
+fm_current fm | isFM_Archive fm = fm_arcname fm </> fm_arcdir fm
+              | otherwise       = fm_dir     fm
+
+-- |Текущий каталог, показываемый в FM, или каталог, в котором находится текущий архив
+fm_curdir fm | isFM_Archive fm = fm_arcname fm .$takeDirectory
+             | otherwise       = fm_dir     fm
+
+-- |Изменить имя архива, открытого в FM
+fm_changeArcname arcname fm@(FM_State {subfm=subfm@FM_Archive{}}) =
+                         fm {subfm = subfm {subfm_arcname=arcname}}
+
+
+----------------------------------------------------------------------------------------------------
+---- Операции над именами каталогов/файлов ---------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Текущее местопребывание в файл-менеджере: каталог внутри архива или на диске
+data PathInfo path  =  ArcPath path path | DiskPath path | Not_Exists  deriving (Eq,Show)
+
+isArcPath ArcPath{} = True
+isArcPath _         = False
+
+-- |Парсит текущее местопребывание в FM в структуру PathInfo
+splitArcPath fm' fullname = do
+  fm <- val fm'
+  -- Сравним fullname с именем открытого в fm архива (arcname)
+  -- Если arcname - префикс fullname, то разобьём fullname на имя архива arcname и каталог внутри него
+  let arcname = isFM_Archive fm.$bool "!^%^@!%" (fm_arcname fm)
+  if arcname `isParentDirOf` fullname
+    then return$ ArcPath arcname (fullname `dropParentDir` arcname)
+    else do
+  -- Проверим существование каталога с таким именем (или "", чтобы избежать зацикливания)
+  d <- not(isURL fullname) &&& io(dirExist fullname)
+  if d || fullname=="" then return$ DiskPath fullname
+    else do
+  -- Проверим существование файла с таким именем
+  f <- io(fileExist fullname)
+  if f then return$ ArcPath fullname ""
+    else do
+  -- Повторим все проверки, отрезав от fullname последнюю компоненту имени
+  res <- splitArcPath fm' (takeDirectory fullname)
+  -- Если результат - каталог внутри архива, то добавим отрезанную компоненту к имени каталога
+  -- Иначе же оригинальный fullname ссылался на несуществующий в природе файл
+  case res of
+    ArcPath  dir name | isURL(takeDirectory fullname) == isURL fullname  -- Проверяем что мы не обрезали URL по самые гланды :D
+                      -> return$ ArcPath dir (name </> takeFileName fullname)
+    _                 -> return$ Not_Exists
+
+
+-- |Перевести путь, записанный относительно текущего дискового каталога в FM, в абсолютный
+fmCanonicalizeDiskPath fm' relname = do
+  let name  =  unquote (trimRight relname)
+  if (name=="")  then return ""  else do
+  fm <- val fm'
+  io$ myCanonicalizePath$ fm_curdir fm </> name
+
+-- |Перевести путь, записанный относительно текущего положения в FM, в абсолютный
+fmCanonicalizePath fm' relname = do
+  fm <- val fm'
+  case () of
+   _ | isURL relname                              ->  return relname
+     | isAbsolute relname                         ->  myCanonicalizePath relname
+     | isURL (fm_current fm) || isFM_Archive fm   ->  return$ urlNormalize (fm_current fm) relname    -- Использовать свой Normalize для навигацуи внутри архивов и по URL
+     | otherwise                                  ->  myCanonicalizePath (fm_current fm </> relname)
+
+-- |Нормализовать путь, записанный относительно некоего URL
+urlNormalize url relname =  dropTrailingPathSeparator$ concat$ reverse$ remove$ reverse$ splitPath (url++[pathSeparator]) ++ splitPath relname
+  where remove (".":xs)    = remove xs
+        remove ("./":xs)    = remove xs
+        remove (".\\":xs)    = remove xs
+        remove ("..":x:xs) = remove xs
+        remove ("../":x:xs) = remove xs
+        remove ("..\\":x:xs) = remove xs
+        remove (x:xs)      = x : remove xs
+        remove []          = []
+
+
+----------------------------------------------------------------------------------------------------
+---- FileData и FileTree ---------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Структура, хранящая всю необходимую нам информацию о файле
+data FileData = FileData
+  { fdPackedDirectory       :: !MyPackedString   -- Имя каталога
+  , fdPackedBasename        :: !MyPackedString   -- Имя файла без каталога, но с расширением
+  , fdSize  :: {-# UNPACK #-}  !FileSize         -- Размер файла (0 для каталогов)
+  , fdTime  :: {-# UNPACK #-}  !FileTime         -- Дата/время создания файла
+  , fdIsDir :: {-# UNPACK #-}  !Bool             -- Это каталог?
+  }
+
+fiToFileData fi = FileData { fdPackedDirectory = fpPackedDirectory (fiStoredName fi)
+                           , fdPackedBasename  = fpPackedBasename  (fiStoredName fi)
+                           , fdSize            = fiSize  fi
+                           , fdTime            = fiTime  fi
+                           , fdIsDir           = fiIsDir fi }
+
+fdDirectory  =  myUnpackStr.fdPackedDirectory
+fdBasename   =  myUnpackStr.fdPackedBasename
+
+-- |Виртуальное поле: полное имя файла, включая каталог и расширение
+fdFullname fd  =  fdDirectory fd </> fdBasename fd
+
+-- |Имя файла. Должно быть fdFullname для поддержки режима "плоского вывода" архивов/деревьев файлов
+fmname = fdBasename
+
+-- |Возвращает искусственный каталог с базовым именем name
+fdArtificialDir name = FileData { fdPackedDirectory = myPackStr ""
+                                , fdPackedBasename  = myPackStr name
+                                , fdSize            = 0
+                                , fdTime            = aMINIMAL_POSSIBLE_DATETIME
+                                , fdIsDir           = True }
+
+
+
+-- |Дерево файлов. Включает список файлов на этом уровне плюс поименованные поддеревья
+--                        files   dirname subtree
+data FileTree a = FileTree [a]  [(String, FileTree a)]
+
+-- |Возвращает количество каталогов в дереве
+ftDirs  (FileTree files subdirs) = length (removeDups (subdirs.$map fst  ++  files.$filter fdIsDir .$map fdBasename))
+                                 + sum (map (ftDirs.snd) subdirs)
+
+-- |Возвращает количество файлов в дереве
+ftFiles (FileTree files subdirs) = length (filter (not.fdIsDir) files)  +  sum (map (ftFiles.snd) subdirs)
+
+-- |Возврашает список файлов в заданном каталоге,
+-- используя отображение artificial для генерации псевдо-файлов из имён вложенных каталогов
+ftFilesIn dir artificial = f (splitDirectories dir)
+ where
+  f (path0:path_rest) (FileTree _     subdirs) = lookup path0 subdirs.$ maybe [] (f path_rest)
+  f []                (FileTree files subdirs) = (files++map (artificial.fst) subdirs)
+                                                  .$ keepOnlyFirstOn (filenameLower.fmname)
+
+-- |Превращает список файлов в дерево
+buildTree x = x
+  .$splitt 0                                  -- Разбиваем на группы по каталогам, начиная с 0-го уровня
+splitt n x = x
+  .$sort_and_groupOn (dirPart n)              -- Сортируем/группируем по имени каталога очередного уровня
+  .$partition ((=="") . dirPart n.head)         -- Отделяем группу с файлами, находящимися непосредственно в этом каталоге
+  .$(\(root,other) -> FileTree (concat root)  -- Остальные группы обрабатываем рекурсивно на (n+1)-м уровне
+                               (map2s (dirPart n.head, splitt (n+1)) other))
+
+-- Имя n-й части каталога
+dirPart n = (!!n).(++[""]) . splitDirectories.fdDirectory
+
+io=id

--- a/FileManager.hs
+++ b/FileManager.hs
@@ -1,3 +1,832 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6b9222136d8214734f2ec8ce4bfe6e9735b0d8ae7bad4c58b20baaac196026e5
-size 42128
+{-# OPTIONS_GHC -cpp #-}
+----------------------------------------------------------------------------------------------------
+---- FreeArc archive manager                                                                  ------
+----------------------------------------------------------------------------------------------------
+module FileManager where
+
+import Prelude hiding (catch)
+import Control.Concurrent
+import Control.Exception
+import Control.Monad
+import Data.Char
+import Data.IORef
+import Data.List
+import Data.Maybe
+import Numeric hiding (readInt)
+import System.IO.Unsafe
+import System.Cmd
+import System.Process
+#if defined(FREEARC_WIN)
+import System.Win32
+import Foreign.Ptr
+#endif
+
+import Graphics.UI.Gtk
+import Graphics.UI.Gtk.ModelView as New
+
+import Utils
+import Errors
+import Files
+import FileInfo
+import Charsets            (i18n, i18ns)
+import Compression
+import Encryption
+import Options
+import Cmdline
+import UI
+import ArhiveStructure
+import ArhiveDirectory
+import ArcExtract
+import FileManPanel
+import FileManUtils
+import FileManDialogs
+import FileManDialogAdd
+
+----------------------------------------------------------------------------------------------------
+---- Главное меню программы и тулбар под ним -------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+--      File: New Archive, Open Archive, New SFX, Change Drive, Select All, Select Group, Deselect Group, Invert Selection
+--      Commands (или Actions): Add, Extract, Test, ArcInfo, View, Delete, Rename
+--      Tools: Wizard (если таковой будет), Protect, Comment, Convert to EXE, Encrypt, Add Recovery record, Repair
+--      Options: Configuration, Save settings, Load settings, View log, Clear log
+--      Help: собственно сам Help, Goto Homepage (и/или Check for update), About
+
+uiDef =
+  "<ui>"++
+  "  <menubar>"++
+  "    <menu name=\"File\"     action=\"FileAction\">"++
+  "      <menuitem name=\"OpenArchive\"        action=\"OpenArchiveAction\" />"++
+  "      <separator/>"++
+  "      <menuitem name=\"Select all\"         action=\"SelectAllAction\" />"++
+  "      <menuitem name=\"Select\"             action=\"SelectAction\" />"++
+  "      <menuitem name=\"Unselect\"           action=\"UnselectAction\" />"++
+  "      <menuitem name=\"Invert selection\"   action=\"InvertSelectionAction\" />"++
+  "      <menuitem name=\"Refresh\"            action=\"RefreshAction\" />"++
+  "      <separator/>"++
+  "      <placeholder name=\"FileMenuAdditions\" />"++
+  "      <menuitem name=\"Exit\"               action=\"ExitAction\"/>"++
+  "    </menu>"++
+  "    <menu name=\"Commands\" action=\"CommandsAction\">"++
+  "      <menuitem name=\"Add\"                action=\"AddAction\" />"++
+  "      <menuitem name=\"Extract\"            action=\"ExtractAction\" />"++
+  "      <menuitem name=\"Test\"               action=\"TestAction\" />"++
+  "      <menuitem name=\"ArcInfo\"            action=\"ArcInfoAction\" />"++
+  "      <menuitem name=\"Delete\"             action=\"DeleteAction\" />"++
+  "    </menu>"++
+  "    <menu name=\"Tools\"    action=\"ToolsAction\">"++
+  "      <menuitem name=\"Lock\"               action=\"LockAction\" />"++
+  "      <menuitem name=\"Comment\"            action=\"CommentAction\" />"++
+  "      <menuitem name=\"Recompress\"         action=\"RecompressAction\" />"++
+  "      <menuitem name=\"Convert to SFX\"     action=\"ConvertToSFXAction\" />"++
+  "      <separator/>"++
+  "      <menuitem name=\"Encrypt\"            action=\"EncryptAction\" />"++
+  "      <menuitem name=\"Protect\"            action=\"ProtectAction\" />"++
+  "      <menuitem name=\"Repair\"             action=\"RepairAction\" />"++
+  "      <separator/>"++
+  "      <menuitem name=\"Modify\"             action=\"ModifyAction\" />"++
+  "      <menuitem name=\"Join archives\"      action=\"JoinArchivesAction\" />"++
+  "    </menu>"++
+  "    <menu name=\"Options\"  action=\"OptionsAction\">"++
+  "      <menuitem name=\"Settings\"           action=\"SettingsAction\" />"++
+  "      <separator/>"++
+  "      <menuitem name=\"ViewLog\"            action=\"ViewLogAction\" />"++
+  "      <menuitem name=\"ClearLog\"           action=\"ClearLogAction\" />"++
+  "    </menu>"++
+  "    <menu name=\"Help\"     action=\"HelpAction\">"++
+  "      <menuitem name=\"MainHelp\"           action=\"MainHelpAction\" />"++
+  "      <separator/>"++
+  "      <menuitem name=\"CmdlineHelp\"        action=\"CmdlineHelpAction\" />"++
+  "      <menuitem name=\"OpenHomepage\"       action=\"OpenHomepageAction\" />"++
+  "      <menuitem name=\"OpenForum\"          action=\"OpenForumAction\" />"++
+  "      <menuitem name=\"OpenWiki\"           action=\"OpenWikiAction\" />"++
+  "      <menuitem name=\"CheckForUpdate\"     action=\"CheckForUpdateAction\" />"++
+  "      <separator/>"++
+  "      <menuitem name=\"About\"              action=\"AboutAction\" />"++
+  "    </menu>"++
+  "  </menubar>"++
+  "  <toolbar>"++
+  "    <placeholder name=\"FileToolItems\">"++
+  "      <toolitem name=\"OpenArchive\"        action=\"OpenArchiveAction\" />"++
+  "      <separator/>"++
+  "      <toolitem name=\"Add\"                action=\"AddAction\" />"++
+  "      <toolitem name=\"Extract\"            action=\"ExtractAction\" />"++
+  "      <toolitem name=\"Test\"               action=\"TestAction\" />"++
+  "      <toolitem name=\"ArcInfo\"            action=\"ArcInfoAction\" />"++
+  "      <toolitem name=\"Delete\"             action=\"DeleteAction\" />"++
+  "      <separator/>"++
+  "      <toolitem name=\"Lock\"               action=\"LockAction\" />"++
+  "      <toolitem name=\"Recompress\"         action=\"RecompressAction\" />"++
+  "      <toolitem name=\"Convert to SFX\"     action=\"ConvertToSFXAction\" />"++
+  "      <toolitem name=\"Join archives\"      action=\"JoinArchivesAction\" />"++
+  "      <separator/>"++
+  "      <toolitem name=\"Refresh\"            action=\"RefreshAction\" />"++
+  "    </placeholder>"++
+  "  </toolbar>"++
+  "</ui>"
+
+
+----------------------------------------------------------------------------------------------------
+---- Визуальная часть файл-менеджера ---------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+myGUI run args = do
+  fileManagerMode =: True
+  startGUI $ do
+  io$ parseCmdline ["l", "a"]   -- инициализация: display, логфайл
+  -- Список ассоциаций клавиша->действие
+  onKeyActions <- newList
+  let onKey = curry (onKeyActions <<=)
+  -- Создадим окно индикатора прогресса и загрузим настройки/локализацию
+  (windowProgress, clearStats) <- runIndicators
+  -- Main menu
+  standardGroup <- actionGroupNew "standard"
+  let action name  =  (concat$ map (mapHead toUpper)$ words$ drop 5 name)++"Action"   -- "9999 the name" -> "TheNameAction"
+  let names = split ',' "0050 File,0258 Commands,0259 Tools,0260 Options,0261 Help"
+  for names $ \name -> do
+    label <- i18n name
+    actionGroupAddAction standardGroup  =<<  actionNew (action name) label Nothing Nothing
+  -- Menus and toolbars
+  let anew name comment icon accel = do
+        [i18name,i18comment] <- i18ns [name,comment]
+        action <- actionNew (action name) i18comment (Just i18comment) icon
+        action `set` [actionShortLabel := i18name]
+        actionGroupAddActionWithAccel standardGroup action (Just accel)
+        accel `onKey` actionActivate action
+        return action
+  --
+  openAct     <- anew "0262 Open archive"     "0265 Open archive"                       (Just stockOpen)            "<Alt>O"
+  selectAllAct<- anew "0263 Select all"       "0290 Select all files"                   (Just stockSelectAll)       "<Ctrl>A"
+  selectAct   <- anew "0037 Select"           "0047 Select files"                       (Just stockAdd)             "KP_Add"
+  unselectAct <- anew "0038 Unselect"         "0048 Unselect files"                     (Just stockRemove)          "KP_Subtract"
+  invertSelAct<- anew "0264 Invert selection" "0291 Invert selection"                   (Nothing)                   "KP_Multiply"
+  refreshAct  <- anew "0039 Refresh"          "0049 Reread archive/directory"           (Just stockRefresh)         "F5"
+  exitAct     <- anew "0036 Exit"             "0046 Quit application"                   (Just stockQuit)            "<Alt>Q"
+
+  addAct      <- anew "0030 Add"              "0040 Add files to archive(s)"            (Just stockMediaRecord)     "<Alt>A"
+  extractAct  <- anew "0035 Extract"          "0045 Extract files from archive(s)"      (Just stockMediaPlay)       "<Alt>E"
+  testAct     <- anew "0034 Test"             "0044 Test files in archive(s)"           (Just stockSpellCheck)      "<Alt>T"
+  arcinfoAct  <- anew "0086 ArcInfo"          "0087 Information about archive"          (Just stockInfo)            "<Alt>I"
+  deleteAct   <- anew "0033 Delete"           "0043 Delete files (from archive)"        (Just stockDelete)          "Delete"
+
+  lockAct     <- anew "0266 Lock"             "0267 Lock archive from further changes"  (Just stockDialogAuthentication) "<Alt>L"
+  commentAct  <- anew "0268 Comment"          "0269 Edit archive comment"               (Just stockEdit)            "<Alt>C"
+  recompressAct<-anew "0293 Recompress"       "0294 Recompress files in archive"        (Just stockGotoBottom)      "<Alt>R"
+  toSfxAct    <- anew "0270 Convert to SFX"   "0271 Convert archive to SFX"             (Just stockConvert)         "<Alt>S"
+  encryptAct  <- anew "0272 Encrypt"          "0273 Encrypt archive contents"           (Nothing)                   ""
+  addRrAct    <- anew "0274 Protect"          "0275 Add Recovery record to archive"     (Nothing)                   "<Alt>P"
+  repairAct   <- anew "0379 Repair"           "0380 Repair damaged archive"             (Nothing)                   ""
+  modifyAct   <- anew "0031 Modify"           "0041 Modify archive(s)"                  (Just stockEdit)            "<Alt>M"
+  joinAct     <- anew "0032 Join archives"    "0042 Join archives together"             (Just stockCopy)            "<Alt>J"
+
+  settingsAct <- anew "0064 Settings"         "0065 Edit program settings"              (Just stockPreferences)     ""
+  viewLogAct  <- anew "0276 View log"         "0277 View logfile"                       (Nothing)                   ""
+  clearLogAct <- anew "0278 Clear log"        "0279 Clear logfile"                      (Nothing)                   ""
+
+  helpAct     <- anew "0280 Main help"        "0281 Help on using FreeArc"              (Just stockHelp)            "F1"
+  helpCmdAct  <- anew "0282 Cmdline help"     "0283 Help on FreeArc command line"       (Just stockHelp)            ""
+  homepageAct <- anew "0284 Open Homepage"    "0285 Open program site"                  (Just stockHome)            ""
+  openForumAct<- anew "0373 Open forum"       "0374 Open program forum"                 (Nothing)                   ""
+  openWikiAct <- anew "0375 Open wiki"        "0376 Open program wiki"                  (Nothing)                   ""
+  whatsnewAct <- anew "0286 Check for update" "0287 Check for new program version"      (Just stockDialogInfo)      ""
+  aboutAct    <- anew "0288 About"            "0289 About"                              (Just stockAbout)           ""
+
+  menufile <- findFile configFilePlaces aMENU_FILE
+  uiData   <- if menufile>""  then fileGetBinary menufile  else return uiDef
+
+  ui <- uiManagerNew
+  uiManagerAddUiFromString ui uiData
+  uiManagerInsertActionGroup ui standardGroup 0
+
+  window <- windowNew
+  (Just menuBar) <- uiManagerGetWidget ui "/ui/menubar"
+  (Just toolBar) <- uiManagerGetWidget ui "/ui/toolbar"
+
+  (listUI, listView, listModel, listSelection, columns, onColumnTitleClicked) <- createFilePanel
+  statusLabel  <- labelNew Nothing
+  miscSetAlignment statusLabel 0 0.5
+  messageCombo <- New.comboBoxNewText
+  statusbar    <- statusbarNew
+  ctx <- statusbarGetContextId statusbar ""
+  statusbarPush statusbar ctx "    "
+  widgetSetSizeRequest messageCombo 30 (-1)
+  lowBox <- vBoxNew False 0
+  boxPackStart lowBox statusLabel  PackNatural 2
+  boxPackStart lowBox messageCombo PackGrow    2
+  --boxPackStart lowBox statusbar    PackNatural 0
+
+  -- Создадим переменную для хранения текущего состояния файл-менеджера
+  fm' <- newFM window listView listModel listSelection statusLabel messageCombo
+  fmStackMsg fm' "              "
+
+  -- Отрихтуем тулбар
+  let toolbar = castToToolbar toolBar
+  toolbarCaptions <- fmGetHistoryBool fm' "ToolbarCaptions" True
+  toolbar `set` [toolbarStyle := if toolbarCaptions then ToolbarBoth else ToolbarIcons]
+  toolbar `toolbarSetIconSize` iconSizeLargeToolbar
+  n <- toolbarGetNItems toolbar
+  for [0..n-1] $ \i -> do
+    Just button <- toolbarGetNthItem toolbar i
+    toolItemSetHomogeneous button False
+
+  -- Полоска навигации
+  naviBar  <- hBoxNew False 0
+  upButton <- button "0006   Up  "
+  curdir   <- fmEntryWithHistory fm' "dir/arcname" (const$ return True) (fmCanonicalizePath fm')
+  saveDirButton <- button "0007   Save  "
+  boxPackStart naviBar (widget upButton)       PackNatural 0
+#if defined(FREEARC_WIN)
+  -- Меню выбора диска
+  driveButton <- button "C:"
+  driveMenu   <- makePopupMenu (chdir fm'.(++"\\") . head.words) =<< getDrives
+  driveButton `onClick` (widgetShowAll driveMenu >> menuPopup driveMenu Nothing)
+  boxPackStart naviBar (widget driveButton)    PackNatural 0
+  -- Менять надпись на кнопке выбора диска при переходе на другой диск
+  fm' `fmOnChdir` do
+    fm <- val fm'
+    let drive = takeDrive (fm_current fm)
+    setTitle driveButton (take 2 drive)  `on` drive
+#endif
+  boxPackStart naviBar (widget curdir)         PackGrow    0
+  boxPackStart naviBar (widget saveDirButton)  PackNatural 0
+
+  -- Целиком окно файл-менеджера
+  vBox <- vBoxNew False 0
+  set vBox [boxHomogeneous := False]
+  boxPackStart vBox menuBar   PackNatural 0
+  boxPackStart vBox toolBar   PackNatural 0
+  boxPackStart vBox naviBar   PackNatural 0
+  boxPackStart vBox listUI    PackGrow    0
+  boxPackStart vBox lowBox    PackNatural 0
+
+  containerAdd window vBox
+
+
+  -- Список действий, выполняемых при закрытии окна файл-менеджера
+  onExit <- newList
+  window `onDestroy` do
+    sequence_ =<< listVal onExit
+    mainQuit
+
+  -- Список ассоциаций клавиша->действие
+  listView `onKeyPress` \event -> do
+    x <- lookup (eventKey event) `fmap` listVal onKeyActions
+    case x of
+      Just action -> do action; return True
+      Nothing     -> return False
+
+
+----------------------------------------------------------------------------------------------------
+---- Сохранение/восстановление размера и положения главного окна и колонок в нём -------------------
+----------------------------------------------------------------------------------------------------
+
+  window `windowSetPosition` WinPosCenter
+  --windowSetGeometryHints window (Just window) (Just (1,1)) (Just (32000,32000)) Nothing Nothing Nothing
+  --widgetSetSizeRequest window 700 500
+  --window `windowSetGravity` GravityStatic
+  --window `windowSetPosition` WinPosNone
+  --windowSetDefaultSize window 200 100
+
+  -- При старте восстановим сохранённый размер окна
+  restoreSizePos fm' window "MainWindow" "-10000 -10000 720 500"
+
+  -- Сохраним размер и положение главного окна после его перемещения
+  window `onConfigure` \e -> do
+    saveSizePos fm' window "MainWindow"
+    return False
+
+  -- Запомним, было ли окно максимизировано
+  window `onWindowState` \e -> do
+    let isMax x = case x of
+                    WindowStateMaximized -> True
+                    _                    -> False
+    saveMaximized fm' "MainWindow" (any isMax (eventWindowState e))
+    return False
+
+
+  -- При закрытии программы сохраним порядок и ширину колонок
+  onExit <<= do
+    colnames  <-  New.treeViewGetColumns listView  >>=  mapM New.treeViewColumnGetTitle
+    fmReplaceHistory fm' "ColumnOrder" (unwords$ catMaybes colnames)
+    for columns $ \(name,col1) -> do
+      w <- New.treeViewColumnGetWidth col1
+      fmReplaceHistory fm' (name++"ColumnWidth") (show w)
+
+  -- При старте восстановим сохранённые порядок и ширину колонок
+  order <- (reverse.words) `fmap` fmGetHistory1 fm' "ColumnOrder" ""
+  for order $ \colname -> do
+    whenJust (lookup colname columns) $
+      New.treeViewMoveColumnFirst listView
+  for columns $ \(name,col1) -> do
+    w <- readInt  `fmap`  fmGetHistory1 fm' (name++"ColumnWidth") "150"
+    New.treeViewColumnSetFixedWidth col1 w
+
+
+----------------------------------------------------------------------------------------------------
+---- Навигационная часть файл-менеджера ------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+--  for [upButton,saveDirButton] (`buttonSetFocusOnClick` False)
+
+  -- Выводить errors/warnings внизу окна FreeArc
+  showErrors' <- ref True
+  errorHandlers   ++= [whenM (val showErrors') . postGUIAsync . fmStackMsg fm']
+  warningHandlers ++= [whenM (val showErrors') . postGUIAsync . fmStackMsg fm']
+
+  -- Отключает вывод сообщений об ошибках на время выполнения action
+  let hideErrors action  =  bracket (showErrors' <=> False)  (showErrors' =: )  (\_ -> action)
+
+  -- Перехват и обработка ошибок
+  errorMsg <- ref ""
+  errorHandlers ++= [(errorMsg =:)]
+  let withErrorHandler onError = handle$ \e->do operationTerminated =: False
+                                                fmErrorMsg fm' =<< val errorMsg
+                                                sequence_ onError
+  -- При возникновении ошибки выдать её пользователю
+  let msgboxOnError = withErrorHandler []
+  -- При возникновении ошибки выдать её пользователю и заверщить выполнение программы
+  let terminateOnError = withErrorHandler [shutdown "" aEXIT_CODE_FATAL_ERROR]
+
+
+  -- Перейти в заданный каталог/архив или выполнить команду
+  let select filename = do
+        fm <- val fm'
+        handle (\e -> (operationTerminated =: False) >> runFile filename (fm_curdir fm) False) $ do    -- при неудаче перехода запустим файл :)
+          hideErrors $ do
+            chdir fm' filename
+            New.treeViewScrollToPoint (fm_view fm) 0 0
+            --New.treeViewSetCursor (fm_view fm) [0] Nothing
+
+  -- Переход в родительский каталог
+  let goParentDir = do
+        fm <- val fm'
+        unless (isFM_Archive fm  &&  isURL(fm_arcname fm)  &&  fm_arcdir fm=="") $ do  -- Запретить Up из архива в инете
+        chdir fm' ".."
+        -- Выбираем каталог/архив, из которого мы только что вышли
+        fmSetCursor fm' (takeFileName$ fm_current fm)
+
+  -- Запись текущего каталога в историю
+  let saveCurdirToHistory = do
+        fm <- val fm'
+        fmAddHistory fm' (isFM_Archive fm.$bool "dir" "arcname") =<< fmCanonicalizePath fm' =<< val curdir
+
+
+  -- При нажатии Enter на строке в списке открываем выбранный архив/каталог
+  listView `New.onRowActivated` \path column -> do
+    fm <- val fm'
+    file <- fmFileAt fm' path
+    unless (isFM_Archive fm  &&  not(fdIsDir file)) $ do  -- Run command don't yet work directly from archives
+    select (fmname file)
+
+  -- При single-click на свободном пространстве справа/снизу снимаем отметку со всех файлов,
+  -- при double-click там же выбираем все файлы
+  listView `onButtonPress` \e -> do
+    path <- New.treeViewGetPathAtPos listView (round$ eventX e, round$ eventY e)
+    coltitle <- case path of
+                  Just (_,column,_) -> New.treeViewColumnGetTitle column >>== fromMaybe ""
+                  _                 -> return ""
+    -- Пустая строка в coltitle означает клик за пределами списка файлов
+    coltitle=="" &&& e.$eventButton==LeftButton &&&
+      ((if e.$eventClick==SingleClick  then fmUnselectAll  else fmSelectAll) fm'  >>  return True)
+
+  -- При переходе в другой каталог/архив отобразить его имя в строке ввода
+  fm' `fmOnChdir` do
+    fm <- val fm'
+    curdir =: fm_current fm
+    -- Сохраняем в историю имена архивов
+    isFM_Archive fm  &&&  fm_arcdir fm==""  &&&  saveCurdirToHistory
+    -- Перечитаем историю с диска
+    rereadHistory curdir
+
+  -- При переходе в другой каталог/архив - отобразить его имя в заголовке окна
+  fm' `fmOnChdir` do
+    fm <- val fm'
+    let title | isFM_Archive fm  =  takeFileName (fm_arcname fm) </> fm_arcdir fm
+              | otherwise        =  takeFileName (fm_dir fm)  |||  fm_dir fm
+    set (fm_window fm) [windowTitle := title++" - "++aARC_NAME]
+
+  -- Переходим в род. каталог по кнопке Up или нажатию BackSpace в списке файлов
+  upButton  `onClick` goParentDir
+  "BackSpace" `onKey` goParentDir
+
+  -- Сохранение выбранного архива/каталога в истории
+  saveDirButton `onClick` do
+    saveCurdirToHistory
+
+  -- Открытие другого каталога или архива (Enter в строке ввода)
+  entry curdir `onEntryActivate` do
+    saveCurdirToHistory
+    select =<< val curdir
+
+  -- Открытие другого каталога или архива (выбор из истории)
+  widget curdir `New.onChanged` do
+    whenJustM_ (New.comboBoxGetActive$ widget curdir) $ \_ -> do
+    saveCurdirToHistory
+    select =<< val curdir
+
+  -- Выполнить action над файлами, состоящими в соотношении makeRE с именем файла под курсором
+  let byFile action makeRE = do
+        filename <- fmGetCursor fm'
+        action fm' ((match$ makeRE filename) . fdBasename)
+
+  -- Клавиши Shift/Ctrl/Alt-Plus/Minus с теми же операциями как в FAR
+  "<Shift>KP_Add"      `onKey` fmSelectAll   fm'
+  "<Shift>KP_Subtract" `onKey` fmUnselectAll fm'
+  "<Ctrl>KP_Add"       `onKey` byFile fmSelectFilenames   (("*" ++) . takeExtension)
+  "<Ctrl>KP_Subtract"  `onKey` byFile fmUnselectFilenames (("*" ++) . takeExtension)
+  "<Alt>KP_Add"        `onKey` byFile fmSelectFilenames   ((++".*") . dropExtension)
+  "<Alt>KP_Subtract"   `onKey` byFile fmUnselectFilenames ((++".*") . dropExtension)
+
+
+  -- При нажатии заголовка столбца в списке файлов - сортировать по этому столбцу
+  --   (при повторном нажатии - сортировать в обратном порядке)
+  onColumnTitleClicked =: \column -> do
+    fmModifySortOrder fm' (showSortOrder columns) (calcNewSortOrder column)
+    refreshCommand fm'
+    fmSaveSortOrder  fm' =<< fmGetSortOrder fm'  -- запишем в конфиг порядок сортировки
+
+  -- Отсортируем файлы по сохранённому критерию
+  fmSetSortOrder fm' (showSortOrder columns) =<< fmRestoreSortOrder fm'
+
+
+----------------------------------------------------------------------------------------------------
+---- Меню File -------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+  -- Открыть архив
+  openAct `onActionActivate` do
+    fm <- val fm'
+    let curfile  =  if isFM_Archive fm  then fm_arcname fm  else fm_dir fm </> "."
+    chooseFile window FileChooserActionOpen "0305 Open archive" aARCFILE_FILTER (return curfile) $ \filename -> do
+      msgboxOnError $
+        chdir fm' filename
+
+  -- Select/unselect files by user-supplied mask
+  let byDialog method msg = do
+        whenJustM_ (fmInputString fm' "mask" msg (const$ return True) return) $ \mask -> do
+          method fm' ((match mask) . fdBasename)
+  selectAct   `onActionActivate`  byDialog fmSelectFilenames   "0008 Select files"
+  unselectAct `onActionActivate`  byDialog fmUnselectFilenames "0009 Unselect files"
+
+  -- Выделить все файлы
+  selectAllAct `onActionActivate` do
+    fmSelectAll fm'
+
+  -- Инвертировать выделение
+  invertSelAct `onActionActivate` do
+    fmInvertSelection fm'
+
+  -- Обновить список файлов актуальными данными
+  refreshAct `onActionActivate` do
+    refreshCommand fm'
+
+  -- Выход из программы
+  exitAct `onActionActivate`
+    mainQuit
+
+
+----------------------------------------------------------------------------------------------------
+---- Движок выполнения консольных команд внутри FM gui ---------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+  -- При выполнении операций не выходим по исключениям, а печатаем сообщения о них в логфайл
+  let myHandleErrors action x  =  do operationTerminated =: False
+                                     action x `catch` handler
+                                     operationTerminated =: False
+        where handler ex = do
+                errmsg <- case ex of
+                   Deadlock    -> i18n"0011 No threads to run: infinite loop or deadlock?"
+                   ErrorCall s -> return s
+                   other       -> return$ show ex
+                with' (val log_separator') (log_separator'=:) $ \_ -> do
+                  log_separator' =: ""
+                  io$ condPrintLineLn "w" errmsg
+                return ()
+
+  -- Выполнить команду архиватора
+  let runWithMsg ([formatStart,formatSuccess,formatFail],msgArgs,cmd) = do
+        -- Сообщение о начале выполнения команды
+        msgStart <- i18n formatStart
+        postGUIAsync$ fmStackMsg fm' (formatn msgStart msgArgs)
+        --postGUIAsync$ fmStackMsg fm' (unwords cmd)
+        -- Выполнить и посчитать число ошибок
+        w <- count_warnings (parseCmdline cmd >>= mapM_ run)
+        -- Сообщение об успешном выполнении либо кол-ве допущенных ошибок
+        msgFinish <- i18n (if w==0  then formatSuccess  else formatFail)
+        postGUIAsync$ fmStackMsg fm' (formatn msgFinish (msgArgs++[show w]))
+
+  -- Commands executed by various buttons
+  cmdChan <- newChan
+  forkIO $ do
+    foreverM $ do
+      commands <- readChan cmdChan
+      postGUIAsync$ do clearStats; widgetShowAll windowProgress
+      mapM_ (myHandleErrors runWithMsg) commands
+      whenM (isEmptyChan cmdChan)$ postGUIAsync$ do widgetHide windowProgress; refreshCommand fm'
+      --uiDoneProgram
+  let exec = writeChan cmdChan
+
+
+----------------------------------------------------------------------------------------------------
+---- Меню Commands ---------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+  -- Упаковка данных
+  addAct `onActionActivate` do
+    addDialog fm' exec "a" NoMode
+
+  -- Распаковка архив(ов)
+  extractAct `onActionActivate` do
+    archiveOperation fm' $
+      extractDialog fm' exec "x"
+    rereadHistory curdir
+
+  -- Тестирование архив(ов)
+  testAct `onActionActivate` do
+    archiveOperation fm' $
+      extractDialog fm' exec "t"
+
+  -- Информация об архиве
+  arcinfoAct `onActionActivate` do
+    msgboxOnError $
+      archiveOperation fm' $
+        arcinfoDialog fm' exec NoMode
+
+  -- Удаление файлов (из архива)
+  deleteAct `onActionActivate` do
+    fm <- val fm'
+    files <- getSelection fm' (if isFM_Archive fm  then xCmdFiles  else const [])
+    if null files  then fmErrorMsg fm' "0012 There are no files selected!" else do
+    msg <- i18n$ case files of [_] | isFM_Archive fm -> "0160 Delete %1 from archive?"
+                                   | otherwise       -> "0161 Delete %1?"
+                               _   | isFM_Archive fm -> "0019 Delete %2 file(s) from archive?"
+                                   | otherwise       -> "0020 Delete %2 file(s)?"
+    whenM (askOkCancel window (formatn msg [head files, show3$ length files])) $ do
+      fmDeleteSelected fm'
+      if isFM_Archive fm
+        -- Стереть файлы из архива
+        then do closeFMArc fm'
+                let arcname = fm_arcname fm
+                exec [(["0228 Deleting from %1",
+                        "0229 FILES SUCCESFULLY DELETED FROM %1",
+                        "0230 %2 WARNINGS WHILE DELETING FROM %1"],
+                       [takeFileName arcname],
+                       ["d", "--noarcext", "--", arcname]++files)]
+        -- Удалить файлы на диске
+        else io$ mapM_ (ignoreErrors.fileRemove.(fm_dir fm </>)) files
+
+
+----------------------------------------------------------------------------------------------------
+---- Меню Tools ------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+  -- Защитить архив от записи
+  lockAct `onActionActivate` do
+    multiArchiveOperation fm' $ \archives -> do
+      let msg = "0299 Lock archive(s)?"
+      whenM (askOkCancel window (formatn msg [head archives, show3$ length archives])) $ do
+        closeFMArc fm'
+        for archives $ \arcname -> do
+          exec [(["0300 Locking archive %1",
+                  "0301 SUCCESFULLY LOCKED ARCHIVE %1",
+                  "0302 %2 WARNINGS WHILE LOCKING ARCHIVE %1"],
+                 [takeFileName arcname],
+                 ["ch", "--noarcext", "-k", "--", arcname])]
+
+  -- Изменить комментарий архива
+  commentAct `onActionActivate` do
+    msgboxOnError $
+      archiveOperation fm' $
+        arcinfoDialog fm' exec CommentMode
+
+  -- Преобразовать архив в SFX
+  recompressAct `onActionActivate` do
+    addDialog fm' exec "ch" RecompressMode
+
+  -- Преобразовать архив в SFX
+  toSfxAct `onActionActivate` do
+    addDialog fm' exec "ch" MakeSFXMode
+
+  -- Зашифровать архив
+  encryptAct `onActionActivate` do
+    addDialog fm' exec "ch" EncryptionMode
+
+  -- Добавить RR в архив
+  addRrAct `onActionActivate` do
+    addDialog fm' exec "ch" ProtectionMode
+
+  -- Восстановить повреждённый архив
+  repairAct `onActionActivate` do
+    multiArchiveOperation fm' $ \archives -> do
+      let msg = "0381 Repair archive(s)? Repaired archive(s) will be placed into files named fixed.*"
+      whenM (askOkCancel window (formatn msg [head archives, show3$ length archives])) $ do
+        closeFMArc fm'
+        for archives $ \arcname -> do
+          exec [(["0382 Repairing archive %1",
+                  "0383 SUCCESFULLY REPAIRED ARCHIVE %1",
+                  "0384 %2 WARNINGS WHILE REPAIRING ARCHIVE %1"],
+                 [takeFileName arcname],
+                 ["r", "--noarcext", "--", arcname])]
+
+  -- Модификация архивов
+  modifyAct `onActionActivate` do
+    addDialog fm' exec "ch" NoMode
+
+  -- Объединение архивов
+  joinAct `onActionActivate` do
+    addDialog fm' exec "j" NoMode
+
+
+----------------------------------------------------------------------------------------------------
+---- Меню Options ----------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+  -- Окно настроек программы
+  settingsAct `onActionActivate` do
+    settingsDialog fm'
+
+  -- Действия с логфайлом
+  let withLogfile action = do
+        logfileHist <- fmGetHistory fm' "logfile"
+        case logfileHist of
+          logfile:_ | logfile>""  ->  action logfile
+          _                       ->  fmErrorMsg fm' "0303 No log file specified in Settings dialog!"
+
+  -- Просмотреть логфайл
+  viewLogAct `onActionActivate` do
+    withLogfile runViewCommand
+
+  -- Удалить логфайл
+  clearLogAct `onActionActivate` do
+    withLogfile $ \logfile -> do
+      msg <- i18n"0304 Clear logfile %1?"
+      whenM (askOkCancel window (format msg logfile)) $ do
+        filePutBinary logfile ""
+
+
+----------------------------------------------------------------------------------------------------
+---- Меню Help -------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+  -- Home/news page for the current locale
+  homeURL  <- ((aARC_WEBSITE ++ "/") ++) ==<< i18n"0254 "
+  newsURL  <- ((aARC_WEBSITE ++ "/") ++) ==<< i18n"0255 News.aspx"
+  forumURL <- ("http://apps.sourceforge.net/phpbb/freearc/" ++) ==<< i18n"0371 viewforum.php?f=3"
+  wikiURL  <- ("http://freearc.wiki.sourceforge.net/"       ++) ==<< i18n"0372 "
+
+  -- Открыть URL
+  let openWebsite url  =  runFile url "." False
+
+  -- Открыть файл помощи
+  let openHelp helpfile = do
+        doc  <- i18n helpfile
+        file <- findFile libraryFilePlaces ("../Documentation" </> doc)
+        case file of
+          "" -> return ()
+          _  -> openWebsite file
+
+  -- Прочитать ИД, сгенерённый для этого компьютера
+  let getUserID = do
+#ifndef FREEARC_WIN
+        -- Имитация неработающего Windows Registry для других ОС
+        let registryGetStr root branch key       = return Nothing
+            registrySetStr root branch key value = return ()
+            hKEY_LOCAL_MACHINE                   = ()
+#endif
+        -- Сначала ищем его в ини-файле
+        userid <- fmGetHistory1 fm' "UserID" ""
+        if userid/=""  then return (Just userid)  else do
+        -- Если не получилось - читаем ключ предыдущей инсталляции из Windows Registry...
+        userid <- do userid <- registryGetStr hKEY_LOCAL_MACHINE "SOFTWARE\\FreeArc" "UserID"
+                     case userid of
+                       Just userid -> return userid
+                                      -- ... или в крайнем случае - генерим новый
+                       Nothing     -> generateRandomBytes 8 >>== encode16
+        -- И записываем его повсюду
+        registrySetStr hKEY_LOCAL_MACHINE "SOFTWARE\\FreeArc" "UserID" userid
+        fmReplaceHistory fm' "UserID" userid
+        -- Возвращаем его только если запись в ини-файл была успешной
+        userid1 <- fmGetHistory1 fm' "UserID" ""
+        return (if userid==userid1  then Just userid  else Nothing)
+
+  -- Возвращает True раз в сутки
+  let daily = do
+        last <- fmGetHistory1 fm' "LastCheck" ""
+        now  <- getUnixTime
+        let day = round$ 24.37*60*60
+        if  last>""  &&  (now - readI last < day)  then return False  else do
+        fmReplaceHistory fm' "LastCheck" (show now)
+        now1 <- fmGetHistory1 fm' "LastCheck" ""
+        return (show now==now1)
+
+  -- Size of maximum memory block we can allocate in bytes
+  maxBlock <- getMaxMemToAlloc
+
+  -- Регистрирует использование программы и проверяет новости
+  --  (manual=True - ручной вызов из меню, False - ежедневная автопроверка)
+  let checkNews manual = do
+        fmStackMsg fm' "0295 Checking for updates..."
+        forkIO_ $ do
+          -- Сообщим об использовании программы
+          whenJustM_ getUserID $ \userid -> do
+#ifdef FREEARC_WIN
+            si <- getSystemInfo; let ramLimit = showMem (si.$siMaximumApplicationAddress.$ptrToWordPtr.$toInteger `roundTo` (4*mb))
+#endif
+            language <- i18n"0000 English"
+            let url = aARC_WEBSITE ++ "/CheckNews.aspx?user=" ++ userid ++ "&version=" ++ urlEncode aARC_VERSION
+                                   ++ "&OS%20family=" ++ iif isWindows "Windows" "Unix"
+                                   ++ "&RAM=" ++ showMem (toInteger getPhysicalMemory `roundTo` (4*mb))
+#ifdef FREEARC_WIN
+                                   ++ "&address%20space=" ++ ramLimit
+#endif
+                                   ++ "&largest%20memory%20block=" ++ showMem (maxBlock `roundDown` (100*mb))
+                                   ++ "&number%20of%20cores=" ++ show getProcessorsCount
+                                   ++ "&language=" ++ urlEncode language
+            --gui$ fmStackMsg fm' url
+            ignoreErrors (fileGetBinary url >> return ())
+          -- Проверим страницу новостей
+          handleErrors
+            -- Выполняется при недоступности страницы новостей
+            (gui $ do
+                msg <- i18n"0296 Cannot open %1. Do you want to check the page with browser?"
+                whenM (askOkCancel window (format msg newsURL)) $ do
+                  openWebsite newsURL)
+            -- Попытка прочитать страницу новостей
+            (fileGetBinary newsURL >>== (`showHex` "") . crc32) $ \new_crc -> do
+          -- Страница новостей успешно прочитана
+          old_crc <- fmGetHistory1 fm' "news_crc" ""
+          gui $ do
+          fmStackMsg fm' ""
+          if (new_crc == old_crc) then do
+             msg <- i18n"0297 Nothing new at %1"
+             manual &&& fmInfoMsg fm' (format msg newsURL)
+           else do
+             fmReplaceHistory fm' "news_crc" new_crc
+             msg <- i18n"0298 Found new information at %1! Open the page with browser?"
+             whenM (askOkCancel window (format msg newsURL)) $ do
+               openWebsite newsURL
+
+  -- Дважды в час проверять отсутствие новостей
+  forkIO_ $ do
+    whenM (fmGetHistoryBool fm' "CheckNews" True) $ do
+      foreverM $ do
+        whenM daily $ do
+          checkNews False
+        threadDelay (30*60*1000000::Int)  -- 60 minutes is too much for Int!
+
+
+  -- Помощь по использованию GUI
+  helpAct `onActionActivate` do
+    openHelp "0256 FreeArc-GUI-Eng.htm"
+
+  -- Помощь по использованию командной строки
+  helpCmdAct `onActionActivate` do
+    openHelp "0257 FreeArc036-eng.htm"
+
+  -- Домашняя страница программы
+  homepageAct `onActionActivate` do
+    openWebsite homeURL
+
+  -- Домашняя страница программы
+  openForumAct `onActionActivate` do
+    openWebsite forumURL
+
+  -- Домашняя страница программы
+  openWikiAct `onActionActivate` do
+    openWebsite wikiURL
+
+  -- Проверка обновлений на сайте
+  whatsnewAct `onActionActivate` do
+    checkNews True
+
+  -- Диалог About
+  aboutAct `onActionActivate` do
+    bracketCtrlBreak "aboutDialogDestroy" aboutDialogNew widgetDestroy $ \dialog -> do
+    dialog `set` [windowTransientFor   := window
+                 ,aboutDialogName      := aARC_NAME
+                 ,aboutDialogVersion   := aARC_VERSION_WITH_DATE
+                 ,aboutDialogCopyright := "(c) "++aARC_EMAIL
+                 ,aboutDialogComments  := "High-performance archiver"
+                 ,aboutDialogWebsite   := homeURL
+                 ,aboutDialogAuthors   := ["Igor Pavlov (author of LZMA and EXE filter)"
+                                          ,"Dmitry Shkarin (author of PPMd)"
+                                          ,"Ilya Grebnov (author of GRZipII and LZP filter)"
+                                          ,"Alexander Djourik and Pavel Zhilin (authors of TTA)"
+                                          ,"Dmitry Subbotin (author of Carryless rangecoder)"
+                                          ,"Joachim Henke (coauthor of Tornado)"
+                                          ,"Mark Shevchenko (author of GUI SFX and web site)"
+                                          ,aARC_EMAIL++" (author of remaining parts)"
+                 ]]
+    dialogRun dialog
+    return ()
+
+  -- Включить поддержку URL в диалоге About
+  aboutDialogSetUrlHook openWebsite
+
+
+  -- Инициализируем состояние файл-менеджера каталогом/архивом, заданным в командной строке (при его отсутствии - текущим каталогом)
+  terminateOnError $
+    chdir fm' (head (args++["."]))
+  fmStatusBarTotals fm'
+
+  return window
+

--- a/FilePath.hs
+++ b/FilePath.hs
@@ -1,3 +1,761 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b68edc78c35b5bfa41aca628143f807b5cc71b6b673a8cb4fedc23102a06cb71
-size 25528
+{-# OPTIONS_GHC -cpp #-}
+{- |
+Module      :  System.FilePath
+Copyright   :  (c) Neil Mitchell 2005-2007
+License     :  BSD-style
+
+A library for 'FilePath' manipulations, using Posix or Windows filepaths
+depending on the platform.
+-}
+
+--
+-- Some short examples:
+--
+-- You are given a C file, you want to figure out the corresponding object (.o) file:
+--
+-- @'replaceExtension' file \"o\"@
+--
+-- Haskell module Main imports Test, you have the file named main:
+--
+-- @['replaceFileName' path_to_main \"Test\" '<.>' ext | ext <- [\"hs\",\"lhs\"] ]@
+--
+-- You want to download a file from the web and save it to disk:
+--
+-- @do let file = 'makeValid' url
+--    System.IO.createDirectoryIfMissing True ('takeDirectory' file)@
+--
+-- You want to compile a Haskell file, but put the hi file under \"interface\"
+--
+-- @'takeDirectory' file '</>' \"interface\" '</>' ('takeFileName' file \`replaceExtension\` \"hi\"@)
+--
+-- The examples in code format descibed by each function are used to generate
+-- tests, and should give clear semantics for the functions.
+-----------------------------------------------------------------------------
+
+module FilePath
+    (
+    isWindows, windosifyPath,
+
+    -- * Separator predicates
+    FilePath,
+    pathSeparator, pathSeparators, isPathSeparator,
+    searchPathSeparator, isSearchPathSeparator,
+    extSeparator, isExtSeparator,
+
+    -- * Path methods (environment $PATH)
+    splitSearchPath, getSearchPath,
+
+    -- * Extension methods
+    splitExtension,
+    takeExtension, replaceExtension, dropExtension, addExtension, hasExtension, (<.>),
+    splitExtensions, dropExtensions, takeExtensions,
+
+    -- * Drive methods
+    splitDrive, joinDrive,
+    takeDrive, hasDrive, dropDrive, isDrive,
+
+    -- * Operations on a FilePath, as a list of directories
+    splitFileName,
+    takeFileName, replaceFileName, dropFileName,
+    takeBaseName, replaceBaseName,
+    takeDirectory, replaceDirectory,
+    combine, (</>),
+    splitPath, joinPath, splitDirectories,
+
+    -- * Low level FilePath operators
+    hasTrailingPathSeparator,
+    addTrailingPathSeparator,
+    dropTrailingPathSeparator,
+
+    -- * File name manipulators
+    normalise, normalisePath, equalFilePath,
+    makeRelative,
+    isRelative, isAbsolute,
+    isValid, makeValid
+    )
+    where
+
+import Data.Maybe(isJust, fromJust)
+import Data.Char(toLower, toUpper)
+
+import System.Environment(getEnv)
+
+
+infixr 7  <.>
+infixr 5  </>
+
+
+
+
+
+---------------------------------------------------------------------
+-- Platform Abstraction Methods (private)
+
+-- | Is the operating system Unix or Linux like
+isPosix :: Bool
+isPosix = not isWindows
+
+-- | Is the operating system Windows like
+isWindows :: Bool
+#if defined(FREEARC_WIN)
+isWindows = True
+#else
+isWindows = False
+#endif
+
+
+
+
+---------------------------------------------------------------------
+-- The basic functions
+
+-- | The character that separates directories. In the case where more than
+--   one character is possible, 'pathSeparator' is the \'ideal\' one.
+--
+-- > pathSeparator ==  '/'
+-- > isPathSeparator pathSeparator
+pathSeparator :: Char
+pathSeparator = '/'
+
+-- | Make filename valid for Windows functions
+windosifyPath :: FilePath -> FilePath
+windosifyPath = replace '/' '\\'
+
+replace from to  =  map (\x -> if x==from  then to  else x)
+
+
+-- | The list of all possible separators.
+--
+-- > Windows: pathSeparators == ['\\', '/']
+-- > Posix:   pathSeparators == ['/']
+-- > pathSeparator `elem` pathSeparators
+pathSeparators :: [Char]
+pathSeparators = if isWindows then "\\/" else "/"
+
+-- | Rather than using @(== 'pathSeparator')@, use this. Test if something
+--   is a path separator.
+--
+-- > isPathSeparator a == (a `elem` pathSeparators)
+isPathSeparator :: Char -> Bool
+isPathSeparator = (`elem` pathSeparators)
+
+
+-- | The character that is used to separate the entries in the $PATH environment variable.
+--
+-- > Windows: searchPathSeparator == ';'
+-- > Posix:   searchPathSeparator == ':'
+searchPathSeparator :: Char
+searchPathSeparator = if isWindows then ';' else ':'
+
+-- | Is the character a file separator?
+--
+-- > isSearchPathSeparator a == (a == searchPathSeparator)
+isSearchPathSeparator :: Char -> Bool
+isSearchPathSeparator = (== searchPathSeparator)
+
+
+-- | File extension character
+--
+-- > extSeparator == '.'
+extSeparator :: Char
+extSeparator = '.'
+
+-- | Is the character an extension character?
+--
+-- > isExtSeparator a == (a == extSeparator)
+isExtSeparator :: Char -> Bool
+isExtSeparator = (== extSeparator)
+
+
+
+
+---------------------------------------------------------------------
+-- Path methods (environment $PATH)
+
+-- | Take a string, split it on the 'searchPathSeparator' character.
+--
+-- > Windows: splitSearchPath "File1;File2;File3" == ["File1","File2","File3"]
+-- > Posix:   splitSearchPath "File1:File2:File3" == ["File1","File2","File3"]
+splitSearchPath :: String -> [FilePath]
+splitSearchPath = f
+    where
+    f xs = case break isSearchPathSeparator xs of
+           ([],  [])   -> []
+           ([],  post) -> f (tail post)
+           (pre, [])   -> [pre]
+           (pre, post) -> pre : f (tail post)
+
+-- | Get a list of filepaths in the $PATH.
+getSearchPath :: IO [FilePath]
+getSearchPath = fmap splitSearchPath (getEnv "PATH")
+
+
+---------------------------------------------------------------------
+-- Extension methods
+
+-- | Split on the extension. 'addExtension' is the inverse.
+--
+-- > uncurry (++) (splitExtension x) == x
+-- > uncurry addExtension (splitExtension x) == x
+-- > splitExtension "file.txt" == ("file",".txt")
+-- > splitExtension "file" == ("file","")
+-- > splitExtension "file/file.txt" == ("file/file",".txt")
+-- > splitExtension "file.txt/boris" == ("file.txt/boris","")
+-- > splitExtension "file.txt/boris.ext" == ("file.txt/boris",".ext")
+-- > splitExtension "file/path.txt.bob.fred" == ("file/path.txt.bob",".fred")
+-- > splitExtension "file/path.txt/" == ("file/path.txt/","")
+splitExtension :: FilePath -> (String, String)
+splitExtension x = case d of
+                       "" -> (x,"")
+                       (y:ys) -> (a ++ reverse ys, y : reverse c)
+    where
+        (a,b) = splitFileName x
+        (c,d) = break isExtSeparator $ reverse b
+
+-- | Get the extension of a file, returns @\"\"@ for no extension, @.ext@ otherwise.
+--
+-- > takeExtension x == snd (splitExtension x)
+-- > takeExtension (addExtension x "ext") == ".ext"
+-- > takeExtension (replaceExtension x "ext") == ".ext"
+takeExtension :: FilePath -> String
+takeExtension = snd . splitExtension
+
+-- | Set the extension of a file, overwriting one if already present.
+--
+-- > replaceExtension "file.txt" ".bob" == "file.bob"
+-- > replaceExtension "file.txt" "bob" == "file.bob"
+-- > replaceExtension "file" ".bob" == "file.bob"
+-- > replaceExtension "file.txt" "" == "file"
+-- > replaceExtension "file.fred.bob" "txt" == "file.fred.txt"
+replaceExtension :: FilePath -> String -> FilePath
+replaceExtension x y = dropExtension x <.> y
+
+-- | Alias to 'addExtension', for people who like that sort of thing.
+(<.>) :: FilePath -> String -> FilePath
+(<.>) = addExtension
+
+-- | Remove last extension, and the \".\" preceding it.
+--
+-- > dropExtension x == fst (splitExtension x)
+dropExtension :: FilePath -> FilePath
+dropExtension = fst . splitExtension
+
+-- | Add an extension, even if there is already one there.
+--   E.g. @addExtension \"foo.txt\" \"bat\" -> \"foo.txt.bat\"@.
+--
+-- > addExtension "file.txt" "bib" == "file.txt.bib"
+-- > addExtension "file." ".bib" == "file..bib"
+-- > addExtension "file" ".bib" == "file.bib"
+-- > addExtension "/" "x" == "/.x"
+-- > takeFileName (addExtension (addTrailingPathSeparator x) "ext") == ".ext"
+-- > Windows: addExtension "\\\\share" ".txt" == "\\\\share\\.txt"
+addExtension :: FilePath -> String -> FilePath
+addExtension file "" = file
+addExtension file xs@(x:_) = joinDrive a res
+    where
+        res = if isExtSeparator x then b ++ xs
+              else b ++ [extSeparator] ++ xs
+
+        (a,b) = splitDrive file
+
+-- | Does the given filename have an extension?
+--
+-- > null (takeExtension x) == not (hasExtension x)
+hasExtension :: FilePath -> Bool
+hasExtension = any isExtSeparator . takeFileName
+
+
+-- | Split on all extensions
+--
+-- > splitExtensions "file.tar.gz" == ("file",".tar.gz")
+splitExtensions :: FilePath -> (FilePath, String)
+splitExtensions x = (a ++ c, d)
+    where
+        (a,b) = splitFileName x
+        (c,d) = break isExtSeparator b
+
+-- | Drop all extensions
+--
+-- > not $ hasExtension (dropExtensions x)
+dropExtensions :: FilePath -> FilePath
+dropExtensions = fst . splitExtensions
+
+-- | Get all extensions
+takeExtensions :: FilePath -> String
+takeExtensions = snd . splitExtensions
+
+
+
+---------------------------------------------------------------------
+-- Drive methods
+
+-- | Is the given character a valid drive letter?
+-- only a-z and A-Z are letters, not isAlpha which is more unicodey
+isLetter :: Char -> Bool
+isLetter x = (x >= 'a' && x <= 'z') || (x >= 'A' && x <= 'Z')
+
+
+-- | Split a path into a drive and a path.
+--   On Unix, \/ is a Drive.
+--
+-- > uncurry (++) (splitDrive x) == x
+-- > Windows: splitDrive "file" == ("","file")
+-- > Windows: splitDrive "c:/file" == ("c:/","file")
+-- > Windows: splitDrive "c:\\file" == ("c:\\","file")
+-- > Windows: splitDrive "\\\\shared\\test" == ("\\\\shared\\","test")
+-- > Windows: splitDrive "\\\\shared" == ("\\\\shared","")
+-- > Windows: splitDrive "\\\\?\\UNC\\shared\\file" == ("\\\\?\\UNC\\shared\\","file")
+-- > Windows: splitDrive "\\\\?\\d:\\file" == ("\\\\?\\d:\\","file")
+-- > Windows: splitDrive "/d" == ("/","d")
+-- > Posix:   splitDrive "/test" == ("/","test")
+-- > Posix:   splitDrive "//test" == ("//","test")
+-- > Posix:   splitDrive "test/file" == ("","test/file")
+-- > Posix:   splitDrive "file" == ("","file")
+splitDrive :: FilePath -> (FilePath, FilePath)
+splitDrive x | isPosix = span (== '/') x
+
+splitDrive x | isJust y = fromJust y
+    where y = readDriveLetter x
+
+splitDrive x | isJust y = fromJust y
+    where y = readDriveUNC x
+
+splitDrive x | isJust y = fromJust y
+    where y = readDriveShare x
+
+splitDrive (x:xs) | isPathSeparator x = addSlash [x] xs
+
+splitDrive x = ("",x)
+
+addSlash :: FilePath -> FilePath -> (FilePath, FilePath)
+addSlash a xs = (a++c,d)
+    where (c,d) = span isPathSeparator xs
+
+-- http://msdn.microsoft.com/library/default.asp?url=/library/en-us/fileio/fs/naming_a_file.asp
+-- "\\?\D:\<path>" or "\\?\UNC\<server>\<share>"
+-- a is "\\?\"
+readDriveUNC :: FilePath -> Maybe (FilePath, FilePath)
+readDriveUNC (s1:s2:'?':s3:xs) | all isPathSeparator [s1,s2,s3] =
+    case map toUpper xs of
+        ('U':'N':'C':s4:_) | isPathSeparator s4 ->
+            let (a,b) = readDriveShareName (drop 4 xs)
+            in Just (s1:s2:'?':s3:take 4 xs ++ a, b)
+        _ -> case readDriveLetter xs of
+                 Just (a,b) -> Just (s1:s2:'?':s3:a,b)
+                 Nothing -> Nothing
+readDriveUNC _ = Nothing
+
+{- c:\ -}
+readDriveLetter :: String -> Maybe (FilePath, FilePath)
+readDriveLetter (x:':':y:xs) | isLetter x && isPathSeparator y = Just $ addSlash [x,':'] (y:xs)
+readDriveLetter (x:':':xs) | isLetter x = Just ([x,':'], xs)
+readDriveLetter _ = Nothing
+
+{- \\sharename\ -}
+readDriveShare :: String -> Maybe (FilePath, FilePath)
+readDriveShare (s1:s2:xs) | isPathSeparator s1 && isPathSeparator s2 =
+        Just (s1:s2:a,b)
+    where (a,b) = readDriveShareName xs
+readDriveShare _ = Nothing
+
+{- assume you have already seen \\ -}
+{- share\bob -> "share","\","bob" -}
+readDriveShareName :: String -> (FilePath, FilePath)
+readDriveShareName name = addSlash a b
+    where (a,b) = break isPathSeparator name
+
+
+
+-- | Join a drive and the rest of the path.
+--
+-- > uncurry joinDrive (splitDrive x) == x
+joinDrive :: FilePath -> FilePath -> FilePath
+joinDrive a b | isPosix = a ++ b
+              | null a = b
+              | null b = a
+              | isPathSeparator (last a) = a ++ b
+              | otherwise = case a of
+                                [a1,':'] | isLetter a1 -> a ++ b
+                                _ -> a ++ [pathSeparator] ++ b
+
+-- | Get the drive from a filepath.
+--
+-- > takeDrive x == fst (splitDrive x)
+takeDrive :: FilePath -> FilePath
+takeDrive = fst . splitDrive
+
+-- | Delete the drive, if it exists.
+--
+-- > dropDrive x == snd (splitDrive x)
+dropDrive :: FilePath -> FilePath
+dropDrive = snd . splitDrive
+
+-- | Does a path have a drive.
+--
+-- > not (hasDrive x) == null (takeDrive x)
+hasDrive :: FilePath -> Bool
+hasDrive = not . null . takeDrive
+
+
+-- | Is an element a drive
+isDrive :: FilePath -> Bool
+isDrive = null . dropDrive
+
+
+---------------------------------------------------------------------
+-- Operations on a filepath, as a list of directories
+
+-- | Split a filename into directory and file. 'combine' is the inverse.
+--
+-- > uncurry (++) (splitFileName x) == x
+-- > uncurry combine (splitFileName (makeValid x)) == (makeValid x)
+-- > splitFileName "file/bob.txt" == ("file/", "bob.txt")
+-- > splitFileName "file/" == ("file/", "")
+-- > splitFileName "bob" == ("", "bob")
+-- > Posix:   splitFileName "/" == ("/","")
+-- > Windows: splitFileName "c:" == ("c:","")
+splitFileName :: FilePath -> (String, String)
+splitFileName x = (c ++ reverse b, reverse a)
+    where
+        (a,b) = break isPathSeparator $ reverse d
+        (c,d) = splitDrive x
+
+
+-- | Set the filename.
+--
+-- > replaceFileName (makeValid x) (takeFileName (makeValid x)) == makeValid x
+replaceFileName :: FilePath -> String -> FilePath
+replaceFileName x y = dropFileName x `combine` y
+
+-- | Drop the filename.
+--
+-- > dropFileName x == fst (splitFileName x)
+dropFileName :: FilePath -> FilePath
+dropFileName = fst . splitFileName
+
+
+-- | Get the file name.
+--
+-- > takeFileName "test/" == ""
+-- > takeFileName x == snd (splitFileName x)
+-- > takeFileName (replaceFileName x "fred") == "fred"
+-- > takeFileName (combine x "fred") == "fred"
+-- > isRelative (takeFileName (makeValid x))
+takeFileName :: FilePath -> FilePath
+takeFileName = snd . splitFileName
+
+-- | Get the base name, without an extension or path.
+--
+-- > takeBaseName "file/test.txt" == "test"
+-- > takeBaseName "dave.ext" == "dave"
+-- > takeBaseName "" == ""
+-- > takeBaseName "test" == "test"
+-- > takeBaseName (addTrailingPathSeparator x) == ""
+-- > takeBaseName "file/file.tar.gz" == "file.tar"
+takeBaseName :: FilePath -> String
+takeBaseName = dropExtension . takeFileName
+
+-- | Set the base name.
+--
+-- > replaceBaseName "file/test.txt" "bob" == "file/bob.txt"
+-- > replaceBaseName "fred" "bill" == "bill"
+-- > replaceBaseName "/dave/fred/bob.gz.tar" "new" == "/dave/fred/new.tar"
+-- > replaceBaseName x (takeBaseName x) == x
+replaceBaseName :: FilePath -> String -> FilePath
+replaceBaseName pth nam = combineAlways a (addExtension nam ext)
+    where
+        (a,b) = splitFileName pth
+        ext = takeExtension b
+
+-- | Is an item either a directory or the last character a path separator?
+--
+-- > hasTrailingPathSeparator "test" == False
+-- > hasTrailingPathSeparator "test/" == True
+hasTrailingPathSeparator :: FilePath -> Bool
+hasTrailingPathSeparator "" = False
+hasTrailingPathSeparator x = isPathSeparator (last x)
+
+
+-- | Add a trailing file path separator if one is not already present.
+--
+-- > hasTrailingPathSeparator (addTrailingPathSeparator x)
+-- > if hasTrailingPathSeparator x then addTrailingPathSeparator x == x else True
+-- > Posix:    addTrailingPathSeparator "test/rest" == "test/rest/"
+addTrailingPathSeparator :: FilePath -> FilePath
+addTrailingPathSeparator x = if hasTrailingPathSeparator x then x else x ++ [pathSeparator]
+
+
+-- | Remove any trailing path separators
+--
+-- > dropTrailingPathSeparator "file/test/" == "file/test"
+-- > not (hasTrailingPathSeparator (dropTrailingPathSeparator x)) || isDrive x
+-- > Posix:    dropTrailingPathSeparator "/" == "/"
+dropTrailingPathSeparator :: FilePath -> FilePath
+dropTrailingPathSeparator x =
+    if hasTrailingPathSeparator x && not (isDrive x)
+    then reverse $ dropWhile isPathSeparator $ reverse x
+    else x
+
+
+-- | Get the directory name, move up one level.
+--
+-- > Posix:    takeDirectory "/foo/bar/baz" == "/foo/bar"
+-- > Posix:    takeDirectory "/foo/bar/baz/" == "/foo/bar/baz"
+-- > Windows:  takeDirectory "foo\\bar" == "foo"
+-- > Windows:  takeDirectory "foo\\bar\\\\" == "foo\\bar"
+-- > Windows:  takeDirectory "C:\\" == "C:\\"
+takeDirectory :: FilePath -> FilePath
+takeDirectory x = if isDrive file then file
+                  else if null res && not (null file) then file
+                  else res
+    where
+        res = reverse $ dropWhile isPathSeparator $ reverse file
+        file = dropFileName x
+
+-- | Set the directory, keeping the filename the same.
+--
+-- > replaceDirectory x (takeDirectory x) `equalFilePath` x
+replaceDirectory :: FilePath -> String -> FilePath
+replaceDirectory x dir = combineAlways dir (takeFileName x)
+
+
+-- | Combine two paths, if the second path 'isAbsolute', then it returns the second.
+--
+-- > combine (takeDirectory (makeValid x)) (takeFileName (makeValid x)) `equalFilePath` makeValid x
+-- > Posix:   combine "/" "test" == "/test"
+-- > Posix:   combine "home" "bob" == "home/bob"
+-- > Windows: combine "home" "bob" == "home\\bob"
+combine :: FilePath -> FilePath -> FilePath
+combine a b | isAbsolute b = b
+            | otherwise = combineAlways a b
+
+-- | Combine two paths, assuming rhs is NOT absolute.
+combineAlways :: FilePath -> FilePath -> FilePath
+combineAlways a b | null a = b
+                  | null b = a
+                  | isPathSeparator (last a) = a ++ b
+                  | isDrive a = joinDrive a b
+                  | otherwise = a ++ [pathSeparator] ++ b
+
+
+-- | A nice alias for 'combine'.
+(</>) :: FilePath -> FilePath -> FilePath
+(</>) = combine
+
+
+-- | Split a path by the directory separator.
+--
+-- > concat (splitPath x) == x
+-- > splitPath "test//item/" == ["test//","item/"]
+-- > splitPath "test/item/file" == ["test/","item/","file"]
+-- > splitPath "" == []
+-- > Windows: splitPath "c:\\test\\path" == ["c:\\","test\\","path"]
+-- > Posix:   splitPath "/file/test" == ["/","file/","test"]
+splitPath :: FilePath -> [FilePath]
+splitPath x = [drive | drive /= ""] ++ f path
+    where
+        (drive,path) = splitDrive x
+
+        f "" = []
+        f y = (a++c) : f d
+            where
+                (a,b) = break isPathSeparator y
+                (c,d) = break (not . isPathSeparator) b
+
+-- | Just as 'splitPath', but don't add the trailing slashes to each element.
+--
+-- > splitDirectories "test/file" == ["test","file"]
+-- > splitDirectories "/test/file" == ["/","test","file"]
+-- > joinPath (splitDirectories (makeValid x)) `equalFilePath` makeValid x
+-- > splitDirectories "" == []
+splitDirectories :: FilePath -> [FilePath]
+splitDirectories path =
+        if hasDrive path then head pathComponents : f (tail pathComponents)
+        else f pathComponents
+    where
+        pathComponents = splitPath path
+
+        f xs = map g xs
+        g x = if null res then x else res
+            where res = takeWhile (not . isPathSeparator) x
+
+
+-- | Join path elements back together.
+--
+-- > joinPath (splitPath (makeValid x)) == makeValid x
+-- > joinPath [] == ""
+-- > Posix: joinPath ["test","file","path"] == "test/file/path"
+
+-- Note that this definition on c:\\c:\\, join then split will give c:\\.
+joinPath :: [FilePath] -> FilePath
+joinPath x = foldr combine "" x
+
+
+
+
+
+
+---------------------------------------------------------------------
+-- File name manipulators
+
+-- | Equality of two 'FilePath's.
+--   If you call @System.Directory.canonicalizePath@
+--   first this has a much better chance of working.
+--   Note that this doesn't follow symlinks or DOSNAM~1s.
+equalFilePath :: FilePath -> FilePath -> Bool
+equalFilePath a b = f a == f b
+    where
+        f x | isWindows = dropTrailSlash $ map toLower $ normalise x
+            | otherwise = dropTrailSlash $ normalise x
+
+        dropTrailSlash "" = ""
+        dropTrailSlash x | isPathSeparator (last x) = init x
+                         | otherwise = x
+
+
+-- | Contract a filename, based on a relative path.
+--
+-- > Windows: makeRelative x (x `combine` y) == y || takeDrive x == x
+-- > Posix:   makeRelative x (x `combine` y) == y
+-- > (isRelative x && makeRelative y x == x) || y `combine` makeRelative y x == x
+-- > Windows: makeRelative "C:\\Home" "c:\\home\\bob" == "bob"
+-- > Windows: makeRelative "C:\\Home" "D:\\Home\\Bob" == "D:\\Home\\Bob"
+-- > Posix:   makeRelative "/Home" "/home/bob" == "/home/bob"
+-- > Posix:   makeRelative "/home/" "/home/bob/foo/bar" == "bob/foo/bar"
+-- > Posix:   makeRelative "/fred" "bob" == "bob"
+-- > Posix:   makeRelative "/file/test" "/file/test/fred" == "fred"
+-- > Posix:   makeRelative "/file/test" "/file/test/fred/" == "fred/"
+-- > Posix:   makeRelative "some/path" "some/path/a/b/c" == "a/b/c"
+makeRelative :: FilePath -> FilePath -> FilePath
+makeRelative root path
+ | not (takeDrive root `equalFilePath` takeDrive path) = path
+ | otherwise = f (dropDrive root) (dropDrive path)
+    where
+        f "" y = dropWhile isPathSeparator y
+        f x y = let (x1,x2) = g x
+                    (y1,y2) = g y
+                in if equalFilePath x1 y1 then f x2 y2 else path
+
+        g x = (dropWhile isPathSeparator a, dropWhile isPathSeparator b)
+            where (a,b) = break isPathSeparator $ dropWhile isPathSeparator x
+
+
+-- | Normalise a file
+--
+-- * \/\/ outside of the drive can be made blank
+--
+-- * \/ -> 'pathSeparator'
+--
+-- * .\/ -> \"\"
+--
+-- > Posix:   normalise "/file/\\test////" == "/file/\\test/"
+-- > Posix:   normalise "/file/./test" == "/file/test"
+-- > Posix:   normalise "/test/file/../bob/fred/" == "/test/file/../bob/fred/"
+-- > Posix:   normalise "../bob/fred/" == "../bob/fred/"
+-- > Posix:   normalise "./bob/fred/" == "bob/fred/"
+-- > Windows: normalise "c:\\file/bob\\" == "C:\\file\\bob\\"
+-- > Windows: normalise "c:\\" == "C:\\"
+-- > Windows: normalise "\\\\server\\test" == "\\\\server\\test"
+-- > Windows: normalise "c:/file" == "C:\\file"
+normalise :: FilePath -> FilePath
+normalise path = joinDrive (normaliseDrive drv) (f pth)
+              ++ [pathSeparator | not (null pth) && isPathSeparator (last pth)]
+    where
+        (drv,pth) = splitDrive path
+
+        f = joinPath . dropDots [] . splitDirectories . propSep
+
+        propSep (a:b:xs)
+         | isPathSeparator a && isPathSeparator b = propSep (a:xs)
+        propSep (a:xs)
+         | isPathSeparator a = pathSeparator : propSep xs
+        propSep (x:xs) = x : propSep xs
+        propSep [] = []
+
+        dropDots acc (".":xs) = dropDots acc xs
+        dropDots acc (x:xs) = dropDots (x:acc) xs
+        dropDots acc [] = reverse acc
+
+normaliseDrive :: FilePath -> FilePath
+normaliseDrive drive | isPosix = drive
+normaliseDrive drive = if isJust $ readDriveLetter x2
+                       then map toUpper x2
+                       else drive
+    where
+        x2 = map repSlash drive
+
+        repSlash x = if isPathSeparator x then pathSeparator else x
+
+-- | Normalise filename, same as normalise
+normalisePath :: FilePath -> FilePath
+normalisePath = normalise
+
+-- information for validity functions on Windows
+-- see http://msdn.microsoft.com/library/default.asp?url=/library/en-us/fileio/fs/naming_a_file.asp
+badCharacters :: [Char]
+badCharacters = ":*?><|"
+badElements :: [FilePath]
+badElements = ["CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9", "CLOCK$"]
+
+
+-- | Is a FilePath valid, i.e. could you create a file like it?
+--
+-- > Posix:   isValid "/random_ path:*" == True
+-- > Posix:   isValid x == True
+-- > Windows: isValid "c:\\test" == True
+-- > Windows: isValid "c:\\test:of_test" == False
+-- > Windows: isValid "test*" == False
+-- > Windows: isValid "c:\\test\\nul" == False
+-- > Windows: isValid "c:\\test\\prn.txt" == False
+-- > Windows: isValid "c:\\nul\\file" == False
+isValid :: FilePath -> Bool
+isValid _ | isPosix = True
+isValid path = not (any (`elem` badCharacters) x2) && not (any f $ splitDirectories x2)
+    where
+        x2 = dropDrive path
+        f x = map toUpper (dropExtensions x) `elem` badElements
+
+
+-- | Take a FilePath and make it valid; does not change already valid FilePaths.
+--
+-- > isValid (makeValid x)
+-- > if isValid x then makeValid x == x else True
+-- > Windows: makeValid "c:\\test:of_test" == "c:\\test_of_test"
+-- > Windows: makeValid "test*" == "test_"
+-- > Windows: makeValid "c:\\test\\nul" == "c:\\test\\nul_"
+-- > Windows: makeValid "c:\\test\\prn.txt" == "c:\\test\\prn_.txt"
+-- > Windows: makeValid "c:\\test/prn.txt" == "c:\\test/prn_.txt"
+-- > Windows: makeValid "c:\\nul\\file" == "c:\\nul_\\file"
+makeValid :: FilePath -> FilePath
+makeValid path | isPosix = path
+makeValid path = joinDrive drv $ validElements $ validChars pth
+    where
+        (drv,pth) = splitDrive path
+
+        validChars x = map f x
+        f x | x `elem` badCharacters = '_'
+            | otherwise = x
+
+        validElements x = joinPath $ map g $ splitPath x
+        g x = h (reverse b) ++ reverse a
+            where (a,b) = span isPathSeparator $ reverse x
+        h x = if map toUpper a `elem` badElements then addExtension (a ++ "_") b else x
+            where (a,b) = splitExtensions x
+
+
+-- | Is a path relative, or is it fixed to the root?
+--
+-- > Windows: isRelative "path\\test" == True
+-- > Windows: isRelative "c:\\test" == False
+-- > Posix:   isRelative "test/path" == True
+-- > Posix:   isRelative "/test" == False
+isRelative :: FilePath -> Bool
+isRelative = null . takeDrive
+
+
+-- | @not . 'isRelative'@
+--
+-- > isAbsolute x == not (isRelative x)
+isAbsolute :: FilePath -> Bool
+isAbsolute = not . isRelative
+

--- a/Files.hs
+++ b/Files.hs
@@ -1,3 +1,596 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9a095d885f48729cf312b401c6c338a925a8403767a6d24ff5e6bc41c439df6f
-size 27169
+{-# OPTIONS_GHC -cpp #-}
+----------------------------------------------------------------------------------------------------
+---- Операции с именами файлов, манипуляции с файлами на диске, ввод/вывод.                     ----
+----------------------------------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Files
+-- Copyright   :  (c) Bulat Ziganshin <Bulat.Ziganshin@gmail.com>
+-- License     :  Public domain
+--
+-- Maintainer  :  Bulat.Ziganshin@gmail.com
+-- Stability   :  experimental
+-- Portability :  GHC
+--
+-----------------------------------------------------------------------------
+
+module Files (module Files, module FilePath) where
+
+import Prelude hiding (catch)
+import Control.Concurrent
+import Control.Concurrent.MVar
+import Control.Exception
+import Control.Monad
+import Data.Array
+import Data.Bits
+import Data.Char
+import Data.Int
+import Data.IORef
+import Data.List
+import Data.Word
+import Foreign
+import Foreign.C
+import Foreign.Marshal.Alloc
+import Foreign.Marshal.Utils (fillBytes)
+#if defined(FREEARC_WIN)
+import System.Posix.Internals hiding (CFilePath, FD, sEEK_SET, sEEK_CUR, sEEK_END)
+#else
+import System.Posix.Internals hiding (CFilePath)
+#endif
+import System.Posix.Types
+import System.IO
+import System.IO.Error hiding (catch)
+import System.IO.Unsafe
+import System.Locale
+import System.Time
+import System.Process
+import System.Directory
+
+import Utils
+import FilePath
+#if defined(FREEARC_WIN)
+import Win32Files
+import System.Win32
+#else
+import System.Posix.Files hiding (fileExist)
+#endif
+
+-- |Размер одного буфера, используемый в различных операциях
+aBUFFER_SIZE = 64*kb
+
+-- |Количество байт, которые должны читаться/записываться за один раз в быстрых методах и при распаковке асимметричных алгоритмов
+aLARGE_BUFFER_SIZE = 256*kb
+
+-- |Количество байт, которые должны читаться/записываться за один раз в очень быстрых методах (storing, tornado и тому подобное)
+-- Этот объём минимизирует потери на disk seek operations - при условии, что одновременно не происходит в/в в другом потоке ;)
+aHUGE_BUFFER_SIZE = 8*mb
+
+
+----------------------------------------------------------------------------------------------------
+---- Filename manipulations ------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |True, если file находится в каталоге `dir`, одном из его подкаталогов, или совпадает с ним
+dir `isParentDirOf` file =
+  case (startFrom dir file) of
+    Just ""    -> True
+    Just (x:_) -> isPathSeparator x
+    Nothing    -> False
+
+-- |Имя файла за минусом каталога dir
+file `dropParentDir` dir =
+  case (startFrom dir file) of
+    Just ""    -> ""
+    Just (x:xs) | isPathSeparator x -> xs
+    _          -> error "Utils::dropParentDir: dir isn't prefix of file"
+
+
+#if defined(FREEARC_WIN)
+-- |Для case-insensitive файловых систем
+filenameLower = strLower
+#else
+-- |Для case-sensitive файловых систем
+filenameLower = id
+#endif
+
+-- |Return False for special filenames like "." and ".." - used to filtering results of getDirContents
+exclude_special_names s  =  (s/=".")  &&  (s/="..")
+
+-- Strip "drive:/" at the beginning of absolute filename
+stripRoot = dropDrive
+
+-- |Replace all '\' with '/'
+translatePath = map (\c -> if isPathSeparator c  then '/'  else c)
+
+-- |Filename extension, "dir/name.ext" -> "ext"
+getFileSuffix = snd . splitFilenameSuffix
+
+splitFilenameSuffix str  =  (name, drop 1 ext)
+                               where (name, ext) = splitExtension str
+
+-- "foo/bar/xyzzy.ext" -> ("foo/bar", "xyzzy.ext")
+splitDirFilename :: String -> (String,String)
+splitDirFilename str  =  case splitFileName str of
+                           x@([d,':',s], name) -> x   -- оставляем ("c:\", name)
+                           (dir, name)         -> (dropTrailingPathSeparator dir, name)
+
+-- "foo/bar/xyzzy.ext" -> ("foo/bar", "xyzzy", "ext")
+splitFilename3 :: String -> (String,String,String)
+splitFilename3 str
+   = let (dir, rest) = splitDirFilename str
+         (name, ext) = splitFilenameSuffix rest
+     in  (dir, name, ext)
+
+-- | Modify the base name.
+updateBaseName :: (String->String) -> FilePath -> FilePath
+updateBaseName f pth  =  dir </> f name <.> ext
+    where
+          (dir, name, ext) = splitFilename3 pth
+
+
+----------------------------------------------------------------------------------------------------
+---- Поиск конфиг-файлов программы и SFX модулей ---------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Найти конфиг-файл с заданным именем или возвратить ""
+findFile = findName fileExist
+findDir  = findName dirExist
+findName exist possibleFilePlaces cfgfilename = do
+  found <- possibleFilePlaces cfgfilename >>= Utils.filterM exist
+  case found of
+    x:xs -> return x
+    []   -> return ""
+
+-- |Найти конфиг-файл с заданным именем или возвратить имя для создания нового файла
+findOrCreateFile possibleFilePlaces cfgfilename = do
+  variants <- possibleFilePlaces cfgfilename
+  found    <- Utils.filterM fileExist variants
+  case found of
+    x:xs -> return x
+    []   -> return (head variants)
+
+
+#if defined(FREEARC_WIN)
+-- Под Windows все дополнительные файлы по умолчанию лежат в одном каталоге с программой
+libraryFilePlaces = configFilePlaces
+configFilePlaces filename  =  do -- dir1 <- getAppUserDataDirectory "FreeArc"
+                                 exe  <- getExeName
+                                 return [-- dir1              </> filename,
+                                         takeDirectory exe </> filename]
+
+-- |Имя исполняемого файла программы
+getExeName = do
+  allocaBytes (long_path_size*4) $ \pOutPath -> do
+    c_GetExeName pOutPath (fromIntegral long_path_size*2) >>= peekCWString
+
+foreign import ccall unsafe "Environment.h GetExeName"
+  c_GetExeName :: CWFilePath -> CInt -> IO CWFilePath
+
+#else
+-- |Места для поиска конфиг-файлов
+configFilePlaces  filename  =  do
+                                  dir1 <- getAppUserDataDirectory "FreeArc"
+                                  return [dir1   </> filename
+                                         ,"/etc/FreeArc" </> filename]
+
+-- |Места для поиска sfx-модулей
+libraryFilePlaces filename  =  return ["/usr/lib/FreeArc"       </> filename
+                                      ,"/usr/local/lib/FreeArc" </> filename]
+#endif
+
+
+----------------------------------------------------------------------------------------------------
+---- Запуск внешних программ и работа с Windows registry -------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Запустить команду через shell и возвратить её stdout
+runProgram cmd = do
+    (_, stdout, stderr, ph) <- runInteractiveCommand cmd
+    forkIO (hGetContents stderr >>= evaluate.length >> return ())
+    result <- hGetContents stdout
+    evaluate (length result)
+    waitForProcess ph
+    return result
+
+-- |Execute file `filename` in the directory `curdir` optionally waiting until it finished
+runFile filename curdir wait_finish = do
+  let p = (proc ("./" ++ filename) []) { cwd = Just curdir }
+  (_, _, _, ph) <- createProcess p
+  when wait_finish $ waitForProcess ph >> return ()
+
+
+#if defined(FREEARC_WIN)
+-- |Создать HKEY и прочитать из Registry значение типа REG_SZ
+registryGetStr root branch key =
+  bracket (regCreateKey root branch) regCloseKey
+    (\hk -> registryGetStringValue hk key)
+
+-- |Создать HKEY и записать в Registry значение типа REG_SZ
+registrySetStr root branch key val =
+  bracket (regCreateKey root branch) regCloseKey
+    (\hk -> registrySetStringValue hk key val)
+
+-- |Прочитать из Registry значение типа REG_SZ
+registryGetStringValue :: HKEY -> String -> IO (Maybe String)
+registryGetStringValue hk key = do
+  (regQueryValue hk (Just key) >>== Just)
+    `catch` (\(e::SomeException) -> return Nothing)
+
+-- |Записать в Registry значение типа REG_SZ
+registrySetStringValue :: HKEY -> String -> String -> IO ()
+registrySetStringValue hk key val =
+  withTString val $ \v ->
+  regSetValueEx hk key rEG_SZ v (length val*2)
+#endif
+
+
+#if defined(FREEARC_WIN)
+-- |OS-specific thread id
+foreign import stdcall unsafe "windows.h GetCurrentThreadId"
+  getOsThreadId :: IO DWORD
+#else
+-- |OS-specific thread id
+foreign import ccall unsafe "pthread.h pthread_self"
+  getOsThreadId :: IO Int
+#endif
+
+
+----------------------------------------------------------------------------------------------------
+---- Операции с неоткрытыми файлами и каталогами ---------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+#if defined(FREEARC_WIN)
+-- |Список дисков в системе с их типами
+getDrives = getLogicalDrives >>== unfoldr (\n -> Just (n `mod` 2, n `div` 2))
+                             >>== zipWith (\c n -> n>0 &&& [c:":"]) ['A'..'Z']
+                             >>== concat
+                             >>=  mapM (\d -> do t <- withCString d c_GetDriveType; return (d++"\t"++(driveTypes!!i t)))
+
+driveTypes = ["", ""]++split ',' "Removable,Fixed,Network,CD/DVD,Ramdisk"
+
+foreign import stdcall unsafe "windows.h GetDriveTypeA"
+  c_GetDriveType :: LPCSTR -> IO CInt
+#endif
+
+
+-- |Create a hierarchy of directories
+createDirectoryHierarchy :: FilePath -> IO ()
+createDirectoryHierarchy dir = do
+  let d = stripRoot dir
+  when (d/= "" && exclude_special_names d) $ do
+    unlessM (dirExist dir) $ do
+      createDirectoryHierarchy (takeDirectory dir)
+      dirCreate dir
+
+-- |Создать недостающие каталоги на пути к файлу
+buildPathTo filename  =  createDirectoryHierarchy (takeDirectory filename)
+
+-- |Return current directory
+getCurrentDirectory = myCanonicalizePath "."
+
+-- | Given path referring to a file or directory, returns a
+-- canonicalized path, with the intent that two paths referring
+-- to the same file\/directory will map to the same canonicalized
+-- path. Note that it is impossible to guarantee that the
+-- implication (same file\/dir \<=\> same canonicalizedPath) holds
+-- in either direction: this function can make only a best-effort
+-- attempt.
+myCanonicalizePath :: FilePath -> IO FilePath
+myCanonicalizePath fpath | isURL fpath = return fpath
+                         | otherwise   =
+#if defined(FREEARC_WIN)
+  withCFilePath fpath $ \pInPath ->
+  allocaBytes (long_path_size*4) $ \pOutPath ->
+  alloca $ \ppFilePart ->
+    do c_GetFullPathName pInPath (fromIntegral long_path_size*2) pOutPath ppFilePart
+       peekCFilePath pOutPath >>== dropTrailingPathSeparator
+
+foreign import stdcall unsafe "GetFullPathNameW"
+            c_GetFullPathName :: CWString
+                              -> CInt
+                              -> CWString
+                              -> Ptr CWString
+                              -> IO CInt
+#else
+  -- Use Haskell's canonicalizePath as a pure-Haskell replacement for C realpath
+  fmap dropTrailingPathSeparator (canonicalizePath fpath)
+#endif
+
+-- |Максимальная длина имени файла (MY_FILENAME_MAX from Common.h is 4096)
+long_path_size :: Int
+long_path_size  =  4096
+
+
+#if defined(FREEARC_WIN)
+-- |Clear file's Archive bit
+clearArchiveBit filename = do
+    attr <- getFileAttributes filename
+    when (attr.&.fILE_ATTRIBUTE_ARCHIVE /= 0) $ do
+        setFileAttributes filename (attr - fILE_ATTRIBUTE_ARCHIVE)
+#else
+clearArchiveBit _ = return ()
+#endif
+
+
+-- |Минимальное datetime, которое только может быть у файла. Соответствует 1 января 1970 г.
+aMINIMAL_POSSIBLE_DATETIME = 0 :: CTime
+
+-- |Get file's date/time
+getFileDateTime filename  =  fileWithStatus "getFileDateTime" filename stat_mtime
+
+-- |Set file's date/time
+#if defined(FREEARC_WIN)
+setFileDateTime filename datetime  =  withCFilePath filename (`c_SetFileDateTime` datetime)
+
+foreign import ccall unsafe "Environment.h SetFileDateTime"
+   c_SetFileDateTime :: CFilePath -> CTime -> IO ()
+#else
+setFileDateTime filename datetime = do
+  status <- getFileStatus filename
+  let atime = accessTime status
+  setFileTimes filename atime datetime
+#endif
+
+-- |Пребразование CTime в ClockTime. Используется информация о внутреннем представлении ClockTime в GHC!!!
+convert_CTime_to_ClockTime ctime = TOD (realToInteger ctime) 0
+  where realToInteger = round . realToFrac :: Real a => a -> Integer
+
+-- |Пребразование ClockTime в CTime
+convert_ClockTime_to_CTime (TOD secs _) = i secs
+
+-- |Текстовое представление времени
+showtime format t = formatCalendarTime defaultTimeLocale format (unsafePerformIO (toCalendarTime t))
+
+-- |Отформатировать CTime в строку с форматом "%Y-%m-%d %H:%M:%S"
+formatDateTime t  =  unsafePerformIO $ do
+  ct <- toCalendarTime (convert_CTime_to_ClockTime t)
+  return $ formatCalendarTime defaultTimeLocale "%Y-%m-%d %H:%M:%S" ct
+
+
+#if defined(FREEARC_UNIX)
+executeModes         =  [ownerExecuteMode, groupExecuteMode, otherExecuteMode]
+removeFileModes a b  =  a `intersectFileModes` (complement b)
+#endif
+
+
+----------------------------------------------------------------------------------------------------
+---- Операции с открытыми файлами ------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+--withMVar  mvar action     =  bracket (takeMVar mvar) (putMVar mvar) action
+liftMVar1  action mvar     =  withMVar mvar action
+liftMVar2  action mvar x   =  withMVar mvar (\a -> action a x)
+liftMVar3  action mvar x y =  withMVar mvar (\a -> action a x y)
+returnMVar action          =  action >>= newMVar
+
+-- |Архивный файл, заворачивается в MVar для реализации параллельного доступа из разных тредов ко входным архивам
+data Archive = Archive { archiveName :: FilePath
+                       , archiveFile :: MVar File
+                       }
+archiveOpen     name = do file <- fileOpen name >>= newMVar; return (Archive name file)
+archiveCreate   name = do file <- fileCreate name >>= newMVar; return (Archive name file)
+archiveCreateRW name = do file <- fileCreateRW name >>= newMVar; return (Archive name file)
+archiveGetPos        = liftMVar1 fileGetPos   . archiveFile
+archiveGetSize       = liftMVar1 fileGetSize  . archiveFile
+archiveSeek          = liftMVar2 fileSeek     . archiveFile
+archiveRead          = liftMVar2 fileRead     . archiveFile
+archiveReadBuf       = liftMVar3 fileReadBuf  . archiveFile
+archiveWrite         = liftMVar2 fileWrite    . archiveFile
+archiveWriteBuf      = liftMVar3 fileWriteBuf . archiveFile
+archiveClose         = liftMVar1 fileClose    . archiveFile
+
+-- |Скопировать данные из одного архива в другой и затем восстановить позицию в исходном архиве
+archiveCopyData srcarc pos size dstarc = do
+  withMVar (archiveFile srcarc) $ \srcfile ->
+    withMVar (archiveFile dstarc) $ \dstfile -> do
+      restorePos <- fileGetPos srcfile
+      fileSeek      srcfile pos
+      fileCopyBytes srcfile size dstfile
+      fileSeek      srcfile restorePos
+
+-- |При работе с одним физическим диском (наиболее частый вариант)
+-- нет смысла выполнять несколько I/O операций параллельно,
+-- поэтому мы их все проводим через "угольное ушко" одной-единственной MVar
+oneIOAtTime = unsafePerformIO$ newMVar "oneIOAtTime value"
+fileReadBuf  file buf size = withMVar oneIOAtTime $ \_ -> fileReadBufSimple  file buf size
+fileWriteBuf file buf size = withMVar oneIOAtTime $ \_ -> fileWriteBufSimple file buf size
+
+
+----------------------------------------------------------------------------------------------------
+---- URL access ------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+data File = FileOnDisk FileOnDisk | URL URL
+
+fileOpen           = choose0 fOpen           url_open
+fileCreate         = choose0 fCreate         (\_ -> err "url_create")
+fileCreateRW       = choose0 fCreateRW       (\_ -> err "url_create_rw")
+fileAppendText     = choose0 fAppendText     (\_ -> err "url_append_text")
+fileGetPos         = choose  fGetPos         (url_pos  .>>==i)
+fileGetSize        = choose  fGetSize        (url_size .>>==i)
+fileSeek           = choose  fSeek           (\f p -> url_seek f (i p))
+fileReadBufSimple  = choose  fReadBufSimple  url_read
+fileWriteBufSimple = choose  fWriteBufSimple (\_ _ _ -> err "url_write")
+fileFlush          = choose  fFlush          (\_     -> err "url_flush")
+fileClose          = choose  fClose          url_close
+
+-- |Проверяет существование файла/URL
+fileExist name | isURL name = do url <- withCString name url_open
+                                 url_close url
+                                 return (url/=nullPtr)
+               | otherwise  = fExist name
+
+-- |Проверяет, является ли имя url
+isURL name = "://" `isInfixOf` name
+
+{-# NOINLINE choose0 #-}
+choose0 onfile onurl name | isURL name = do url <- withCString name onurl
+                                            when (url==nullPtr) $ do
+                                              fail$ "Can't open url "++name   --registerError$ CANT_OPEN_FILE name
+                                            return (URL url)
+                          | otherwise  = onfile name >>== FileOnDisk
+
+choose _ onurl  (URL        url)   = onurl  url
+choose onfile _ (FileOnDisk file)  = onfile file
+
+{-# NOINLINE err #-}
+err s  =  fail$ s++" isn't implemented"    --registerError$ GENERAL_ERROR ["0343 %1 isn't implemented", s]
+
+
+type URL = Ptr ()
+foreign import ccall safe "URL.h url_setup_proxy"         url_setup_proxy         :: Ptr CChar -> IO ()
+foreign import ccall safe "URL.h url_setup_bypass_list"   url_setup_bypass_list   :: Ptr CChar -> IO ()
+foreign import ccall safe "URL.h url_open"   url_open   :: Ptr CChar -> IO URL
+foreign import ccall safe "URL.h url_pos"    url_pos    :: URL -> IO Int64
+foreign import ccall safe "URL.h url_size"   url_size   :: URL -> IO Int64
+foreign import ccall safe "URL.h url_seek"   url_seek   :: URL -> Int64 -> IO ()
+foreign import ccall safe "URL.h url_read"   url_read   :: URL -> Ptr a -> Int -> IO Int
+foreign import ccall safe "URL.h url_close"  url_close  :: URL -> IO ()
+
+
+----------------------------------------------------------------------------------------------------
+---- Под Windows мне пришлось реализовать библиотеку в/в самому для поддержки файлов >4Gb и Unicode имён файлов
+----------------------------------------------------------------------------------------------------
+#if defined(FREEARC_WIN)
+
+type FileOnDisk      = FD
+type CFilePath       = CWFilePath
+type FileAttributes  = FileAttributeOrFlag
+withCFilePath        = withCWFilePath
+peekCFilePath        = peekCWString
+fOpen       name     = wopen name (read_flags  .|. o_BINARY) 0o666
+fCreate     name     = wopen name (write_flags .|. o_BINARY .|. o_TRUNC) 0o666
+fCreateRW   name     = wopen name (rw_flags    .|. o_BINARY .|. o_TRUNC) 0o666
+fAppendText name     = wopen name (append_flags) 0o666
+fGetPos              = wtell
+fGetSize             = wfilelength
+fSeek   file pos     = wseek file pos sEEK_SET
+fReadBufSimple       = wread
+fWriteBufSimple      = wwrite
+fFlush  file         = return ()
+fClose               = wclose
+fExist               = wDoesFileExist
+fileRemove           = wunlink
+fileRename           = wrename
+fileWithStatus       = wWithFileStatus
+fileStdin            = 0
+stat_mode            = wst_mode
+stat_size            = wst_size
+stat_mtime           = wst_mtime
+dirCreate            = wmkdir
+dirExist             = wDoesDirectoryExist
+dirRemove            = wrmdir
+dirList dir          = dirWildcardList (dir </> "*")
+dirWildcardList wc   = withList $ \list -> do
+                         wfindfiles wc $ \find -> do
+                           name <- w_find_name find
+                           list <<= name
+
+#else
+
+type FileOnDisk      = Handle
+type CFilePath       = CString
+type FileAttributes  = Int
+withCFilePath s a    = (`withCString` a) =<< str2filesystem s
+peekCFilePath ptr    = peekCString ptr >>= filesystem2str
+fOpen                = (`openBinaryFile` ReadMode     ) =<<. str2filesystem
+fCreate              = (`openBinaryFile` WriteMode    ) =<<. str2filesystem
+fCreateRW            = (`openBinaryFile` ReadWriteMode) =<<. str2filesystem
+fAppendText          = (`openFile`       AppendMode   ) =<<. str2filesystem
+fGetPos              = hTell
+fGetSize             = hFileSize
+fSeek                = (`hSeek` AbsoluteSeek)
+fReadBufSimple       = hGetBuf
+fWriteBufSimple      = hPutBuf
+fFlush               = hFlush
+fClose               = hClose
+fExist               = doesFileExist =<<. str2filesystem
+fileGetStatus        = getFileStatus =<<. str2filesystem
+fileSetMode name mode= (`setFileMode` mode) =<< str2filesystem name
+fileRemove name      = removeFile    =<<  str2filesystem name
+fileRename a b       = do a1 <- str2filesystem a; b1 <- str2filesystem b; renameFile a1 b1
+fileSetSize          = hSetFileSize
+fileStdin            = stdin
+stat_mode            = st_mode
+stat_size            = st_size  .>>== i
+stat_mtime           = st_mtime
+dirCreate            = createDirectory     =<<. str2filesystem
+dirExist             = doesDirectoryExist  =<<. str2filesystem
+dirRemove            = removeDirectory     =<<. str2filesystem
+dirList dir          = str2filesystem dir >>= getDirectoryContents >>= mapM filesystem2str
+dirWildcardList wc   = dirList (takeDirectory wc)  >>==  filter (match$ takeFileName wc)
+
+-- kidnapped from System.Directory :)))
+fileWithStatus :: String -> FilePath -> (Ptr CStat -> IO a) -> IO a
+fileWithStatus loc name f = do
+  modifyIOError (`ioeSetFileName` name) $
+    allocaBytes sizeof_stat $ \p ->
+      withCFilePath name $ \s -> do
+        throwErrnoIfMinus1Retry_ loc (c_stat s p)
+	f p
+
+#endif
+
+fileRead      file size = allocaBytes size $ \buf -> do fileReadBuf file buf size; peekCStringLen (buf,size)
+fileWrite     file str  = withCStringLen str $ \(buf,size) -> fileWriteBuf file buf size
+fileGetBinary name      = bracket (fileOpen   name) fileClose (\file -> fileGetSize file >>= fileRead file . i)
+filePutBinary name str  = bracket (fileCreate name) fileClose (`fileWrite` str)
+
+-- |Скопировать заданное количество байт из одного открытого файла в другой
+fileCopyBytes srcfile size dstfile = do
+  allocaBytes aHUGE_BUFFER_SIZE $ \buf -> do        -- используем `alloca`, чтобы автоматически освободить выделенный буфер при выходе
+    doChunks size aHUGE_BUFFER_SIZE $ \bytes -> do  -- Скопировать size байт кусками по aHUGE_BUFFER_SIZE
+      bytes <- fileReadBuf srcfile buf bytes        -- Проверим, что прочитано ровно столько байт, сколько затребовано
+      fileWriteBuf dstfile buf bytes
+
+-- |True, если существует файл или каталог с заданным именем
+fileOrDirExist f  =  mapM ($f) [fileExist, dirExist] >>== or
+
+
+---------------------------------------------------------------------------------------------------
+---- Глобальные настройки перекодировки для использования в глубоко вложенных функциях ------------
+---------------------------------------------------------------------------------------------------
+
+-- |Translate filename from filesystem to internal encoding
+filesystem2str'   = unsafePerformIO$ newIORef$ id   -- 'id' means that inifiles can't have non-English names
+filesystem2str s  = val filesystem2str' >>== ($s)
+-- |Translate filename from internal to filesystem encoding
+str2filesystem'   = unsafePerformIO$ newIORef$ id
+str2filesystem s  = val str2filesystem' >>== ($s)
+
+
+---------------------------------------------------------------------------------------------------
+---- Utility functions ----------------------------------------------------------------------------
+---------------------------------------------------------------------------------------------------
+
+-- |Fill memory block with a byte value.
+-- Pure Haskell replacement for C memset using Foreign.Marshal.Utils.fillBytes.
+memset :: Ptr a -> Int -> CSize -> IO ()
+memset ptr val size = fillBytes ptr (fromIntegral val :: Word8) (fromIntegral size :: Int)
+
+-- |XOR two memory blocks: dest[i] ^= src[i] for i in [0..size-1]
+-- Pure Haskell replacement for the C memxor from Environment.cpp.
+-- Processes 8 bytes at a time using Word64 for performance, then handles any remainder byte-by-byte.
+memxor :: Ptr a -> Ptr a -> Int -> IO ()
+memxor dest src size = do
+  let w64s = size `quot` 8
+      rem8 = size `rem`  8
+  goW64 0 w64s
+  goBytes (w64s * 8) rem8
+  where
+    goW64 !k !lim
+      | k >= lim  = return ()
+      | otherwise = do
+          let off = k * 8
+          s <- peek (castPtr src  `plusPtr` off :: Ptr Word64)
+          d <- peek (castPtr dest `plusPtr` off :: Ptr Word64)
+          poke (castPtr dest `plusPtr` off :: Ptr Word64) (d `xor` s)
+          goW64 (k + 1) lim
+    goBytes !off !n
+      | n <= 0    = return ()
+      | otherwise = do
+          s <- peek (castPtr src  `plusPtr` off :: Ptr Word8)
+          d <- peek (castPtr dest `plusPtr` off :: Ptr Word8)
+          poke (castPtr dest `plusPtr` off :: Ptr Word8) (d `xor` s)
+          goBytes (off + 1) (n - 1)
+

--- a/GUI.hs
+++ b/GUI.hs
@@ -1,3 +1,884 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b1b259f45c11ea00733661b6b6bdb77808d93b6eda3620762ecd7e2bae124b80
-size 39285
+{-# OPTIONS_GHC -cpp #-}
+----------------------------------------------------------------------------------------------------
+---- Информирование пользователя о ходе выполнения программы.                                 ------
+----------------------------------------------------------------------------------------------------
+module GUI where
+
+import Prelude    hiding (catch)
+import Control.Monad
+import Control.Concurrent
+import Control.Exception
+import Data.Char  hiding (Control)
+import Data.IORef
+import Data.List
+import Data.Maybe
+import Foreign
+import Foreign.C
+import Numeric           (showFFloat)
+import System.CPUTime    (getCPUTime)
+import System.IO
+import System.Time
+
+import Graphics.UI.Gtk
+import Graphics.UI.Gtk.ModelView as New
+
+import Utils
+import Errors
+import Files
+import Charsets
+import FileInfo
+import Options
+import UIBase
+
+-- |Файл настроек программы
+aINI_FILE = "freearc.ini"
+
+-- |Файл с описанием меню и тулбара
+aMENU_FILE = "freearc.menu"
+
+-- Теги в INI-файле
+aINITAG_LANGUAGE = "language"
+aINITAG_PROGRESS = "ProgressWindowSize"
+
+-- |Каталог локализаций
+aLANG_DIR = "arc.languages"
+
+-- |Имя конфиг-файла где хранятся душераздирающие истории открытых архивов
+aHISTORY_FILE = "freearc.history"
+
+-- |Имя файла с иконкой программы
+aICON_FILE = "FreeArc.ico"
+
+-- |Фильтры для выбора архива
+aARCFILE_FILTER = ["0307 FreeArc archives (*.arc)", "0308 Archives and SFXes (*.arc;*.exe)"]
+
+
+----------------------------------------------------------------------------------------------------
+---- Отображение индикатора прогресса --------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Инициализирует Gtk и создаёт начальное окно программы
+startGUI action = runInBoundThread $ do
+  unsafeInitGUIForThreadedRTS
+  guiThread =:: getOsThreadId
+  action >>= widgetShowAll
+  mainGUI
+
+-- |Переменная, хранящая номер GUI-треда
+guiThread  =  unsafePerformIO$ newIORef$ error "undefined GUI::guiThread"
+
+-- |Инициализация GUI-части программы
+guiStartProgram = forkIO$ startGUI (fmap fst runIndicators)
+
+{-# NOINLINE runIndicators #-}
+-- |Создаёт окно индикатора прогресса и запускает тред для его периодического обновления.
+runIndicators = do
+  -- INI-файл
+  inifile  <- findFile configFilePlaces aINI_FILE
+  settings <- inifile  &&&  readConfigFile inifile >>== map (split2 '=')
+  -- Локализация.
+  langDir  <- findDir libraryFilePlaces aLANG_DIR
+  setLocale$ langDir </> (settings.$lookup aINITAG_LANGUAGE `defaultVal` aLANG_FILE)
+
+  -- Собственно окно индикатора прогресса
+  window <- windowNew
+  vbox   <- vBoxNew False 10
+  set window [windowWindowPosition := WinPosCenter,
+              containerBorderWidth := 10, containerChild := vbox]
+
+  -- Размер окна индикатора прогресса
+  let sz = settings.$lookup aINITAG_PROGRESS `defaultVal` "350 200"
+  let (w,h) = sz.$ split2 ' '
+  windowResize window (readInt w) (readInt h)
+
+  -- Разделим окно по вертикали
+  (statsBox, updateStats, clearStats) <- createStats
+  curFileLabel <- labelNew Nothing
+  curFileBox   <- hBoxNew True 0
+  boxPackStart curFileBox curFileLabel PackGrow 2
+  widgetSetSizeRequest curFileLabel 30 (-1)
+  progressBar  <- progressBarNew
+  buttonBox    <- hBoxNew True 10
+  boxPackStart vbox statsBox     PackNatural 0
+  boxPackStart vbox curFileBox   PackNatural 0
+  boxPackStart vbox progressBar  PackNatural 0
+  boxPackEnd   vbox buttonBox    PackNatural 0
+  miscSetAlignment curFileLabel 0 0    -- выровняем влево имя текущего файла
+  progressBarSetText progressBar " "   -- нужен непустой текст чтобы установить правильную высоту progressBar
+
+  -- Заполним кнопками нижнюю часть окна
+  --buttonNew window stockClose ResponseClose
+  backgroundButton <- buttonNewWithMnemonic       =<< i18n"0052   _Background  "
+  pauseButton      <- toggleButtonNewWithMnemonic =<< i18n"0053   _Pause  "
+  cancelButton     <- buttonNewWithMnemonic       =<< i18n"0081   _Cancel  "
+  boxPackStart buttonBox backgroundButton PackNatural 0
+  boxPackStart buttonBox pauseButton      PackNatural 0
+  boxPackEnd   buttonBox cancelButton     PackNatural 0
+
+  -- Обработчики событий (закрытие окна/нажатие кнопок)
+  let askProgramClose = do
+        active <- val pauseButton
+        terminationRequested <-
+            (if active then id else syncUI) $ do
+               pauseTiming $ do
+                 askYesNo window "0251 Abort operation?"
+        when terminationRequested $ do
+          pauseButton =: False
+          ignoreErrors$ terminateOperation
+
+  window `onDelete` \e -> do
+    askProgramClose
+    return True
+
+  cancelButton `onClicked` do
+    askProgramClose
+
+  pauseButton `onToggled` do
+    active <- val pauseButton
+    if active then do takeMVar mvarSyncUI
+                      pause_real_secs
+                      buttonSetLabel pauseButton =<< i18n"0054   _Continue  "
+              else do putMVar mvarSyncUI "mvarSyncUI"
+                      resume_real_secs
+                      buttonSetLabel pauseButton =<< i18n"0053   _Pause  "
+
+  backgroundButton `onClicked` do
+    windowIconify window
+
+  -- Обновляем заголовок окна, статистику и надпись индикатора прогресса раз в 0.5 секунды
+  i' <- ref 0   -- а сам индикатор прогресса раз в 0.1 секунды
+  indicatorThread 0.1 $ \indicator indType title b bytes total processed p -> postGUIAsync$ do
+    i <- val i'; i' += 1; let once_a_halfsecond = (i `mod` 5 == 0)
+    -- Заголовок окна
+    set window [windowTitle := title]                              `on` once_a_halfsecond
+    -- Статистика
+    updateStats indType b total processed                          `on` once_a_halfsecond
+    -- Прогресс-бар и надпись на нём
+    progressBarSetFraction progressBar processed                   `on` True
+    progressBarSetText     progressBar p                           `on` once_a_halfsecond
+  backgroundThread 0.5 $ postGUIAsync$ do
+    -- Имя текущего файла или стадия выполнения команды
+    uiMessage' <- val uiMessage
+    labelSetText curFileLabel uiMessage'
+
+  -- Очищает все поля с информацией о текущем архиве
+  let clearAll = do
+        set window [windowTitle := " "]
+        clearStats
+        labelSetText curFileLabel ""
+        progressBarSetFraction progressBar 0
+        progressBarSetText     progressBar " "
+
+  -- Поехали!
+  widgetGrabFocus pauseButton
+  return (window, clearAll)
+
+
+-- |Создание полей для вывода статистики
+createStats = do
+  textBox <- tableNew 4 6 False
+  labels' <- ref []
+
+  -- Создадим поля для вывода текущей статистики и нарисуем метки к ним
+  let newLabel2 x y s = do label1 <- labelNewWithMnemonic =<< i18n s
+                           tableAttach textBox label1 (x+0) (x+1) y (y+1) [Expand, Fill] [Expand, Fill] 0 0
+                           --set label1 [labelWidthChars := 25]
+                           miscSetAlignment label1 0 0
+
+                           label2 <- labelNew Nothing
+                           tableAttach textBox label2 (x+1) (x+2) y (y+1) [Expand, Fill] [Expand, Fill] 10 0
+                           set label2 [labelSelectable := True]
+                           miscSetAlignment label2 1 0
+                           labels' ++= [label2]
+                           return [label1,label2]
+      -- Возвращает только поле значения
+      newLabel x y s  =    newLabel2 x y s >>== (!!1)
+
+  newLabel 2 0 "     "        -- make space between left and right columns
+  filesLabel      <- newLabel 0 0 "0056 Files"
+  totalFilesLabel <- newLabel 3 0 "0057 Total files"
+  bytesLabel      <- newLabel 0 1 "0058 Bytes"
+  totalBytesLabel <- newLabel 3 1 "0059 Total bytes"
+  ratioLabel      <- newLabel 0 3 "0060 Ratio"
+  speedLabel      <- newLabel 3 3 "0061 Speed"
+  timesLabel      <- newLabel 0 4 "0062 Time"
+  totalTimesLabel <- newLabel 3 4 "0063 Total time"
+
+  compressed      @ [_,      compressedLabel] <- newLabel2 0 2 "0252 Compressed"
+  totalCompressed @ [_, totalCompressedLabel] <- newLabel2 3 2 "0253 Total compressed"
+  last_cmd' <- ref ""
+
+  -- Процедура, выводящая текущую статистику (indType==INDICATOR_FULL - полноценный индикатор, иначе - только проценты, например операции с RR)
+  let updateStats indType b total_b (processed :: Double) = do
+        ~UI_State { total_files = total_files
+                  , total_bytes = total_bytes
+                  , files       = files
+                  , cbytes      = cbytes
+                  , archive_total_bytes      = archive_total_bytes
+                  , archive_total_compressed = archive_total_compressed
+                  }  <-  val ref_ui_state
+        total_bytes <- return (if indType==INDICATOR_FULL  then total_bytes  else total_b)
+        -- Общее время с начала операции и момент когда начался показ текущего индикатора прогресса
+        secs <- return_real_secs
+        sec0 <- val indicator_start_real_secs
+
+        -- Для команд добавления выводится строка с Compressed/Total compressed, для остальных она скрывается
+        cmd <- val ref_command >>== cmd_name
+        let total_compressed
+              | cmdType cmd == ADD_CMD              =  "~"++show3 (total_bytes*cbytes `div` b)
+              | archive_total_bytes == total_bytes  =       show3 (archive_total_compressed)
+              | archive_total_bytes == 0            =       show3 (0)
+              | otherwise                           =  "~"++show3 (archive_total_compressed*total_bytes `div` archive_total_bytes)
+
+        labelSetMarkup filesLabel$           bold$ show3 files                                  `on` indType==INDICATOR_FULL
+        labelSetMarkup bytesLabel$           bold$ show3 b
+        labelSetMarkup compressedLabel$      bold$ show3 cbytes                                 `on` indType==INDICATOR_FULL
+        labelSetMarkup totalFilesLabel$      bold$ show3 total_files                            `on` indType==INDICATOR_FULL
+        labelSetMarkup totalBytesLabel$      bold$ show3 total_bytes
+        labelSetMarkup timesLabel$           bold$ showHMS secs
+        when (processed>0.001 && b>0 && secs-sec0>0.001) $ do
+        labelSetMarkup totalCompressedLabel$ bold$ total_compressed                             `on` indType==INDICATOR_FULL
+        labelSetMarkup ratioLabel$           bold$ ratio2 cbytes b++"%"                         `on` indType==INDICATOR_FULL
+        labelSetMarkup totalTimesLabel$      bold$ "~"++showHMS (sec0 + (secs-sec0)/processed)
+        labelSetMarkup speedLabel$           bold$ showSpeed b (secs-sec0)
+
+  -- Процедура, очищающая текущую статистику
+  let clearStats  =  val labels' >>= mapM_ (`labelSetMarkup` "     ")
+  --
+  return (textBox, updateStats, clearStats)
+
+
+-- |Вызывается в начале обработки файла
+guiStartFile = doNothing0
+
+-- |Приостановить вывод индикатора прогресса и стереть его следы
+uiSuspendProgressIndicator = do
+  aProgressIndicatorEnabled =: False
+
+-- |Возобновить вывод индикатора прогресса и вывести его текущее значение
+uiResumeProgressIndicator = do
+  aProgressIndicatorEnabled =: True
+
+-- |Приостановить индикатор (если он запущен) на время выполнения операции
+uiPauseProgressIndicator action =
+  bracket (do x <- val aProgressIndicatorEnabled
+              aProgressIndicatorEnabled =: False
+              return x)
+          (\x -> aProgressIndicatorEnabled =: x)
+          (\x -> action)
+
+-- |Reset console title
+resetConsoleTitle = return ()
+
+-- |Pause progress indicator & timing while dialog runs
+myDialogRun dialog  =  uiPauseProgressIndicator$ pauseTiming$ dialogRun dialog
+
+
+----------------------------------------------------------------------------------------------------
+---- Запросы к пользователю ("Перезаписать файл?" и т.п.) ------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+{-# NOINLINE askOverwrite #-}
+-- |Запрос о перезаписи файла
+askOverwrite filename diskFileSize diskFileTime arcfile ref_answer answer_on_u = do
+  (title:file:question) <- i18ns ["0078 Confirm File Replace",
+                                  "0165 %1\n%2 bytes\nmodified on %3",
+                                  "0162 Destination folder already contains processed file.",
+                                  "",
+                                  "",
+                                  "",
+                                  "0163 Would you like to replace the existing file",
+                                  "",
+                                  "%1",
+                                  "",
+                                  "",
+                                  "0164 with this one?",
+                                  "",
+                                  "%2"]
+  let f1 = formatn file [filename,           show3$ diskFileSize,   formatDateTime$ diskFileTime]
+      f2 = formatn file [storedName arcfile, show3$ fiSize arcfile, formatDateTime$ fiTime arcfile]
+  ask (format title filename) (formatn (joinWith "\n" question) [f1,f2]) ref_answer answer_on_u
+
+-- |Общий механизм для выдачи запросов к пользователю
+ask title question ref_answer answer_on_u =  do
+  old_answer <- val ref_answer
+  new_answer <- case old_answer of
+                  "a" -> return old_answer
+                  "u" -> return old_answer
+                  "s" -> return old_answer
+                  _   -> ask_user title question
+  ref_answer =: new_answer
+  case new_answer of
+    "u" -> return answer_on_u
+    _   -> return (new_answer `elem` ["y","a"])
+
+-- |Собственно общение с пользователем происходит здесь
+ask_user title question  =  gui $ do
+  -- Создадим диалог
+  bracketCtrlBreak "ask_user" (messageDialogNew Nothing [] MessageQuestion ButtonsNone question) widgetDestroy $ \dialog -> do
+  set dialog [windowTitle          := title,
+              windowWindowPosition := WinPosCenter]
+{-
+  -- Запрос к пользователю
+  upbox <- dialogGetUpper dialog
+  label <- labelNew$ Just$ question++"?"
+  boxPackStart  upbox label PackGrow 0
+  widgetShowAll upbox
+-}
+  -- Кнопки для всех возможных ответов
+  hbox <- dialogGetActionArea dialog
+  buttonBox <- tableNew 3 3 True
+  boxPackStart hbox buttonBox PackGrow 0
+  id' <- ref 1
+  for (zip [0..] buttons) $ \(y,line) -> do
+    for (zip [0..] (split '/' line)) $ \(x,text) -> do
+      when (text>"") $ do
+      text <- i18n text
+      button <- buttonNewWithMnemonic ("  "++text++"  ")
+      tableAttachDefaults buttonBox button x (x+1) y (y+1)
+      id <- val id'; id' += 1
+      dialogAddActionWidget dialog button (ResponseUser id)
+  widgetShowAll hbox
+
+  -- Получить ответ в виде буквы: y/n/a/...
+  (ResponseUser id) <- myDialogRun dialog
+  let answer = (split '/' valid_answers) !! (id-1)
+  when (answer=="q") $ do
+    terminateOperation
+  return answer
+
+
+-- Ответы, возвращаемые ask_user, и соответствующие им надписи на кнопках, построчно
+valid_answers = "y/n/q/a/s/u"
+buttons       = ["0079 _Yes/0080 _No/0081 _Cancel"
+                ,"0082 Yes to _All/0083 No to A_ll/0084 _Update all"]
+
+
+----------------------------------------------------------------------------------------------------
+---- Запрос паролей --------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Запрос пароля при шифровании/дешифровании. Используется невидимый ввод.
+-- При шифровании пароль надо ввести дважды - для защиты от ошибок при вводе
+ask_passwords = ( ask_password_dialog "0076 Enter encryption password" 2
+                , ask_password_dialog "0077 Enter decryption password" 1
+                , doNothing0   -- вызывается при неправильном пароле
+                )
+
+-- |Диалог запроса пароля.
+ask_password_dialog title' amount opt_parseData = gui $ do
+  -- Создадим диалог со стандартными кнопками OK/Cancel
+  bracketCtrlBreak "ask_password_dialog" dialogNew widgetDestroy $ \dialog -> do
+  title <- i18n title'
+  set dialog [windowTitle          := title,
+              windowWindowPosition := WinPosCenter]
+  okButton <- addStdButton dialog ResponseOk
+  addStdButton dialog ResponseCancel
+
+  -- Создаёт таблицу с полями для ввода одного или двух паролей
+  (pwdTable, [pwd1,pwd2]) <- pwdBox amount
+  for [pwd1,pwd2] (`onEntryActivate` buttonClicked okButton)
+
+  -- Кнопка OK срабатывает только если оба введённых пароля одинаковы
+  onClicked okButton $ do
+    p1 <- val pwd1
+    p2 <- val pwd2
+    when (p1>"" && p1==p2) $ do
+      dialogResponse dialog ResponseOk
+
+  -- Добавим пробелы вокруг таблицы и кинем её на форму
+  set pwdTable [containerBorderWidth := 10]
+  upbox <- dialogGetUpper dialog
+  boxPackStart  upbox pwdTable PackGrow 0
+  widgetShowAll upbox
+
+  choice <- myDialogRun dialog
+  if choice==ResponseOk
+    then val pwd1
+    else terminateOperation >> return ""
+
+
+{-# NOINLINE ask_passwords #-}
+
+-- |Создаёт таблицу с полями для ввода одного или двух паролей
+pwdBox amount = do
+  pwdTable <- tableNew 2 amount False
+  tableSetColSpacings pwdTable 0
+  let newField y s = do -- Надписи в левом столбце
+                        label <- labelNewWithMnemonic =<< i18n s
+                        tableAttach pwdTable label 0 1 (y-1) y [Fill] [Expand, Fill] 5 0
+                        miscSetAlignment label 0 0.5
+                        -- Поля ввода пароля в правом столбце
+                        pwd <- entryNew
+                        set pwd [entryVisibility := False, entryActivatesDefault := True]
+                        tableAttach pwdTable pwd 1 2 (y-1) y [Expand, Shrink, Fill] [Expand, Fill] 5 0
+                        return pwd
+  pwd1 <- newField 1 "0074 Enter password:"
+  pwd2 <- if amount==2  then newField 2 "0075 Reenter password:"  else return pwd1
+  return (pwdTable, [pwd1,pwd2])
+
+
+----------------------------------------------------------------------------------------------------
+---- Ввод/вывод комментариев к архиву  -------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+{-# NOINLINE uiPrintArcComment #-}
+uiPrintArcComment = doNothing
+
+{-# NOINLINE uiInputArcComment #-}
+uiInputArcComment old_comment = gui$ do
+  bracketCtrlBreak "uiInputArcComment" dialogNew widgetDestroy $ \dialog -> do
+  title <- i18n"0073 Enter archive comment"
+  set dialog [windowTitle := title,
+              windowDefaultHeight := 200, windowDefaultWidth := 400,
+              windowWindowPosition := WinPosCenter]
+  addStdButton dialog ResponseOk
+  addStdButton dialog ResponseCancel
+
+  commentTextView <- newTextViewWithText old_comment
+  upbox <- dialogGetUpper dialog
+  boxPackStart upbox commentTextView PackGrow 10
+  widgetShowAll upbox
+
+  choice <- myDialogRun dialog
+  if choice==ResponseOk
+    then textViewGetText commentTextView
+    else terminateOperation >> return ""
+
+
+----------------------------------------------------------------------------------------------------
+---- Библиотека ------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Выполнить операцию в GUI-треде
+gui action = do
+  gui <- val guiThread
+  my  <- getOsThreadId
+  if my==gui  then action else do
+  x <- ref Nothing
+  y <- postGUISync (action `catch` (\e -> do x=:Just e; return undefined))
+  whenJustM (val x) throwIO
+  return y
+
+-- |Глобальная переменная, хранящая тултипы контролов на текущей форме
+tooltips :: IORef Tooltips = unsafePerformIO$ ref$ error "undefined GUI::tooltips"
+tooltip w s = do s <- i18n s; t <- val tooltips; tooltipsSetTip t w s ""
+
+-- |Создать контрол, дав ему локализованную надпись и тултип
+i18t title create = do
+  (label, t) <- i18n' title
+  control <- create label
+  tooltip control t  `on`  t/=""
+  return control
+
+-- |This instance allows to get/set checkbox state using standard =:/val interface
+instance Variable RadioButton Bool where
+  new  = undefined
+  val  = toggleButtonGetActive
+  (=:) = toggleButtonSetActive
+
+-- |This instance allows to get/set checkbox state using standard =:/val interface
+instance Variable ToggleButton Bool where
+  new  = undefined
+  val  = toggleButtonGetActive
+  (=:) = toggleButtonSetActive
+
+-- |This instance allows to get/set checkbox state using standard =:/val interface
+instance Variable CheckButton Bool where
+  new  = undefined
+  val  = toggleButtonGetActive
+  (=:) = toggleButtonSetActive
+
+-- |This instance allows to get/set entry state using standard =:/val interface
+instance Variable Entry String where
+  new  = undefined
+  val  = entryGetText
+  (=:) = entrySetText
+
+-- |This instance allows to get/set expander state using standard =:/val interface
+instance Variable Expander Bool where
+  new  = undefined
+  val  = expanderGetExpanded
+  (=:) = expanderSetExpanded
+
+-- |This instance allows to get/set expander state using standard =:/val interface
+instance Variable TextView String where
+  new  = undefined
+  val  = textViewGetText
+  (=:) = textViewSetText
+
+-- |This instance allows to get/set value displayed by widget using standard =:/val interface
+instance GtkWidgetClass w gw a => Variable w a where
+  new  = undefined
+  val  = getValue
+  (=:) = setValue
+
+-- |Universal interface to arbitrary GTK widget `w` that controls value of type `a`
+class GtkWidgetClass w gw a | w->gw, w->a where
+  widget        :: w -> gw                 -- ^The GTK widget by itself
+  getTitle      :: w -> IO String          -- ^Read current widget's title
+  setTitle      :: w -> String -> IO ()    -- ^Set current widget's title
+  getValue      :: w -> IO a               -- ^Read current widget's value
+  setValue      :: w -> a -> IO ()         -- ^Set current widget's value
+  setOnUpdate   :: w -> (IO ()) -> IO ()   -- ^Called when user changes widget's value
+  onClick       :: w -> (IO ()) -> IO ()   -- ^Called when user clicks button
+  saveHistory   :: w -> IO ()
+  rereadHistory :: w -> IO ()
+
+data GtkWidget gw a = GtkWidget
+ {gwWidget        :: gw
+ ,gwGetTitle      :: IO String
+ ,gwSetTitle      :: String -> IO ()
+ ,gwGetValue      :: IO a
+ ,gwSetValue      :: a -> IO ()
+ ,gwSetOnUpdate   :: (IO ()) -> IO ()
+ ,gwOnClick       :: (IO ()) -> IO ()
+ ,gwSaveHistory   :: IO ()
+ ,gwRereadHistory :: IO ()
+ }
+
+instance GtkWidgetClass (GtkWidget gw a) gw a where
+  widget        = gwWidget
+  getTitle      = gwGetTitle
+  setTitle      = gwSetTitle
+  getValue      = gwGetValue
+  setValue      = gwSetValue
+  setOnUpdate   = gwSetOnUpdate
+  onClick       = gwOnClick
+  saveHistory   = gwSaveHistory
+  rereadHistory = gwRereadHistory
+
+-- |Пустой GtkWidget
+gtkWidget = GtkWidget { gwWidget        = undefined
+                      , gwGetTitle      = undefined
+                      , gwSetTitle      = undefined
+                      , gwGetValue      = undefined
+                      , gwSetValue      = undefined
+                      , gwSetOnUpdate   = undefined
+                      , gwOnClick       = undefined
+                      , gwSaveHistory   = undefined
+                      , gwRereadHistory = undefined
+                      }
+
+-- Использовать жирный Pango Markup для переданного текста
+bold text = "<b>"++text++"</b>"
+
+
+{-# NOINLINE eventKey #-}
+-- |Возвращает полное имя клавиши, например <Alt><Ctrl>M
+eventKey (Key {eventKeyName = name, eventModifier = modifier}) =
+  let mshow Shift   = "<Shift>"
+      mshow Control = "<Ctrl>"
+      mshow Alt     = "<Alt>"
+      mshow _       = "<_>"
+  --
+  in concat ((sort$ map mshow modifier)++[mapHead toUpper name])
+
+
+{-# NOINLINE addStdButton #-}
+-- |Добавить к диалогу стандартную кнопку со стандартной иконкой
+addStdButton dialog responseId = do
+  let (emsg,item) = case responseId of
+                      ResponseYes    -> ("0079 _Yes",    stockYes         )
+                      ResponseNo     -> ("0080 _No",     stockNo          )
+                      ResponseOk     -> ("0362 _OK",     stockOk          )
+                      ResponseCancel -> ("0081 _Cancel", stockCancel      )
+                      ResponseClose  -> ("0364 _Close",  stockClose       )
+                      _              -> ("???",          stockMissingImage)
+  msg <- i18n emsg
+  button <- dialogAddButton dialog msg responseId
+  image  <- imageNewFromStock item iconSizeButton
+  buttonSetImage button image
+  return button
+
+
+{-# NOINLINE debugMsg #-}
+-- |Диалог с отладочным сообщением
+debugMsg msg = do
+  bracketCtrlBreak "debugMsg" (messageDialogNew (Nothing) [] MessageError ButtonsClose msg) widgetDestroy $ \dialog -> do
+  dialogRun dialog
+  return ()
+
+-- |Диалог с информационным сообщением
+msgBox window dialogType msg  =  askConfirmation [ResponseClose] window msg  >>  return ()
+
+-- |Запросить у пользователя подтверждение операции
+askOkCancel = askConfirmation [ResponseOk,  ResponseCancel]
+askYesNo    = askConfirmation [ResponseYes, ResponseNo]
+{-# NOINLINE askConfirmation #-}
+askConfirmation buttons window msg = do
+  -- Создадим диалог с единственной кнопкой Close
+  bracketCtrlBreak "askConfirmation" dialogNew widgetDestroy $ \dialog -> do
+    set dialog [windowTitle        := aARC_NAME,
+                windowTransientFor := window,
+                containerBorderWidth := 10]
+    mapM_ (addStdButton dialog) buttons
+    -- Напечатаем в нём сообщение
+    label <- labelNew.Just =<< i18n msg
+    upbox <- dialogGetUpper dialog
+    label `set` [labelWrap := True]
+    boxPackStart  upbox label PackGrow 20
+    widgetShowAll upbox
+    -- И запустим
+    dialogRun dialog >>== (==buttons!!0)
+
+{-# NOINLINE inputString #-}
+-- |Запросить у пользователя строку
+inputString window msg = do
+  -- Создадим диалог со стандартными кнопками OK/Cancel
+  bracketCtrlBreak "inputString" dialogNew widgetDestroy $ \dialog -> do
+    set dialog [windowTitle        := msg,
+                windowTransientFor := window]
+    addStdButton dialog ResponseOk      >>= \okButton -> do
+    addStdButton dialog ResponseCancel
+
+    --label    <- labelNew$ Just msg
+    entry <- entryNew
+    entry `onEntryActivate` buttonClicked okButton
+
+    upbox <- dialogGetUpper dialog
+    --boxPackStart  upbox label    PackGrow 0
+    boxPackStart  upbox entry PackGrow 0
+    widgetShowAll upbox
+
+    choice <- dialogRun dialog
+    case choice of
+      ResponseOk -> val entry >>== Just
+      _          -> return Nothing
+
+
+{-# NOINLINE boxed #-}
+-- |Создать control и поместить его в hbox
+boxed makeControl title = do
+  hbox    <- hBoxNew False 0
+  control <- makeControl .$i18t title
+  boxPackStart  hbox  control  PackNatural 0
+  return (hbox, control)
+
+
+{-# NOINLINE label #-}
+-- |Метка
+label title   =  do (hbox, _) <- boxed labelNewWithMnemonic title
+                    return gtkWidget {gwWidget = hbox}
+
+
+{-# NOINLINE button #-}
+-- |Кнопка
+button title  =  do
+  (hbox, control) <- boxed buttonNewWithMnemonic title
+  return gtkWidget { gwWidget   = hbox
+                   , gwOnClick  = \action -> onClicked control action >> return ()
+                   , gwSetTitle = buttonSetLabel control
+                   , gwGetTitle = buttonGetLabel control
+                   }
+
+
+{-# NOINLINE checkBox #-}
+-- |Чекбокс
+checkBox title = do
+  (hbox, control) <- boxed checkButtonNewWithMnemonic title
+  return gtkWidget { gwWidget      = hbox
+                   , gwGetValue    = val control
+                   , gwSetValue    = (control=:)
+                   , gwSetOnUpdate = \action -> onToggled control action >> return ()
+                   }
+
+
+{-# NOINLINE comboBox #-}
+-- |Создаёт комбобокс, содержащий заданный набор альтернатив
+comboBox title labels = do
+  hbox  <- hBoxNew False 0
+  label <- labelNewWithMnemonic .$i18t title
+  combo <- New.comboBoxNewText
+  for labels (\l -> New.comboBoxAppendText combo =<< i18n l)
+  boxPackStart  hbox  label  PackNatural 5
+  boxPackStart  hbox  combo  PackNatural 5
+  return gtkWidget { gwWidget      = hbox
+                   , gwGetValue    = New.comboBoxGetActive combo >>== fromMaybe 0
+                   , gwSetValue    = New.comboBoxSetActive combo
+                   }
+
+
+{-# NOINLINE simpleComboBox #-}
+-- |Создаёт комбобокс, содержащий заданный набор альтернатив
+simpleComboBox labels = do
+  combo <- New.comboBoxNewText
+  for labels (New.comboBoxAppendText combo)
+  return combo
+
+{-# NOINLINE makePopupMenu #-}
+-- |Создаёт popup menu
+makePopupMenu action labels = do
+  m <- menuNew
+  mapM_ (mkitem m) labels
+  return m
+    where
+        mkitem menu label =
+            do i <- menuItemNewWithLabel label
+               menuShellAppend menu i
+               i `onActivateLeaf` (action label)
+
+
+
+{-# NOINLINE radioFrame #-}
+-- |Создаёт фрейм, содержащий набор радиокнопок и возвращает этот фрейм
+--  плюс процедуру для чтения текущей выбранной кнопки
+radioFrame title (label1:labels) = do
+  -- Создать радио-кнопки, объединив их в одну группу
+  radio1 <- radioButtonNewWithMnemonic .$i18t label1
+  radios <- mapM (\title -> radioButtonNewWithMnemonicFromWidget radio1 .$i18t title) labels
+  let buttons = radio1:radios
+  -- Упаковать их вертикально и заставить выполнять событие, запомненное в переменной onChanged
+  vbox <- vBoxNew False 0
+  onChanged <- ref doNothing0
+  for buttons $ \button -> do boxPackStart vbox button PackNatural 0
+                              button `onToggled` do
+                                whenM (val button) $ do
+                                  val onChanged >>= id
+  -- Создать рамочку вокруг кнопок
+  frame <- i18t title $ \title -> do
+             frame <- frameNew
+             set frame [frameLabel := title.$ deleteIf (=='_'), containerChild := vbox]
+             return frame
+  return gtkWidget { gwWidget      = frame
+                   , gwGetValue    = foreach buttons val >>== fromJust.elemIndex True
+                   , gwSetValue    = \i -> (buttons!!i) =: True
+                   , gwSetOnUpdate = (onChanged=:)
+                   }
+
+
+{-# NOINLINE twoColumnTable #-}
+-- |Двухколоночная таблица, отображающая заданные метки+данные
+twoColumnTable dataset = do
+  (table, setLabels) <- emptyTwoColumnTable$ map fst dataset
+  zipWithM_ ($) setLabels (map snd dataset)
+  return table
+
+{-# NOINLINE emptyTwoColumnTable #-}
+-- |Двухколоночная таблица: принимает список меток для левой колонки
+-- и возвращает список операций setLabels для помещения данных во вторую колонку
+emptyTwoColumnTable dataset = do
+  table <- tableNew (length dataset) 2 False
+  -- Создадим поля для вывода текущей статистики и нарисуем метки к ним
+  setLabels <- foreach (zip [0..] dataset) $ \(y,s) -> do
+      -- Первая колонка
+      label <- labelNewWithMnemonic =<< i18n s;  let x=0
+      tableAttach table label (x+0) (x+1) y (y+1) [Expand, Fill] [Expand, Fill] 0 0
+      miscSetAlignment label 0 0     --set label [labelWidthChars := 25]
+      -- Вторая колонка
+      label <- labelNew Nothing
+      tableAttach table label (x+1) (x+2) y (y+1) [Expand, Fill] [Expand, Fill] 10 0
+      set label [labelSelectable := True]
+      miscSetAlignment label 1 0
+      -- Возвратим операцию, устанавливающую текст второй метки (предназначенной для вывода данных)
+      return$ \text -> labelSetMarkup label$ bold$ text
+  return (table, setLabels)
+
+{-# NOINLINE scrollableTextView #-}
+-- |Прокручиваемый TextView
+scrollableTextView s attributes = do
+  control <- newTextViewWithText s
+  set control attributes
+  -- Scrolled window where the TextView will be placed
+  scrwin <- scrolledWindowNew Nothing Nothing
+  scrolledWindowSetPolicy scrwin PolicyAutomatic PolicyAutomatic
+  containerAdd scrwin control
+  return gtkWidget { gwWidget   = scrwin
+                   , gwGetValue = val control
+                   , gwSetValue = (control=:)
+                   }
+
+-- |Создаёт новый объект TextView с заданным текстом
+newTextViewWithText s = do
+  textView <- textViewNew
+  textViewSetText textView s
+  return textView
+
+-- |Задаёт текст, отображаемый в TextView
+textViewSetText textView s = do
+  buffer <- textViewGetBuffer textView
+  textBufferSetText buffer s
+
+-- |Считывает текст, отображаемый в TextView
+textViewGetText textView = do
+  buffer <- textViewGetBuffer      textView
+  start  <- textBufferGetStartIter buffer
+  end    <- textBufferGetEndIter   buffer
+  textBufferGetText buffer start end False
+
+
+----------------------------------------------------------------------------------------------------
+---- Выбор файла -----------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+#if defined(FREEARC_WIN)
+
+{-# NOINLINE chooseFile #-}
+-- |Выбор файла через диалог
+chooseFile parentWindow dialogType dialogTitle filters getFilename setFilename = do
+  title <- i18n dialogTitle
+  filename <- getFilename >>== windosifyPath
+  -- Строка фильтров состоит из пар (название,шаблоны), разделённых NULL char, плюс дополнительный NULL char в конце
+  filterStr <- prepareFilters filters >>== map (join2 "\0") >>== joinWith "\0" >>== (++"\0")
+  withCFilePath title            $ \c_prompt   -> do
+  withCFilePath filename         $ \c_filename -> do
+  withCFilePath filterStr        $ \c_filters  -> do
+  allocaBytes (long_path_size*4) $ \c_outpath  -> do
+    result <- case dialogType of
+                FileChooserActionSelectFolder  ->  c_BrowseForFolder c_prompt c_filename c_outpath
+                _                              ->  c_BrowseForFile   c_prompt c_filters c_filename c_outpath
+    when (result/=0) $ do
+       setFilename =<< peekCFilePath c_outpath
+
+foreign import ccall safe "Environment.h BrowseForFolder"  c_BrowseForFolder :: CFilePath -> CFilePath -> CFilePath -> IO CInt
+foreign import ccall safe "Environment.h BrowseForFile"    c_BrowseForFile   :: CFilePath -> CFilePath -> CFilePath -> CFilePath -> IO CInt
+
+
+guiFormatDateTime t = unsafePerformIO $ do
+  allocaBytes 1000 $ \buf -> do
+  c_GuiFormatDateTime t buf 1000 nullPtr nullPtr
+  peekCString buf
+
+foreign import ccall safe "Environment.h GuiFormatDateTime"
+  c_GuiFormatDateTime :: CTime -> CString -> CInt -> CString -> CString -> IO ()
+
+#else
+
+{-# NOINLINE chooseFile #-}
+-- |Выбор файла через диалог
+chooseFile parentWindow dialogType dialogTitle filters getFilename setFilename = do
+  title <- i18n dialogTitle
+  filename <- getFilename
+  [select,cancel] <- i18ns ["0363 _Select", "0081 _Cancel"]
+  bracketCtrlBreak "chooseFile" (fileChooserDialogNew (Just title) (Just$ castToWindow parentWindow) dialogType [(select,ResponseOk), (cancel,ResponseCancel)]) widgetDestroy $ \chooserDialog -> do
+    fileChooserSetFilename chooserDialog (unicode2utf8 filename)
+    case dialogType of
+      FileChooserActionSave -> fileChooserSetCurrentName chooserDialog (takeFileName filename)
+      _                     -> fileChooserSetFilename    chooserDialog (unicode2utf8 filename++"/non-existing-file") >> return ()
+    prepareFilters filters >>= addFilters chooserDialog
+    choice <- dialogRun chooserDialog
+    when (choice==ResponseOk) $ do
+      whenJustM_ (fileChooserGetFilename chooserDialog) $ \filename -> do
+        setFilename (utf8_to_unicode filename)
+
+{-# NOINLINE addFilters #-}
+-- |Установить фильтры для выбора файла
+addFilters chooserDialog filters = do
+  for filters $ \(text, patterns) -> do
+    filt <- fileFilterNew
+    fileFilterSetName filt text
+    for (patterns.$ split ';')  (fileFilterAddPattern filt)
+    fileChooserAddFilter chooserDialog filt
+
+guiFormatDateTime = formatDateTime
+
+#endif
+
+
+-- |Подготовить фильтры к использованию в диалоге
+prepareFilters filters = do
+  foreach (filters &&& filters++["0309 All files (*)"]) $ \element -> do
+    text <- i18n element
+    let patterns = text .$words .$last .$drop 1 .$dropEnd 1
+    return (text, patterns)
+

--- a/HashTable.hs
+++ b/HashTable.hs
@@ -1,3 +1,35 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ee08496f710e6dffe256d44a73f2447902f3275be3d131ff9e20e94016ee94aa
-size 1118
+{-# LANGUAGE CPP #-}
+-- |Compatibility shim for the removed Data.HashTable module.
+-- Implements a mutable hash table using an IORef-backed association list,
+-- preserving support for arbitrary equality predicates.
+module HashTable
+  ( HashTable
+  , new
+  , lookup
+  , insert
+  ) where
+
+import Prelude hiding (lookup)
+import Data.IORef
+import Data.Int (Int32)
+
+-- |Mutable hash table backed by an association list, storing the equality predicate.
+data HashTable k v = HashTable (k -> k -> Bool) (IORef [(k, v)])
+
+-- |Create a new empty hash table.
+new :: (k -> k -> Bool) -> (k -> Int32) -> IO (HashTable k v)
+new eq _hash = HashTable eq <$> newIORef []
+
+-- |Look up a key in the hash table using the equality predicate supplied to 'new'.
+lookup :: HashTable k v -> k -> IO (Maybe v)
+lookup (HashTable eq ref) key = do
+  xs <- readIORef ref
+  return (go xs)
+  where
+    go []           = Nothing
+    go ((k,v):rest) = if eq key k then Just v else go rest
+
+-- |Insert a key-value pair into the hash table.
+insert :: HashTable k v -> k -> v -> IO ()
+insert (HashTable _eq ref) key val =
+  modifyIORef ref ((key, val) :)

--- a/Installer/arc.languages/7tr.hs
+++ b/Installer/arc.languages/7tr.hs
@@ -1,3 +1,314 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bcb2a929c371c797e0080d31e5b01a66e39c1aad9b4f7df632f800aba0c37751
-size 11037
+{-# LANGUAGE CPP #-}
+import Data.Char
+import Data.List
+import Data.Maybe
+import System.Environment
+
+-- "7tr arc.russian.txt pl.txt" translates 7-zip language file pl.txt
+--   into the FreeArc language file arc.polish.txt
+-- "7tr arc.russian.txt pl.txt dir\arc.polish.txt" translates 7-zip language file pl.txt
+--   and old FreeArc language file dir\arc.polish.txt into the new FreeArc language file arc.polish.txt
+main = do (my:szip:old) <- getArgs
+          dict    <-  readFile szip >>= return.makeDict
+          oldLang <-  if null old then return []
+                                  else readFile (head old) >>= return.makeOldLang
+          let lang = dict .$lookup "00000000" .$fromMaybe "_New" .$replace ' ' '_' .$map toLower
+              out  = "arc."++lang++".txt"
+          readFile my >>= writeFile out.unlines.map (makeLine dict oldLang).lines
+
+-- |Сообразить словарь из файла национализации 7-zip
+makeDict x = ("copyright", c): xs
+  where l  = x .$ lines
+        xs = l .$ map (split2 '=')
+               .$ map (\(key,str) -> (trim key, drop 1 $dropEnd 1 $trim str))
+        c = l .$drop 2 .$takeWhile ((";"==).take 1) .$map (dropWhile isSpace.drop 1) .$filter (not.null) .$joinWith "\\n"
+
+-- |Сообразить словарь из старого файла национализации FreeArc
+makeOldLang x = x .$ lines
+                  .$ filter (\s -> length s > 4  &&  s `contains` '=')
+                  .$ filter (all isDigit.take 4)
+                  .$ map    (split2 '=')
+                  .$ filter (("??"/=).snd)
+                  .$ map    (\(a,b) -> (take 4 a, b))
+
+-- |Преобразовать строку x в язык, описанный в dict
+makeLine dict oldLang x =
+  case x.$ split2 '=' of
+    (x,xs) | (n,eng) <- split2 ' ' x,
+             length n==4, all isDigit n
+       -> x++"="++(n `lookup` oldLang `defaultVal`
+                   makeSubst dict n .$replaceAll "{0}" "%1" .$replaceAll "{1}" "%2")
+    _  -> x
+
+makeSubst dict n = case n of
+  "0000" -> d "00000000"++" ("++d "00000001"++")"
+  "0159" -> "Automatic translation from 7-Zip language file.\\nPlease edit it to finish translation.\\nOriginal copyrights:\\n"++d "copyright"
+  "0022" ->(d "02000301".$replaceAll "{0}" "{1}")++", "++d "02000982"
+  "0023" ->(d "02000302".$replaceAll "{0}" "{1}")++", "++d "02000982"
+  "0020" -> d "03020215".$replaceAll "{0}" "{1}"
+  "0019" -> d "03020215".$replaceAll "{0}" "{1}"
+  "0114" -> d "02000D0B"++" %1"
+  "0115" -> d "02000D0E"++" %2, "++d "02000C04"++" %1"
+  "0116" -> d "02000D0F"++" %2, "++d "02000C04"++" %1"
+  "0024" -> d "02000800"++" %3"
+  "0152" -> d "02000109"++" %3"
+  "0172" ->(d "03010302".$tryToSkipAtEnd ":" .$replaceAll "7-Zip" "FreeArc" .$replaceAll "7-zip" "FreeArc") ++ " .arc"
+  "0165" -> "%1\\n"++(d "02000982".$replaceAll "{0}" "%2")++"\\n"++d "02000983"++" %3"
+  _      -> d (trans .$lookup n .$fromMaybe ":(")
+  where d n = dict .$lookup n .$fromMaybe "??"
+
+-- |Трансляция номеров сообщений из FreeArc в 7-zip
+trans = map (split2 ' ')
+        ["0050 03000102"
+        ,"0066 03000103"
+        ,"0259 03000105"
+        ,"0260 02000D07"
+        ,"0261 03000106"
+
+        ,"0262 02000103"
+        ,"0263 03000330"
+        ,"0008 03000333"
+        ,"0009 03000334"
+        ,"0037 03020250"
+        ,"0038 03020251"
+        ,"0264 03000332"
+        ,"0039 03000440"
+        ,"0036 03000260"
+
+        ,"0030 03020400"
+        ,"0040 02000108"
+        ,"0033 03000233"
+        ,"0034 03020402"
+        ,"0044 0200010A"
+        ,"0086 03020423"
+        ,"0035 03020401"
+        ,"0045 02000106"
+        ,"0064 03010400"
+
+        ,"0268 03020290"
+        ,"0272 02000D10"
+
+
+        ,"0015 02000204"
+        ,"0016 02000207"
+        ,"0017 0200020C"
+        ,"0018 02000140"
+
+        ,"0134 02000108"
+        ,"0135 02000108"
+        ,"0136 02000108"
+
+        ,"0107 02000D0B"
+        ,"0129 02000D04"
+        ,"0108 02000D83"
+        ,"0110 02000D82"
+        ,"0111 02000D84"
+        ,"0112 02000D85"
+        ,"0137 02000D13"
+        ,"0138 02000322"
+        ,"0139 02000320"
+
+        ,"0119 02000D10"
+        ,"0120 02000D0A"
+        ,"0121 02000D11"
+        ,"0131 02000D01"
+
+        ,"0160 03020213"
+        ,"0161 03020213"
+
+        ,"0005 02000820"
+        ,"0001 02000821"
+        ,"0002 02000822"
+        ,"0051 02000823"
+        ,"0004 02000801"
+        ,"0021 02000881"
+
+        ,"0088 02000320"
+        ,"0089 02000C03"
+        ,"0090 02000323"
+        ,"0091 02000C06"
+        ,"0099 02000D0E"
+        ,"0100 02000D0F"
+        ,"0105 02000D0C"
+        ,"0156 02000D0A"
+        ,"0097 02000D11"
+        ,"0098 03020291"
+
+        ,"0067 03010400"
+        ,"0068 01000401"
+        ,"0069 03000221"
+        ,"0292 03000220"
+
+        ,"0079 02000705"
+        ,"0080 02000709"
+        ,"0081 02000711"
+        ,"0362 02000702"
+        ,"0364 02000713"
+
+        ,"0052 02000C10"
+        ,"0053 02000C12"
+        ,"0054 02000C13"
+
+        ,"0056 02000320"
+        ,"0058 02000C05"
+        ,"0059 02000C03"
+        ,"0252 02000323"
+        ,"0060 02000C06"
+        ,"0061 02000C04"
+        ,"0062 02000C01"
+
+        ,"0078 02000900"
+        ,"0162 02000901"
+        ,"0163 02000902"
+        ,"0164 02000903"
+        ,"0082 02000707"
+        ,"0083 0200070B"
+
+        ,"0076 02000B00"
+        ,"0077 02000B00"
+        ,"0074 02000B01"
+        ,"0075 02000B03"
+
+        ,"0173 02000321"
+        ,"0184 02000D10"
+        ,"0183 03080002"
+        ,"0106 03080002"
+        ,"0186 03020291"
+        ,"0227 02000D08"
+        ,"0199 03020290"
+        ,"0221 02000830"
+
+        ,"0194 02000D02"
+        ,"0195 02000DA1"
+        ,"0196 02000DA2"
+        ,"0197 02000DA3"
+        ,"0198 02000DA4"
+        ]
+
+
+---------------------------------------------------------------------------------------------------
+---- Операции над строками ------------------------------------------------------------------------
+---------------------------------------------------------------------------------------------------
+
+-- |Соединить список строк в единый текст с разделителем: "one, two, three"
+joinWith :: [a] -> [[a]] -> [a]
+joinWith x  =  concat . intersperse x
+
+-- |Разбить строку на две подстроки, разделённые заданным символом
+split2 :: (Eq a) => a -> [a] -> ([a],[a])
+split2 c s  =  (chunk, drop 1 rest)
+  where (chunk, rest) = break (==c) s
+
+contains a b = elem b a
+
+-- |Удалить n элементов в конце спсика
+dropEnd n  =  reverse . drop n . reverse
+
+-- |Истина, если `s` содержит хотя бы один из элементов множества `set`
+s `contains_one_of` set  =  any (`elem` set) s
+
+-- |Последние n элементов
+n `lastElems` xs  =  drop (length xs - n) xs
+
+-- |Заменить n'й элемент (считая с 0) в списке `xs` на `x`
+replaceAt n x xs  =  hd ++ x : drop 1 tl
+    where (hd,tl) = splitAt n xs
+
+-- |Изменить n'й элемент (считая с 0) в списке `xs` с `x` на `f x`
+updateAt n f xs  =  hd ++ f x : tl
+    where (hd,x:tl) = splitAt n xs
+
+-- |Заменить в списке все вхождения элемента 'from' на 'to'
+replace from to  =  map (\x -> if x==from  then to  else x)
+
+-- |Если первая строка является префиксом второй - возвратить остаток второй строки, иначе Nothing
+startFrom (x:xs) (y:ys) | x==y  =  startFrom xs ys
+startFrom [] str                =  Just str
+startFrom _  _                  =  Nothing
+
+-- |Проверка, что строка начинается или заканчивается заданными символами
+beginWith s = isJust . startFrom s
+endWith   s = beginWith (reverse s) . reverse
+
+-- |Попытаемся удалить строку substr в начале str
+tryToSkip substr str  =  (startFrom substr str) `defaultVal` str
+
+-- |Попытаться удалить строку substr в конце str
+tryToSkipAtEnd substr str = reverse (tryToSkip (reverse substr) (reverse str))
+
+-- | The 'isInfixOf' function takes two lists and returns 'True'
+-- if the second list is contained, wholy and intact,
+-- anywhere within the first.
+substr haystack needle  =  any (needle `isPrefixOf`) (tails haystack)
+
+-- |Список позиций подстроки в строке
+strPositions haystack needle  =  elemIndices True$ map (needle `isPrefixOf`) (tails haystack)
+
+-- |Заменить в строке `s` все вхождения `from` на `to`
+replaceAll from to = repl
+  where repl s      | Just remainder <- startFrom from s  =  to ++ repl remainder
+        repl (c:cs)                                       =  c : repl cs
+        repl []                                           =  []
+
+-- |Заменить %1 на заданную строку
+format msg s  =  replaceAll "%1" s msg
+
+-- |Заменить %1..%9 на заданные строки
+formatn msg s  =  go msg
+  where go ('%':d:rest) | isDigit d = (s !! (digitToInt d-1)) ++ go rest
+        go (x:rest)                 = x : go rest
+        go ""                       = ""
+
+-- |Заменить в строке `s` префикс `from` на `to`
+replaceAtStart from to s =
+  case startFrom from s of
+    Just remainder  -> to ++ remainder
+    Nothing         -> s
+
+-- |Заменить в строке `s` суффикс `from` на `to`
+replaceAtEnd from to s =
+  case startFrom (reverse from) (reverse s) of
+    Just remainder  -> reverse remainder ++ to
+    Nothing         -> s
+
+-- |Выровнять строку влево/вправо, дополнив её до заданной ширины пробелами или чем-нибудь ещё
+right_fill  c n s  =  s ++ replicate (n-length s) c
+left_fill   c n s  =  replicate (n-length s) c ++ s
+left_justify       =  right_fill ' '
+right_justify      =  left_fill  ' '
+
+-- Удалить пробелы в начале/конце строки или по обоим сторонам
+trimLeft  = dropWhile (==' ')
+trimRight = reverse.trimLeft.reverse
+trim      = trimLeft.trimRight
+
+-- |Перевести строку в нижний регистр
+strLower = map toLower
+
+-- |Сравнить две строки, игнорируя регистр
+strLowerEq a b  =  strLower a == strLower b
+
+-- |Map various parts of list
+mapHead f []      =  []
+mapHead f (x:xs)  =  f x : xs
+
+mapTail f []      =  []
+mapTail f (x:xs)  =  x : map f xs
+
+mapInit f []      =  []
+mapInit f xs      =  map f (init xs) : last xs
+
+mapLast f []      =  []
+mapLast f xs      =  init xs ++ [f (last xs)]
+
+{-# NOINLINE replaceAll #-}
+{-# NOINLINE replaceAtEnd #-}
+
+
+
+-- |Заменить Nothing на значение по умолчанию
+defaultVal = flip fromMaybe
+
+infixl 9  .$
+a.$b         =  b a                -- вариант $ с перевёрнутым порядком аргументов
+

--- a/Installer/buildList.hs
+++ b/Installer/buildList.hs
@@ -1,3 +1,23 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6e41f27eafb1c9dc26f6da280742181dcf3bd1a1a2bd15fc6faa06cdcdb49b63
-size 785
+-- Build list of files/dirs in FreeArc installation for uninstall/clear before install procedures
+
+import Data.List
+import System.Cmd
+import System.Directory
+import System.Environment
+
+main = do
+  args <- getArgs
+  let dir = case args of
+              []    -> "C:\\Program Files (x86)\\FreeArc"
+              dir:_ -> dir
+  system$ "dir/s/b/a:-d \""++dir++"\" >files"
+  system$ "dir/s/b/a:d  \""++dir++"\" >dirs"
+  files <- readFile "files"
+  dirs  <- readFile "dirs"
+  let nobase = drop (length dir+1)
+  writeFile "FreeArc-delete.nsh"$
+    (unlines$ map (\f -> "Delete   \"$INSTDIR\\"++nobase f++"\"") $ sort$ lines files)++
+    (unlines$ map (\f -> "RMDir    \"$INSTDIR\\"++nobase f++"\"") $ reverse$ sort$ lines dirs)
+  return $! last dirs
+  removeFile "files"
+  removeFile "dirs"

--- a/Options.hs
+++ b/Options.hs
@@ -1,3 +1,677 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e2506f1722f895d5dcf2bd24f24a3b33f136360a3f1ddafde61032dae921d0a0
-size 45796
+{-# LANGUAGE CPP #-}
+---------------------------------------------------------------------------------------------------
+---- Описание команд и опций, поддерживаемых FreeArc.                                          ----
+---- Универсальный парсер командной строки.                                                    ----
+---- Интерпретация Lua-скриптов.                                                               ----
+---------------------------------------------------------------------------------------------------
+module Options where
+
+import Prelude hiding (catch)
+import Control.Exception
+import Control.Monad
+import Control.Concurrent
+import qualified GHC.Conc
+import Data.Array
+import Data.Bits
+import Data.Char
+import Data.IORef
+import Data.List hiding (sortOn)
+import Data.Maybe
+import Foreign.C
+import Foreign.C.Types
+import System.Environment
+import System.IO.Unsafe
+import System.Time
+#if !defined(FREEARC_NO_LUA)
+import qualified Scripting.Lua as Lua
+#endif
+
+import qualified CompressionLib
+import Utils
+import Files
+import Charsets
+import Errors
+import FileInfo
+import Compression
+
+
+-- |Описание выполняемой команды
+data Command = Command {
+    cmd_args                 :: ![String]           -- Полный текст команды, разбитый на слова
+  , cmd_additional_args      :: ![String]           -- Дополнительные опции, прочитанные из переменной среды и конфиг-файла
+  , cmd_name                 :: !String             -- Название команды
+  , cmd_arcspec              ::  String             -- Маска архивов
+  , cmd_arclist              ::  [FilePath]         --   Имена всех найденных по этой маске (и возможно, рекурсивно) архивов
+  , cmd_arcname              ::  FilePath           --   Имя обрабатываемого архива (из одной команды с wildcards в cmd_arcspec формируется несколько команд с конкретным именем обрабатываемого архива)
+  , cmd_archive_filter       :: (FileInfo -> Bool)  -- Предикат отбора файлов из существующих архивов
+  , cmd_filespecs            :: ![String]           -- Спецификации добавляемых архивов или файлов
+  , cmd_added_arcnames       :: !(IO [FilePath])    --   Вычисление, возвращающее имена добавляемых архивов (команда "j")
+  , cmd_diskfiles            :: !(IO [FileInfo])    --   Вычисление, возвращающее имена добавляемых файлов  (остальные команды создания/обновления архивов)
+  , cmd_subcommand           :: !Bool               -- Подкоманда? (например, тестирование после архивации)
+  , cmd_setup_command        :: !(IO ())            -- Действия, которые надо выполнить непосредственно перед началом отработки этой команды (один раз на все архивы)
+                                                    -- Опции:
+  , opt_scan_subdirs         :: !Bool               --   рекурсивный поиск файлов?
+  , opt_add_dir              :: !Bool               --   добавить имя архива к имени каталога, куда происходит распаковка?
+  , opt_add_exclude_path     :: !Int                --   исключить имя базового каталога / сохранить абсолютный путь (при ПОИСКЕ архивируемых файлов на диске)
+  , opt_dir_exclude_path     :: !Int                --   исключить имя базового каталога / сохранить абсолютный путь (при чтении КАТАЛОГА АРХИВА)
+  , opt_arc_basedir          :: !String             --   базовый каталог внутри архива
+  , opt_disk_basedir         :: !String             --   базовый каталог на диске
+  , opt_group_dir            :: ![Grouping]         --   группировка файлов для каталога архива
+  , opt_group_data           :: ![Grouping]         --   группировка файлов для солид-блока
+  , opt_data_compressor      :: !UserCompressor     --   методы сжатия для данных
+  , opt_dir_compressor       :: !Compressor         --   метод сжатия для блоков каталога
+  , opt_autodetect           :: !Int                --   уровень автодетекта типов файлов (0..9)
+  , opt_arccmt_file          :: !String             --   файл, из которого читается (в который пишется) комментарий к архиву
+  , opt_arccmt_str           :: !String             --   .. или сам комментарий в чистом виде
+  , opt_include_dirs         :: !(Maybe Bool)       --   включить каталоги в обработку? (Да/Нет/По обстоятельствам)
+  , opt_indicator            :: !String             --   тип индикатора прогресса ("0" - отсутствует, "1" - индикатор по умолчанию, "2" - вывод в отдельной строке имени каждого обрабатываемого файла)
+  , opt_display              :: !String             --   внутренняя опция, описывающая какие строки выводить на экран
+  , opt_overwrite            :: !(IORef String)     --   состояние запроса к пользователю о перезаписи файлов ("a" - перезаписывать все, "s" - пропускать все, любые другие - задавать вопросы)
+  , opt_sfx                  :: !String             --   имя SFX-модуля, который надо присоединить к архиву ("-" - отсоединить, если уже есть, "--" - скопировать существующий)
+  , opt_keep_time            :: !Bool               --   сохранить mtime архива после обновления содержимого?
+  , opt_time_to_last         :: !Bool               --   установить mtime архива на mtime самого свежего файла в нём?
+  , opt_keep_broken          :: !Bool               --   не удалять файлы, распакованные с ошибками?
+  , opt_test                 :: !Bool               --   протестировать архив после упаковки?
+  , opt_pretest              :: !Int                --   режим тестирования архивов _перед_ выполнением операции (0 - нет, 1 - только recovery info, 2 - recovery или full, 3 - full testing)
+  , opt_lock_archive         :: !Bool               --   закрыть создаваемый архив от дальнейших изменений?
+  , opt_match_with           :: !(PackedFilePath -> FilePath)  -- сопоставлять при фильтрации маски с fpBasename или fpFullname
+  , opt_append               :: !Bool               --   добавлять новые файлы только в конец архива?
+  , opt_recompress           :: !Bool               --   принудительно перепаковать все файлы?
+  , opt_keep_original        :: !Bool               --   не перепаковывать ни одного файла?
+  , opt_noarcext             :: !Bool               --   не добавлять стандартное расширение к имени архива?
+  , opt_nodir                :: !Bool               --   не записывать в архив его оглавление (для бенчмарков)?
+  , opt_update_type          :: !Char               --   алгоритм обновления файлов (a/f/u/s)
+  , opt_x_include_dirs       :: !Bool               --   включить каталоги в обработку (для команд листинга/распаковки)?
+  , opt_no_nst_filters       :: !Bool               --   TRUE, если в команде отсутствуют опции отбора файлов по имени/размеру/времени (-n/-s../-t..)
+  , opt_file_filter          :: !(FileInfo -> Bool) --   сформированный опциями предикат отбора файлов по атрибутам/размеру/времени/имени (всё, кроме filespecs)
+  , opt_sort_order           :: !String             --   порядок сортировки файлов в архиве
+  , opt_reorder              :: !Bool               --   переупорядочить файлы после сортировки (поместив рядом одинаковые/близкие файлы)?
+  , opt_find_group           :: !(FileInfo -> Int)  --   функция, определяющая по FileInfo к какой группе (из arc.groups) относится данный файл
+  , opt_groups_count         :: !Int                --   количество групп (`opt_find_group` возвращает результаты в диапазоне 0..opt_groups_count-1)
+  , opt_find_type            :: !(FileInfo -> Int)  --   функция, определяющая по FileInfo к какому типу данных (из перечисленных в `opt_data_compressor`) относится данный файл
+  , opt_types_count          :: !Int                --   количество типов файлов (`opt_find_type` возвращает результаты в диапазоне 0..opt_types_count-1)
+  , opt_group2type           :: !(Int -> Int)       --   преобразует номер группы из arc.groups а номер типа файла из opt_data_compressor
+  , opt_logfile              :: !String             --   имя лог-файла или ""
+  , opt_delete_files         :: !DelOptions         --   удалить файлы/каталоги после успешной архивации?
+  , opt_workdir              :: !String             --   каталог для временных файлов или ""
+  , opt_clear_archive_bit    :: !Bool               --   сбросить атрибут Archive у успешно упакованных файлов (и файлов, которые уже есть в архиве)
+  , opt_language             :: !String             --   язык/файл локализации
+  , opt_recovery             :: !String             --   величина Recovery блока (в процентах, байтах или секторах)
+  , opt_broken_archive       :: !String             --   обрабатывать неисправный архив, полностью сканируя его в поисках оставшихся исправными блоков
+  , opt_original             :: !String             --   перезагружать с указанного URL сбойные части архива
+  , opt_save_bad_ranges      :: !String             --   записать в заданный файл список неисправных частей архива для их перевыкачки
+  , opt_cache                :: !Int                --   размер буфера упреждающего чтения.
+  , opt_limit_compression_memory   :: !MemSize      --   ограничение памяти при упаковке, байт
+  , opt_limit_decompression_memory :: !MemSize      --   ограничение памяти при распаковке, байт
+
+                                                    -- Настройки шифрования:
+  , opt_encryption_algorithm :: !String             --   алгоритм шифрования.
+  , opt_cook_passwords                              --   подготавливает команду к использованию шифрования, заправшивая у пользователя пароль и считывая keyfile (не должно выполняться прежде, чем начнётся выполнение самой команды, поэтому не может быть выполнено в parseCmdline)
+                             :: !(Command -> (ParseDataFunc -> IO String, ParseDataFunc -> IO String, IO ()) -> IO Command)
+  , opt_data_password        :: String              --   пароль, используемый для шифрования данных (включает в себя ввод с клавиатуры и содержимое keyfiles). "" - паролирование не нужно
+  , opt_headers_password     :: String              --   пароль, используемый для шифрования заголовков (ditto)
+  , opt_decryption_info                             --   информация, используемая процедурой подбора ключа дешифрации:
+                             :: ( Bool              --     не запрашивать у пользователя новый пароль, даже если все известные для распаковки данных не подходят?
+                                , MVar [String]     --     список "старых паролей", которыми мы пытаемся расшифровать распаковываемые данные
+                                , [String]          --     содержимое keyfiles, добавляемых к паролям
+                                , IO String         --     ask_decryption_password
+                                , IO ()             --     bad_decryption_password
+                                )
+  -- Операции чтения/записи файлов в кодировке, настраиваемый опцией -sc
+  , opt_parseFile   :: !(Domain -> FilePath -> IO [String])      -- процедура парсинга файла с настраиваемой в -sc кодировкой и ОС-независимым разбиением на строки
+  , opt_unParseFile :: !(Domain -> FilePath -> String -> IO ())  -- процедура записи файла с настраиваемой в -sc кодировкой
+  , opt_parseData   :: !(Domain -> String -> String)             -- процедура парсинга введённых данных с настраиваемой в -sc кодировкой
+  , opt_unParseData :: !(Domain -> String -> String)             -- процедура депарсинга данных для вывода с настраиваемой в -sc кодировкой
+  }
+
+-- |Виртуальная опция --debug
+opt_debug cmd = cmd.$opt_display.$(`contains_one_of` "$#")
+
+-- |Включить тестирование памяти?
+opt_testMalloc cmd = cmd.$opt_display.$(`contains_one_of` "%")
+
+-- |Реально используемый компрессор отличается от записываемого в заголовок блока
+-- вызовами "tempfile", вставленными между слишком прожорливыми алгоритмами
+-- (память ограничивается до значения -lc и размера наибольшего блока свободной памяти,
+-- если не задано -lc-)
+limit_compressor command compressor = do
+  let memory_limit = opt_limit_compression_memory command
+  if memory_limit==CompressionLib.aUNLIMITED_MEMORY
+    then return compressor
+    else do maxMem <- getMaxMemToAlloc
+            return$ limitCompressionMemoryUsage (memory_limit `min` maxMem) compressor
+
+
+-- |Список опций, поддерживаемых программой
+optionsList = sortOn (\(OPTION a b _) -> (a|||"zzz",b))
+   [OPTION "--"    ""                   "stop processing options"
+   ,OPTION "cfg"   "config"            ("use config FILE (default: " ++ aCONFIG_FILE ++ ")")
+   ,OPTION "env"   ""                  ("read default options from environment VAR (default: " ++ aCONFIG_ENV_VAR ++ ")")
+   ,OPTION "r"     "recursive"          "recursively collect files"
+   ,OPTION "f"     "freshen"            "freshen files"
+   ,OPTION "u"     "update"             "update files"
+   ,OPTION ""      "sync"               "synchronize archive and disk contents"
+   ,OPTION "o"     "overwrite"          "existing files overwrite MODE (+/-/p)"
+   ,OPTION "y"     "yes"                "answer Yes to all queries"
+   ,OPTION "x"     "exclude"            "exclude FILESPECS from operation"
+   ,OPTION "n"     "include"            "include only files matching FILESPECS"
+   ,OPTION "ep"    "ExcludePath"        "Exclude/expand path MODE"
+   ,OPTION "ap"    "arcpath"            "base DIR in archive"
+   ,OPTION "dp"    "diskpath"           "base DIR on disk"
+   ,OPTION "m"     "method"             "compression METHOD (-m0..-m9, -m1x..-m9x)"
+   ,OPTION "dm"    "dirmethod"          "compression METHOD for archive directory"
+   ,OPTION "ma"    ""                   "set filetype detection LEVEL (+/-/1..9)"
+   ,OPTION "md"    "dictionary"         "set compression dictionary to N mbytes"
+   ,OPTION "mm"    "multimedia"         "set multimedia compression to MODE"
+   ,OPTION "ms"    "StoreCompressed"    "store already compressed files"
+   ,OPTION "mt"    "MultiThreaded"      "number of compression THREADS"
+   ,OPTION "mc"    ""                   "disable compression algorithms (-mcd-, -mc-rep...)"
+   ,OPTION "mx"    ""                   "maximum internal compression mode"
+   ,OPTION "max"   ""                   "maximum compression using external precomp, ecm, ppmonstr"
+   ,OPTION "ds"    "sort"               "sort files in ORDER"                      -- to do: сделать эту опцию OptArg
+   ,OPTION ""      "groups"             "name of groups FILE"                      -- to do: сделать эту опцию OptArg
+   ,OPTION "s"     "solid"              "GROUPING for solid compression"           -- to do: сделать эту опцию OptArg
+   ,OPTION "p"     "password"           "encrypt/decrypt compressed data using PASSWORD"
+   ,OPTION "hp"    "HeadersPassword"    "encrypt/decrypt archive headers and data using PASSWORD"
+   ,OPTION "ae"    "encryption"         "encryption ALGORITHM (aes, blowfish, serpent, twofish)"
+   ,OPTION "kf"    "keyfile"            "encrypt/decrypt using KEYFILE"
+   ,OPTION "op"    "OldPassword"        "old PASSWORD used only for decryption"
+   ,OPTION "okf"   "OldKeyfile"         "old KEYFILE used only for decryption"
+   ,OPTION "w"     "workdir"            "DIRECTORY for temporary files"
+   ,OPTION "sc"    "charset"            "CHARSETS used for listfiles and comment files"
+   ,OPTION ""      "language"           "load localisation from FILE"
+   ,OPTION "tp"    "pretest"            "test archive before operation using MODE"
+   ,OPTION "t"     "test"               "test archive after operation"
+   ,OPTION "d"     "delete"             "delete files & dirs after successful archiving"
+   ,OPTION "df"    "delfiles"           "delete only files after successful archiving"
+   ,OPTION "kb"    "keepbroken"         "keep broken extracted files"
+   ,OPTION "ba"    "BrokenArchive"      "deal with badly broken archive using MODE"
+#if defined(FREEARC_WIN)
+   ,OPTION "ac"    "ClearArchiveBit"    "clear Archive bit on files succesfully (de)archived"
+   ,OPTION "ao"    "SelectArchiveBit"   "select only files with Archive bit set"
+#endif
+   ,OPTION "sm"    "SizeMore"           "select files larger than SIZE"
+   ,OPTION "sl"    "SizeLess"           "select files smaller than SIZE"
+   ,OPTION "tb"    "TimeBefore"         "select files modified before specified TIME"
+   ,OPTION "ta"    "TimeAfter"          "select files modified after specified TIME"
+   ,OPTION "tn"    "TimeNewer"          "select files newer than specified time PERIOD"
+   ,OPTION "to"    "TimeOlder"          "select files older than specified time PERIOD"
+   ,OPTION "k"     "lock"               "lock archive"
+   ,OPTION "rr"    "recovery"           "add recovery information of specified SIZE to archive"
+   ,OPTION "sfx"   ""                  ("add sfx MODULE (\""++aDEFAULT_SFX++"\" by default)")  -- to do: сделать эту опцию OptArg
+   ,OPTION "z"     "arccmt"             "read archive comment from FILE or stdin"  -- to do: сделать эту опцию OptArg
+   ,OPTION ""      "archive-comment"    "input archive COMMENT in cmdline"
+   ,OPTION "i"     "indicator"          "select progress indicator TYPE (0/1/2)"   -- to do: сделать эту опцию OptArg
+   ,OPTION "ad"    "adddir"             "add arcname to extraction path"
+   ,OPTION "ag"    "autogenerate"       "autogenerate archive name with FMT"       -- to do: сделать эту опцию OptArg
+   ,OPTION ""      "noarcext"           "don't add default extension to archive name"
+   ,OPTION "tk"    "keeptime"           "keep original archive time"
+   ,OPTION "tl"    "timetolast"         "set archive time to latest file"
+   ,OPTION "fn"    "fullnames"          "match with full names"
+   ,OPTION ""      "append"             "add new files to the end of archive"
+   ,OPTION ""      "recompress"         "recompress archive contents"
+   ,OPTION ""      "dirs"               "add empty dirs to archive"
+   ,OPTION "ed"    "nodirs"             "don't add empty dirs to archive"
+   ,OPTION ""      "cache"              "use N mbytes for read-ahead cache"
+   ,OPTION "lc"    "LimitCompMem"       "limit memory usage for compression to N mbytes"
+   ,OPTION "ld"    "LimitDecompMem"     "limit memory usage for decompression to N mbytes"
+   ,OPTION ""      "nodir"              "don't write archive directories"
+   ,OPTION ""      "nodata"             "don't store data in archive"
+   ,OPTION ""      "crconly"            "save/check CRC, but don't store data"
+   ,OPTION "di"    "display"           ("control AMOUNT of information displayed: ["++aDISPLAY_ALL++"]*")
+   ,OPTION ""      "logfile"            "duplicate all information displayed to this FILE"
+   ,OPTION ""      "print-config"       "display built-in definitions of compression methods"
+   ,OPTION ""      "proxy"              "setups proxy(s) for URL access"
+   ,OPTION ""      "bypass"             "setups proxy bypass list for URL access"
+   ,OPTION ""      "original"           "redownload broken parts of archive from the URL"
+   ,OPTION ""      "save-bad-ranges"    "save list of broken archive parts to the FILE"
+   ]
+
+-- |Список опций, которым надо отдавать предпочтение при возникновении коллизий в разборе командной строки
+aPREFFERED_OPTIONS = words "method sfx charset SizeMore SizeLess overwrite"
+
+-- |Опции из предыдущего списка, имеющий максимальный приоритет :)
+aSUPER_PREFFERED_OPTIONS = words "OldKeyfile"
+
+-- |Скрыть пароли в командной строке (перед её выводом в лог)
+hidePasswords args = map f args1 ++ args2 where
+  (args1,args2)  =  break (=="--") args
+  f "-p-"                                   =  "-p-"
+  f ('-':'p':_)                             =  "-p"
+  f "-op-"                                  =  "-op-"
+  f ('-':'o':'p':_)                         =  "-op"
+  f "-hp-"                                  =  "-hp-"
+  f ('-':'h':'p':_)                         =  "-hp"
+  f "--OldPassword-"                        =  "--OldPassword-"
+  f x | "--OldPassword" `isPrefixOf` x      =  "--OldPassword"
+  f "--HeadersPassword-"                    =  "--HeadersPassword-"
+  f x | "--HeadersPassword" `isPrefixOf` x  =  "--HeadersPassword"
+  f "--password-"                           =  "--password-"
+  f x | "--password" `isPrefixOf` x         =  "--password"
+  f x = x
+
+
+-- |Описание команд, поддерживаемых программой
+commandsList = [
+    "a        add files to archive"
+  , "c        add comment to archive"
+  , "ch       modify archive (recompress, encrypt and so on)"
+  , "create   create new archive"
+  , "cw       write archive comment to file"
+  , "d        delete files from archive"
+  , "e        extract files from archive ignoring pathnames"
+  , "f        freshen archive"
+  , "j        join archives"
+  , "k        lock archive"
+  , "l        list files in archive"
+  , "lb       bare list of files in archive"
+  , "lt       technical archive listing"
+  , "m        move files and dirs to archive"
+  , "mf       move files to archive"
+  , "r        recover archive using recovery record"
+  , "rr       add recovery record to archive"
+  , "s        convert archive to SFX"
+  , "t        test archive integrity"
+  , "u        update files in archive"
+  , "v        verbosely list files in archive"
+  , "x        extract files from archive"
+  ]
+
+-- |Список команд, поддерживаемых программой
+aLL_COMMANDS = map (head.words) commandsList
+
+-- |Список команд, которые просто копируют архив
+is_COPYING_COMMAND ('r':'r':_) = True
+is_COPYING_COMMAND ('s':_)     = True
+is_COPYING_COMMAND x           = x `elem` words "c ch d j k"
+
+-- |Команда, у которой НЕ ДОЛЖНО быть ни одного аргумента (помимо имени архива)
+is_CMD_WITHOUT_ARGS x  =  is_COPYING_COMMAND x  &&  (x `notElem` words "d j")
+
+-- |Классификация всех команд по четырём типам: команды упаковки, распаковки, тестирования и листинга
+data CmdType = ADD_CMD | EXTRACT_CMD | TEST_CMD | LIST_CMD | RECOVER_CMD  deriving (Eq)
+cmdType "t"  = TEST_CMD
+cmdType "e"  = EXTRACT_CMD
+cmdType "x"  = EXTRACT_CMD
+cmdType "cw" = EXTRACT_CMD
+cmdType "l"  = LIST_CMD
+cmdType "lb" = LIST_CMD
+cmdType "lt" = LIST_CMD
+cmdType "v"  = LIST_CMD
+cmdType "r"  = RECOVER_CMD
+cmdType  _   = ADD_CMD
+{-# NOINLINE cmdType #-}
+
+-- |Версия архиватора, записываемая в HEADER BLOCK
+aARCHIVE_VERSION = make4byte 0 0 5 1
+
+{-# NOINLINE aARC_VERSION_WITH_DATE #-}
+{-# NOINLINE aARC_HEADER_WITH_DATE #-}
+{-# NOINLINE aARC_HEADER #-}
+{-# NOINLINE aARC_VERSION #-}
+{-# NOINLINE aARC_AUTHOR #-}
+{-# NOINLINE aARC_EMAIL #-}
+{-# NOINLINE aARC_WEBSITE #-}
+-- |Краткое наименование программы, выводимое в начале работы
+aARC_VERSION_WITH_DATE = aARC_VERSION ++ " ("++aARC_DATE++")"   -- aARC_VERSION
+aARC_HEADER_WITH_DATE  = aARC_HEADER  ++ " ("++aARC_DATE++")"   -- aARC_HEADER
+aARC_HEADER  = aARC_NAME++" "++aARC_VERSION++" "
+aARC_VERSION = "0.51"                                  -- "0.50 alpha ("++aARC_DATE++")"
+aARC_DATE    = "Apr 28 2009"
+aARC_NAME    = "FreeArc"
+aARC_AUTHOR  = "Bulat Ziganshin"
+aARC_EMAIL   = "Bulat.Ziganshin@gmail.com"
+aARC_WEBSITE = "http://freearc.org"
+
+{-# NOINLINE aHELP #-}
+-- |HELP, выводимый при вызове программы без параметров
+aHELP = aARC_HEADER++" "++aARC_WEBSITE++"  "++aARC_DATE++"\n"++
+        "Usage: Arc command [options...] archive [files... @listfiles...]\n" ++
+        joinWith "\n  " ("Commands:":commandsList) ++ "\nOptions:\n" ++ optionsHelp
+
+-- |Способы группировки файлов для солид-блока или оглавления архива
+data Grouping = GroupNone                   -- каждый файл отдельно
+                                            -- группировка по:
+              | GroupByExt                  --   одинаковому расширению
+              | GroupBySize      FileSize   --   минимальному объёму блока данных
+              | GroupByBlockSize MemSize    --   максимальному объёму блока данных (для блочно-ориентированных алгоритмов, таких как BWT и ST)
+              | GroupByNumber    FileCount  --   количеству файлов
+              | GroupAll                    -- все файлы вместе
+
+-- |Значение опции -d[f]: не удалять, удалять только файлы, удалять файлы и каталоги
+data DelOptions = NO_DELETE | DEL_FILES | DEL_FILES_AND_DIRS  deriving (Eq)
+
+
+---------------------------------------------------------------------------------------------------
+-- ЗНАЧЕНИЯ, ИСПОЛЬЗУЕМЫЕ ПО УМОЛЧАНИЮ ------------------------------------------------------------
+---------------------------------------------------------------------------------------------------
+
+-- |Метод сжатия данных
+aDEFAULT_COMPRESSOR = "4"
+
+-- |Метод сжатия каталога архива
+-- Note: MicroHs mkCALL_BACK returns nullFunPtr so C-based compressors (lzma etc.) can't be used yet
+aDEFAULT_DIR_COMPRESSION = "storing"
+
+-- |Размер солид-блоков (один солид-блок на всех)
+aDEFAULT_DATA_GROUPING  =  ""
+
+-- |Группировка для каталогов
+aDEFAULT_DIR_GROUPING  =  GroupByNumber (20*1000)
+
+-- |Алгоритм сжатия данных, используемый по умолчанию
+aDEFAULT_ENCRYPTION_ALGORITHM = "aes"
+
+-- |Если в командной строке не указаны имена обрабатываемых файлов - обрабатывать все, т.е. "*"
+aDEFAULT_FILESPECS = [reANY_FILE]
+
+-- |Расширение архивных файлов
+aDEFAULT_ARC_EXTENSION = ".arc"
+
+-- |Расширение SFX архивных файлов
+#ifdef FREEARC_WIN
+aDEFAULT_SFX_EXTENSION = ".exe"
+#else
+aDEFAULT_SFX_EXTENSION = ""
+#endif
+
+-- |Файл локализации
+aLANG_FILE = "arc.language.txt"
+
+-- |Файл с описанием порядка сортировки имён файлов при "-og"
+aDEFAULT_GROUPS_FILE = "arc.groups"
+
+-- |SFX-модуль, используемый по умолчанию
+aDEFAULT_SFX = "freearc.sfx"
+
+-- |Файл конфигурации (хранящий опции, используемые по умолчанию)
+aCONFIG_FILE = "arc.ini"
+
+-- |Переменная среды, содержащая опции, используемые по умолчанию
+aCONFIG_ENV_VAR = "FREEARC"
+
+-- |Порядок сортировки, используемый при solid-сжатии (для увеличения сжатия)
+aDEFAULT_SOLID_SORT_ORDER = "gerpn"
+
+-- |Объём информации, выводимой на экран - по умолчанию и при использовании опции "--display" без параметра.
+-- По умолчанию на экран не выводятся "cmo" - доп. опции, режим сжатия и используемая память
+aDISPLAY_DEFAULT = "hanwrftske"
+aDISPLAY_ALL     = "hoacmnwrfdtske"
+
+-- Секции arc.ini
+compressionMethods = "[Compression methods]"
+defaultOptions     = "[Default options]"
+externalCompressor = "[External compressor:*]"
+
+-- |Приведение имени секции к стандартизованной форме
+cleanupSectionName  =  strLower . filter (not.isSpace)
+
+-- |Проверка того, что это - заголовок секции
+selectSectionHeadings  =  ("["==) . take 1 . trim
+
+
+----------------------------------------------------------------------------------------------------
+---- Универсальный парсер командной строки ---------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Описание опции - краткое имя, длинное имя, печатаемое описание
+data Option = OPTION String String String
+
+-- |Тип опции - короткие имеют префикс "-", длинные - префикс "--"
+data OptType  =  SHORT | LONG
+
+-- |Наличие параметра в опции: нет/обязательно/опционально
+data ParamType  =  ParamNo | ParamReq | ParamOpt
+
+-- |"Словарь" опций, содержащий их в удобной для разбора командной строки форме
+optionsDict  =  concatMap compileOption optionsList
+  where compileOption (OPTION short long description)  =  compile short ++ compile ('-':long)
+          where -- Добавить в список описание опции с именем `name`, если оно непустое
+                compile name  =  case (name, paramName description) of
+                    ("",  _      )  ->  []                                -- нет имени - нет и опции :)
+                    ("-", _      )  ->  []                                -- нет имени - нет и опции :)
+                    (_,   Nothing)  ->  [(name, long|||short, ParamNo )]  -- опция без параметра
+                    (_,   Just _ )  ->  [(name, long|||short, ParamReq)]  -- опция с параметром
+
+-- |Описание опций для пользователя.
+optionsHelp  =  init$ unlines table
+  where (ss,ls,ds)     = (unzip3 . map fmtOpt) optionsList
+        table          = zipWith3 paste (sameLen ss) (sameLen ls) ds
+        paste x y z    = "  " ++ x ++ "  " ++ y ++ "  " ++ z
+        sameLen xs     = flushLeft ((maximum . map length) xs) xs
+        flushLeft n    = map (left_justify n)
+          -- Возвращает формат "короткой опции", "длинной опции", и их описание
+        fmtOpt (OPTION short long description)  =  (format short "" description, format ('-':long) "=" description, description)
+          -- Возвращает формат опции `name` с учётом наличия у неё имени и параметра
+        format name delim description  =  case (name, paramName description) of
+                                            ("",   _         )  ->  ""
+                                            ("-",  _         )  ->  ""
+                                            ("--", _         )  ->  "--"
+                                            (_,    Nothing   )  ->  "-"++name
+                                            (_,    Just aWORD)  ->  "-"++name++delim++aWORD
+
+-- |Возвращает имя параметра опции, извлекая его из строки её описания.
+paramName descr =
+  case filter (all isUpper) (words descr)
+    of []      -> Nothing      -- Описание не содержит UPPERCASED слов
+       [aWORD] -> Just aWORD   -- Описание включает UPPERCASED слово, обозначающее параметр опции
+       _       -> error$ "option description \""++descr++"\" contains more than one uppercased word"
+
+-- |Разбор командной строки, возвращающий список опций и список "свободных аргументов"
+parseOptions []          options freeArgs  =  return (reverse options, reverse freeArgs)
+parseOptions ("--":args) options freeArgs  =  return (reverse options, reverse freeArgs ++ args)
+
+parseOptions (('-':option):args) options freeArgs = do
+  let check (prefix, _, ParamNo)  =  (option==prefix)
+      check (prefix, _, _)        =  (startFrom prefix option /= Nothing)
+  let accept (prefix, name, haveParam)  =  return (name, tryToSkip "=" (tryToSkip prefix option))
+      unknown                           =  registerError$ CMDLINE_UNKNOWN_OPTION ('-':option)
+      ambiguous variants                =  registerError$ CMDLINE_AMBIGUOUS_OPTION ('-':option) (map (('-':) . fst3) variants)
+  newopt <- case (filter check optionsDict) of
+              [opt] -> accept opt  -- принять опцию
+              []    -> unknown     -- неизвестная опция.
+              xs    -> -- При неоднозначности в разборе опции посмотрим на список предпочтительных опций
+                       case (filter ((\x -> x `elem` (aPREFFERED_OPTIONS++aSUPER_PREFFERED_OPTIONS)) . snd3) xs) of
+                         [opt] -> accept opt        -- принять опцию
+                         []    -> ambiguous xs      -- неоднозначная опция, которой нет в списке предпочтений
+                         xs    -> -- Повторим трюк! :)
+                                  case (filter ((\x -> x `elem` aSUPER_PREFFERED_OPTIONS) . snd3) xs) of
+                                    [opt] -> accept opt        -- принять опцию
+                                    []    -> ambiguous xs      -- неоднозначная опция, которой нет в списке предпочтений
+                                    xs    -> ambiguous xs      -- неоднозначный разбор даже в списке предпочтений!
+
+  parseOptions args (newopt:options) freeArgs
+
+parseOptions (arg:args) options freeArgs   =  parseOptions args options (arg:freeArgs)
+
+
+-- |Вернуть список значений опции с названием `flag`. Пример вызова: findReqList opts "exclude"
+findReqList ((name, param):flags) flag  | name==flag  =  param: findReqList flags flag
+findReqList (_:flags) flag                            =  findReqList flags flag
+findReqList [] flag                                   =  []
+
+-- |Вернуть значение опции с названием `flag`, если её нет - значение по умолчанию `deflt`
+findReqArg options flag deflt  =  last (deflt : findReqList options flag)
+
+-- |Вернуть значение опции с необязательным параметром
+findOptArg = findReqArg
+
+-- |Вернуть значение опции с названием `flag`, если её нет - Nothing
+findMaybeArg options flag  =  case findReqList options flag
+                                of [] -> Nothing
+                                   xs -> Just (last xs)
+
+-- |Вернуть True, если в списке опций есть опция с названием `flag`
+findNoArg options flag  =  case findReqList options flag
+                                of [] -> False
+                                   _  -> True
+
+-- |Вернуть Just True, если в списке опций есть опция с названием `flag1`,
+--          Just False, если в списке опций есть опция с названием `flag2`,
+--          Nothing, если нет ни той, ни другой
+findNoArgs options flag1 flag2  =  case filter (\(o,_) -> o==flag1||o==flag2) options
+                                     of [] -> Nothing
+                                        xs -> Just (fst (last xs) == flag1)
+
+{-# NOINLINE optionsDict #-}
+{-# NOINLINE optionsHelp #-}
+{-# NOINLINE parseOptions #-}
+{-# NOINLINE findReqList #-}
+{-# NOINLINE findReqArg #-}
+{-# NOINLINE findMaybeArg #-}
+{-# NOINLINE findNoArg #-}
+{-# NOINLINE findNoArgs #-}
+
+
+---------------------------------------------------------------------------------------------------
+---- Интерпретация Lua-скриптов                                                                ----
+---------------------------------------------------------------------------------------------------
+
+#if defined(FREEARC_NO_LUA)
+-- Lua support disabled, just imitate it
+type LuaState = ()
+luaInit      = return ()
+luaRun _ _ _ = return ()
+#else
+
+-- |Instance of Lua interpreter (separate instances may be created for every command executed)
+type LuaState = Lua.LuaState
+
+-- |Create new Lua instance
+luaInit = do
+  l <- Lua.newstate
+  Lua.openlibs l
+  -- Init event handler lists
+  for luaEvents (addLuaEvent l)
+  -- Execute configuration scripts, adding handlers for events
+  places <- configFilePlaces "arc.*.lua"
+  for places $ \place -> do
+    scripts <- dirWildcardList place `catch` (\(e::SomeException)->return [])
+    for scripts (Lua.dofile l . (takeDirectory place </>))
+  return l
+
+-- |Execute Lua scripts assigned to the event cmd.
+-- Exceptions from callproc (e.g. "attempt to call a nil value" when a Lua global
+-- is not yet defined, or errors from user-registered handlers) are silently swallowed:
+-- Lua events are advisory-only and must not crash the archiver.
+luaRun l cmd params = (Lua.callproc l cmd params :: IO ())
+                        `catch` (\(_::SomeException) -> return ())
+
+-- |Add support of event cmd to Lua instance; check for dostring errors.
+addLuaEvent l cmd = do
+    ret <- Lua.dostring l $ unlines
+                      [ handlers++" = {}"
+                      , "function on"++cmd++"(handler)"
+                      , "  table.insert ("++handlers++", handler)"
+                      , "end"
+                      , "function "++cmd++"(params_raw)"
+                      , "  local params = params_raw"
+                      , "  for _,handler in ipairs("++handlers++") do"
+                      , "    handler(params)"
+                      , "  end"
+                      , "end"
+                      ]
+    -- If dostring fails the error message is left on the Lua stack; pop it so
+    -- subsequent calls don't see a corrupted stack.
+    when (ret /= 0) $ Lua.pop l 1
+  where handlers = "on"++cmd++"Handlers"
+
+-- |Lua events list
+luaEvents = words "ProgramStart ProgramDone CommandStart CommandDone"++
+            words "ArchiveStart ArchiveDone Error Warning"
+
+#endif
+
+
+-- |The global Lua instance
+{-# NOINLINE lua_state #-}
+lua_state :: MVar LuaState
+lua_state = unsafePerformIO $ do
+   lua <- luaInit
+   errorHandlers   ++= [\msg -> luaEvent "Error"   [("message", msg)]]
+   warningHandlers ++= [\msg -> luaEvent "Warning" [("message", msg)]]
+   newMVar lua
+
+-- |Run Lua event in the global Lua instance
+luaEvent  =  liftMVar3 luaRun lua_state
+
+-- |Perform Start/Done procedures of givel level
+luaLevel level params action = do
+  luaEvent (level++"Start") params
+  ensureCtrlBreak "luaDone" (luaEvent (level++"Done") [""]) action
+
+
+----------------------------------------------------------------------------------------------------
+---- System information ----------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+#if defined(FREEARC_WIN)
+-- |Number of physical processors/cores in the system. Determines number of heavy-computations thread runned
+foreign import ccall unsafe "Environment.h GetProcessorsCount"
+  getProcessorsCount :: CInt
+
+-- |Size of physical computer memory in bytes
+foreign import ccall unsafe "Environment.h GetPhysicalMemory"
+  getPhysicalMemory :: CUInt
+
+-- |Size of maximum memory block we can allocate in bytes
+foreign import ccall unsafe "Environment.h GetMaxMemToAlloc"
+  getMaxMemToAlloc :: IO CUInt
+
+-- |Size of physical computer memory that is currently unused
+foreign import ccall unsafe "Environment.h GetAvailablePhysicalMemory"
+  getAvailablePhysicalMemory :: CUInt
+
+-- |Prints detailed stats about memory available
+foreign import ccall unsafe "Environment.h TestMalloc"
+  testMalloc :: IO ()
+
+#else
+
+-- |Number of physical processors/cores in the system.
+-- Uses GHC.Conc.getNumProcessors which queries the OS directly.
+{-# NOINLINE getProcessorsCount #-}
+getProcessorsCount :: CInt
+getProcessorsCount  =  unsafePerformIO $ fmap fromIntegral GHC.Conc.getNumProcessors
+
+-- |Size of physical computer memory in bytes (Linux: read /proc/meminfo)
+{-# NOINLINE getPhysicalMemory #-}
+getPhysicalMemory :: CUInt
+getPhysicalMemory  =  unsafePerformIO $ readSysMemKB "MemTotal:"
+
+-- |Size of physical computer memory that is currently unused (Linux: read /proc/meminfo)
+{-# NOINLINE getAvailablePhysicalMemory #-}
+getAvailablePhysicalMemory :: CUInt
+getAvailablePhysicalMemory  =  unsafePerformIO $ readSysMemKB "MemAvailable:"
+
+-- |Parse a memory value in kB from /proc/meminfo for the given field label
+readSysMemKB :: String -> IO CUInt
+readSysMemKB label = do
+  result <- Control.Exception.try (readFile "/proc/meminfo") :: IO (Either Control.Exception.SomeException String)
+  case result of
+    Left  _    -> return 0
+    Right info ->
+      case [ fromIntegral (n * 1024 :: Integer)
+           | l <- lines info
+           , label `Data.List.isPrefixOf` l
+           , w <- [words (drop (length label) l)]
+           , not (null w)
+           , let n = read (head w) :: Integer ] of
+        (v:_) -> return v
+        []    -> return 0
+
+-- |Size of maximum memory block we can allocate.
+-- On 64-bit Unix there is effectively no single-allocation limit.
+getMaxMemToAlloc :: IO CUInt
+getMaxMemToAlloc  =  return maxBound
+
+-- |Prints detailed stats about memory available (simplified Haskell version)
+testMalloc :: IO ()
+testMalloc  =  do
+  let physMem  = getPhysicalMemory
+      availMem = getAvailablePhysicalMemory
+  putStrLn $ "Physical memory: " ++ show (physMem `div` (1024*1024)) ++ " mb"
+  putStrLn $ "Available memory: " ++ show (availMem `div` (1024*1024)) ++ " mb"
+
+#endif
+

--- a/Process.hs
+++ b/Process.hs
@@ -1,3 +1,289 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8f9f4b5a51b891f56d3f88050ac3b7ad3f96ee2acfa41c4e7e2d6b4701b871b7
-size 15683
+---------------------------------------------------------------------------------------------------
+---- "Взаимодействующие последовательные процессы", как описано в книге Хоара.                 ----
+---------------------------------------------------------------------------------------------------
+-- |
+-- Module      :  Process
+-- Copyright   :  (c) Bulat Ziganshin <Bulat.Ziganshin@gmail.com>
+-- License     :  Public domain
+--
+-- Maintainer  :  Bulat.Ziganshin@gmail.com
+-- Stability   :  experimental
+-- Portability :  GHC
+--
+-- Concurrency model: pipeline of concurrent processes communicating via MVar/Chan.
+-- Each stage runs in its own OS thread (forkIO) and passes data forward via
+-- sendP/receiveP.  Back-pressure is provided by the one-element MVar channel
+-- created by '|>', while '|>>>' creates an unbounded Chan for look-ahead I/O.
+--
+-----------------------------------------------------------------------------
+
+module Process where
+{-
+Процессы соединяются в цепочку операторами "|>" или "|>>>" и запускаются на выполнение функцией runP:
+    runP( read_files |>>> compress |> write_data )
+Процессы исполняются параллельно благодаря тому, что для их запуска используется функция forkOS.
+Каждый процесс описывается обычной функцией, которая получает дополнительный параметр типа Pipe.
+  С этой переменной можно выполнять операцию receiveP для получения данных от предыдущего
+  процесса в списке, и операцию sendP для посылки данных следующему процессу в списке:
+    compress pipe = foreverM (do data <- receiveP pipe; .....; sendP pipe compressed_data)
+Данные от процесса к процессу передаются "слева направо". В зависимости от использованной
+  при создании связи между процессами операции - "|>" или "|>>>" - в канал между этими процессами
+  можно поместить только одно или неограниченное кол-во значений (реализуется с помощью MVar/Chan,
+  соответственно).
+Данные также можно посылать в обратную сторону ("справа налево") операциями send_backP и receive_backP.
+  Канал обратной связи всегда имеет неограниченную ёмкость. Его можно использовать, например,
+  для подтверждения выполнения операций, синхронизации, возвращения использованных ресурсов
+  (например, буферов ввода/вывода):
+    производитель: sendP pipe (buf,len); receive_backP pipe; теперь буфер свободен
+    потребитель:   (buf,len) <- receiveP pipe; hPutBuf file buf len; send_backP pipe ()
+Операция runP выполняется синхронно, она завершается по окончании выполнения последнего процесса
+  в цепочке (даже если остальные процессы ещё не завершились). Если первый процесс в списке
+  запускаемых пытается обмениваться с предыдущим (т.е. выполняет операции receiveP/send_backP) или
+  последний процесс пытается обмениваться со следующим - то сигнализируется ошибка.
+Операция runAsyncP запускает процесс или цепочку процессов асинхронно и возвращает Pipe для обмена
+  с ним(и). В этом случае и первый процесс в цепочке может общаться с "предыдущим", и последний - со
+  "следующим", хотя это и не обязательно:
+    pipe <- runAsyncP compress; sendP pipe data; compressed_data <- receiveP pipe
+    pipe <- runAsyncP( compress |> write_data ); sendP pipe data
+    pipe <- runAsyncP( read_files |>>> compress ); compressed_data <- receiveP pipe
+    runAsyncP( read_files |>>> compress |> write_data )
+  Входная и выходная очереди асинхронно запущенного процесса - (пока) одноэлементные.
+-}
+
+import Prelude hiding (catch)
+import Control.Concurrent
+import Control.Exception
+import Control.Monad
+import Data.IORef
+
+-- | Unbounded FIFO channel that uses takeMVar (not readMVar) for blocking reads.
+-- MicroHs's put_mvar does not wake threads blocked via readMVar (mv_read queue),
+-- so Control.Concurrent.Chan.readChan deadlocks when the reader arrives first.
+-- This implementation uses takeMVar on holes so readers wait in mv_takeput,
+-- which put_mvar handles correctly.
+data OurStream a = OurStream (MVar (OurChItem a))
+data OurChItem a = OurChItem a (OurStream a)
+
+data OurChan a = OurChan !(MVar (OurStream a)) !(MVar (OurStream a))
+
+newOurChan :: IO (OurChan a)
+newOurChan = do
+  hole     <- newEmptyMVar
+  readVar  <- newMVar (OurStream hole)
+  writeVar <- newMVar (OurStream hole)
+  return (OurChan readVar writeVar)
+
+writeOurChan :: OurChan a -> a -> IO ()
+writeOurChan (OurChan _ writeVar) val = do
+  new_hole <- newEmptyMVar
+  OurStream old_hole <- takeMVar writeVar
+  putMVar old_hole (OurChItem val (OurStream new_hole))
+  putMVar writeVar (OurStream new_hole)
+
+readOurChan :: OurChan a -> IO a
+readOurChan (OurChan readVar _) = do
+  OurStream read_end <- takeMVar readVar
+  OurChItem val new_read_end <- takeMVar read_end
+  putMVar readVar new_read_end
+  return val
+
+instance PipeElement OurChan where
+  getP = readOurChan
+  putP = writeOurChan
+
+-- |Операция соединения двух последовательных процессов:
+-- выходной канал первого становится входным каналом второго.
+-- "|>" создаёт одноэлементную очередь, а "|>>>" - очередь неограниченной длины
+infixl 1  |>, |>>>
+
+p1 |>   p2 = createP p1 p2 newEmptyMVar
+p1 |>>> p2 = createP p1 p2 newOurChan
+
+createP p1 p2 create_inner (Pipe pid finished income income_back outcome outcome_back) = do
+  inner       <- create_inner      -- Канал между p1 и p2 (MVar или Chan)
+  inner_back  <- newOurChan        -- Обратный канал между p1 и p2 (unbounded, uses takeMVar not readMVar)
+  p1_finished <- newEmptyMVar      -- Признак завершения выполнения p1
+
+  -- Запустим первый процесс в отдельном треде, а второй исполним напрямую
+  p1_id <- forkIO$ (p1 (Pipe pid finished income income_back inner inner_back) >> return ())
+                       `finally` (putMVar p1_finished ())
+  --
+  p2 (Pipe (Just p1_id) (Just p1_finished) inner inner_back outcome outcome_back)
+  takeMVar p1_finished
+  return ()
+
+
+-- |Запустить комбинированный процесс, созданный операциями "|>" и "|>>>"
+runP p = do
+  p (Pipe Nothing
+          Nothing
+          (error "First process in runP tried to receive")
+          (error "First process in runP tried to send_back")
+          (error "Last process in runP tried to send")
+          (error "Last process in runP tried to receive_back"))
+
+-- |Запустить процесс асинхронно и возвратить канал для обмена с ним
+runAsyncP p = do
+  income  <- newEmptyMVar
+  outcome <- newEmptyMVar
+  income_back  <- newEmptyMVar
+  outcome_back <- newEmptyMVar
+  parent_id    <- myThreadId
+  p_finished   <- newEmptyMVar
+  p_id         <- forkIO (p (Pipe Nothing Nothing income income_back outcome outcome_back)
+                            `catch` (\(e :: SomeException) -> do killThread parent_id; throwIO e)
+                            `finally` putMVar p_finished ())
+  return (Pipe (Just p_id) (Just p_finished) outcome outcome_back income income_back)
+
+
+-- |Канал обмена с соседними процессами, который получает в своё распоряжение каждый процесс.
+-- Канал имеет 6 элементов - ИД предыдущего (запущенного асинхронно) процесса,
+--                           MVar-переменная, сигнализирующая о его завершении,
+--                           входные данные, отсылка подтверждений,
+--                           выходные данные, получение подтверждений
+data Pipe a b c d  =  Pipe (Maybe ThreadId) (Maybe (MVar ())) a b c d
+killP    pipe@(Pipe (Just pid) _ _ _ _ _)                                  = killThread pid >> joinP pipe
+joinP         (Pipe _ (Just finished) _ _ _ _)                             = takeMVar finished
+receiveP      (Pipe pid finished income income_back outcome outcome_back)  = getP income
+sendP         (Pipe pid finished income income_back outcome outcome_back)  = putP outcome
+receive_backP (Pipe pid finished income income_back outcome outcome_back)  = getP outcome_back
+send_backP    (Pipe pid finished income income_back outcome outcome_back)  = putP income_back
+
+-- |Довольно странная операция - "возвращение" сообщений самому себе - так, как если бы это сделал
+-- последующий процесс в очереди. Но она нужна для создания начального пула ресурсов, используемых
+-- процессом
+send_back_itselfP (Pipe pid finished income income_back outcome outcome_back)  =  putP outcome_back
+
+
+-- |Элемент канала между процессами - может иметь тип как MVar, так и Chan
+class PipeElement e where
+  getP :: e a -> IO a
+  putP :: e a -> a -> IO ()
+
+instance PipeElement MVar where
+  getP = takeMVar
+  putP = putMVar
+
+instance PipeElement Chan where
+  getP = readChan
+  putP = writeChan
+
+-- |Псевдо-канал процесса - состоит из двух явно заданных функций для получения и посылки данных
+data PairFunc a = PairFunc (IO a) (a -> IO ())
+
+instance PipeElement PairFunc where
+  getP (PairFunc get_f put_f) = get_f
+  putP (PairFunc get_f put_f) = put_f
+
+-- |Процедура запуска процесса с 4 функциями для эмуляции каналов ввода/вывода
+runFuncP :: (Pipe (PairFunc a) (PairFunc b) (PairFunc c) (PairFunc d) -> IO e)
+         -> IO a -> (b -> IO ()) -> (c -> IO ()) -> IO d -> IO e
+runFuncP p receive_f send_back_f send_f receive_back_f  =
+  p (Pipe Nothing
+          Nothing
+          (PairFunc receive_f      undefined)
+          (PairFunc undefined      send_back_f)
+          (PairFunc undefined      send_f)
+          (PairFunc receive_back_f undefined))
+
+{-# NOINLINE createP #-}
+{-# NOINLINE runP #-}
+{-# NOINLINE runAsyncP #-}
+{-# NOINLINE runFuncP #-}
+
+
+-- Пример использования:
+{-
+exampleP = do
+  -- Demonstrates using of "runP"
+  print "runP: before"
+  runP( producer 5 |> transformer (++"*2") |> transformer (++"+1") |> printer "runP" )
+  print "runP: after"
+
+  -- Demonstrates using of "runAsyncP" to run computation as parallelly computed function
+  pipe <- runAsyncP (transformer (++" modified"))
+  sendP pipe "value"
+  n <- receiveP pipe
+  print n
+
+  -- Demonstrates using of "runAsyncP" with "|>"
+  pipe <- runAsyncP( transformer (++"*2") |> transformer (++"+1") )
+  sendP pipe "7"
+  n <- receiveP pipe
+  print n
+
+  -- Demonstrates using of "runAsyncP" to run asynchronous process
+  print "runAsyncP: before"
+  pipe <- runAsyncP( producer 7 |> printer "runAsyncP" )
+  print "runAsyncP: after?"
+
+producer n pipe = do
+  mapM_ (sendP pipe.show) [1..n]
+  sendP pipe "0"
+
+transformer f pipe = do
+  n <- receiveP pipe
+  sendP pipe (f n)
+  transformer f pipe
+
+printer str pipe = do
+  n <- receiveP pipe
+  when (head n/='0')$  do print$ str ++ ": " ++ n
+                          printer str pipe
+-}
+
+{- Design principles:
+1. Процессы в runP должны запускаться слева направо. При небольшом объёме
+обрабатываемых данных это приведёт к тому, что первый процесс в
+транспортёре произведёт все необходимые данные и завершится прежде, чем
+второй и последующие процессы вообще будут запущены
+2. runP должен запустить все процессы в дополнительных тредах и дожидаться
+их завершения. Выход из runP желательно производить только после
+завершения работы всех процессов
+3. При завершении процесса предыдущий процесс в транспортёре должен получить
+исключение для того, чтобы завершиться как можно быстрее (после чего
+предшествующий ему процесс должен получить исключение в свою очередь).
+Следующий же процесс должен получить только информацию о завершении
+входных данных при попытке их прочитать (tryReceiveP, eofP)
+4. При возникновении необработанного исключения в одном из процессов все
+остальные процессы в транспортёре должны быть прекращены (посылкой сигнала
+KillThread) и это исключение перевозбуждено в основном процессе
+5. runP (p1 |> p2 |> protectP p) защищает процесс `p` от возбуждения в нём исключений,
+вместо этого возникающие ситуации только сигнализируются в состоянии канала
+6. Для ожидания завершения процесса, запущенного по runAsyncP или
+предыдущего процесса в транспортёре ввести операцию joinP pipe
+7. "p |> yP p1 p2" посылает вывод одного процесса двум другим
+8. killP pipe убивает все процессы из запущенного асинхронно транспортёра
+9. Нужны удобные и эффективные средства для создания процессов, имеющих
+несколько входных и/или выходных каналов (использовать getP/putP?)
+10. new_pipe <- insertOnInputP old_pipe process - вставить новый процесс перед своим входом
+    new_pipe <- insertOnOutputP old_pipe process - вставить новый процесс после своего выхода
+
+p1 |> p2   -->  PChain p1 p2 ?
+
+(p1 |> p2) pipe{ MainThreadId, ref_threads... }
+  p2_threadId <- forkIO $ (p2 pipe2  >> writeIORef pipe.isEof True - по окончании второго процесса)
+                          `catch` (throwTo MainThreadId)
+  addToMVar ref_threads p2_threadId
+  p1 pipe1
+
+p1 |> (p2 |> p3)
+  forkIO (forkIO p3; p2)
+  p1
+
+runP p =
+  p_threadId <- forkIO$ p pipe{ MainThreadId = MyThreadId, ref_threads = newIORef [], ...}
+  addToMVar ref_threads p_threadId
+  wait them all `catch` (\e -> mapM killThread ref_threads; throw e)
+
+11. Вокруг запущенного треда - катч, который убивает сына, дожидается его завершения и посылает
+    полученное исключение отцу
+-}
+
+
+{-New design guidelines:
+1. a|>b запускается как "fork a; b"
+2. При завершении b дождаться завершения a
+3. При возникновении в любом из процессов необработанного сигнала
+   надо убивать все порцессы в транспортёре и перевозбуждать этот сигнал в основной порграмме
+-}

--- a/UI.hs
+++ b/UI.hs
@@ -1,3 +1,471 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7c89a74166b6c45e759cf09a60ab25b121318e7c4a7f7c4405a221955af21fde
-size 26038
+{-# OPTIONS_GHC -cpp #-}
+----------------------------------------------------------------------------------------------------
+---- Сбор и отображение статистики работы программы (объём обработанных данных, скорость и т.д.) ---
+----------------------------------------------------------------------------------------------------
+#ifdef FREEARC_GUI
+module UI (module UI, module UIBase, module GUI) where
+import GUI
+#else
+module UI (module UI, module UIBase, module CUI) where
+import CUI
+#endif
+
+import Prelude hiding (catch)
+import Control.Monad
+import Control.Concurrent
+import Data.IORef
+import Numeric           (showFFloat)
+import System.CPUTime    (getCPUTime)
+import System.IO
+import System.IO.Unsafe
+import System.Time
+
+import Utils
+import Errors
+import Charsets
+import Files
+import FileInfo
+import Compression (encode_method, showMem, getCompressionMem, getDecompressionMem)
+import Options
+import UIBase
+
+
+-- |Отметить начало выполнения программы
+uiStartProgram = do
+  guiStartProgram
+
+-- |Отметить начало выполнения команды
+uiStartCommand command = do
+  ref_command =: command
+  display_option' =: opt_display command
+  refStartArchiveTime =:: getClockTime
+  -- Открыть логфайл и вывести в него выполняемую команду. Длинные комментарии/списки файлов/имена файлов
+  -- не должны попадать в лог-файл, так что мы обрезаем список и все строки в нём до 100 элементов
+  openLogFile (opt_logfile command)
+  curdir <- getCurrentDirectory
+  printLog (curdir++">arc "++unwords(map (takeSome 100 "...")$ hidePasswords$ takeSome 100 ["..."]$ cmd_args command)++"\n")
+  -- Выведем версию архиватора и используемые дополнительные опции
+  let addArgs = cmd_additional_args command
+  once putHeader$ condPrintLine "h" aARC_HEADER
+  condPrintLine "o" (addArgs &&& "Using additional options: "++unwords(hidePasswords addArgs)++"\n")
+  myFlushStdout
+
+-- |Отметить начало выполнения подкоманды
+uiStartSubCommand command subCommand = do
+  ref_command =: subCommand
+  uiArcname   =: cmd_arcname command
+  display_option' =: opt_display subCommand
+
+-- |Отметить начало обработки очередного архива
+uiStartArchive command@Command {
+                 opt_data_compressor = compressor
+               , opt_cache           = cache
+               }
+               method = do
+  -- Запомнить время начала обработки архива и выполняемую команду
+  refStartArchiveTime =:: getClockTime
+  ref_command =: command
+  display_option' =: opt_display command
+  uiMessage =: ""
+
+  -- Остаток процедуры не нужно выполнять, если это под-команда (например, тестирование после архивации)
+  if cmd_subcommand command
+    then do condPrintLineNeedSeparator "" "\n"
+    else do
+
+  -- Вывести сообщение типа "Testing archive ..."
+  let cmd     = cmd_name    command
+      arcname = cmd_arcname command
+  uiArcname =: arcname
+  exist <- fileExist arcname
+  condPrintLine "a"  $ (msgStart cmd exist) ++ arcname
+  condPrintLine "c"  $ (method &&& " using "++encode_method method)
+  condPrintLine "ac" $ "\n"
+  when (cmdType cmd == ADD_CMD) $ do
+      condPrintLineLn "m" $
+          "Memory for compression "++showMem (getCompressionMem   method)
+          ++", decompression "     ++showMem (getDecompressionMem method)
+          ++", cache "             ++showMem cache
+
+-- |Отметить начало упаковки или распаковки данных
+uiStartProcessing filelist archive_total_bytes archive_total_compressed = do
+  refArchiveProcessingTime =: 0
+  command <- val ref_command
+  let cmd = cmd_name command
+      total_files' = i$ length filelist
+      total_bytes' = sum (map fiSize filelist)
+      ui_state = UI_State {
+          total_files     = total_files'
+        , total_bytes     = total_bytes'
+        , archive_total_bytes      = archive_total_bytes
+        , archive_total_compressed = archive_total_compressed
+        , datatype        = error "internal CUI error: datatype not initialized"
+        , uiFileinfo      = Nothing
+        , files           = 0
+        , bytes           = 0
+        , cbytes          = 0
+        , dirs            = 0
+        , dir_bytes       = 0
+        , dir_cbytes      = 0
+        , fake_files      = 0
+        , fake_bytes      = 0
+        , fake_cbytes     = 0
+        , algorithmsCount = error "internal CUI error: algorithmsCount not initialized"
+        , rw_ops          = error "internal CUI error: rw_ops not initialized"
+        , r_bytes         = 0
+        , rnum_bytes      = 0
+        }
+  ref_ui_state =: ui_state
+  printLine$ msgDo cmd ++ show_files3 total_files' ++ ", "
+                       ++ show_bytes3 total_bytes'
+  -- Вывод этого "разделителя" позволит затереть на экране строчку с текущей статистикой
+  printLineNeedSeparator $ "\r"++replicate 75 ' '++"\r"
+  when (opt_indicator command == "1") $ do
+    myPutStr$ ". Processed "
+  -- Сложный progress indicator учитывает также процент обработанных файлов, что позволяет ему работать плавнее
+  -- Данные с файлами смешиваются из расчёта: скорость упаковки 1мб/с, время открытия файла - 10 мсек
+  let current bytes = do ui_state <- val ref_ui_state
+                         return$ bytes + (bytes_per_sec `div` 100)*i (files ui_state)
+      total = do ui_state <- val ref_ui_state
+                 return$ total_bytes ui_state + (bytes_per_sec `div` 100)*i (total_files ui_state)
+  uiStartProgressIndicator INDICATOR_FULL command current total
+  myFlushStdout
+
+
+-- |Отметить стадию выполнения процесса
+uiStage msg = do
+  syncUI $ do
+  uiMessage =:: i18n msg
+
+-- |Сбросить счётчик просканированных файлов
+uiStartScanning = do
+  files_scanned =: 0
+
+-- |Вызывается в ходе сканирования диска, files - список файлов, найденных в очередном каталоге
+uiScanning msg files = do  -- Пока это работает только в GUI
+#ifdef FREEARC_GUI
+  failOnTerminated
+  files_scanned += i(length files)
+  files_scanned' <- val files_scanned
+  msg <- i18n msg
+  uiStage$ format msg (show3 files_scanned')
+#endif
+  return ()
+
+-- |Отметить начало упаковки/распаковки файлов
+uiStartFiles count = do
+  syncUI $ do
+  modifyIORef ref_ui_state $ \(ui_state :: UI_State) ->
+    ui_state { datatype        = File
+             , algorithmsCount = count
+             , rw_ops          = (replicate count [] :: [[UI_RW FileSize]])
+             , r_bytes         = (0 :: FileSize)
+             , rnum_bytes      = (0 :: FileSize)
+             }
+
+-- |Отметить начало упаковки/распаковки каталога архива
+uiStartDirectory = do
+  syncUI $ do
+  modifyIORef ref_ui_state $ \(ui_state :: UI_State) ->
+    ui_state { datatype        = Dir
+             , dirs            = dirs ui_state + 1
+             , algorithmsCount = 0 }
+
+-- |Отметить начало упаковки/распаковки служебной информации архива
+uiStartControlData = do
+  syncUI $ do
+  modifyIORef ref_ui_state $ \(ui_state :: UI_State) ->
+    ui_state { datatype        = CData
+             , algorithmsCount = 0 }
+
+-- |Отметить начало упаковки/распаковки файла
+uiStartFile fileinfo = do
+  syncUI $ do
+    uiMessage =: (fpFullname . fiStoredName) fileinfo  ++  (fiIsDir fileinfo &&& "/")
+    modifyIORef ref_ui_state $ \(ui_state :: UI_State) ->
+      ui_state { datatype   = File
+               , uiFileinfo = Just fileinfo
+               , files      = files ui_state + 1}
+  guiStartFile
+
+-- |Откорректировать total_bytes в ui_state
+uiCorrectTotal files bytes = do
+  when (files/=0 || bytes/=0) $ do
+    syncUI $ do
+    modifyIORef ref_ui_state $ \(ui_state :: UI_State) ->
+      ui_state { total_files = total_files ui_state + files
+               , total_bytes = total_bytes ui_state + bytes }
+
+-- |Отметить имитацию обработки файлов согласно прилагаемому списку
+uiFakeFiles filelist compsize = do
+  let origsize  =  sum (map fiSize filelist)
+  syncUI $ do
+    modifyIORef ref_ui_state $ \(ui_state :: UI_State) ->
+      ui_state { datatype    = File
+               , files       = (files       ui_state) + (i$ length filelist)
+               , fake_files  = (fake_files  ui_state) + (i$ length filelist)
+               , fake_bytes  = (fake_bytes  ui_state) + origsize
+               , fake_cbytes = (fake_cbytes ui_state) + compsize
+               }
+  uiUnpackedBytes           origsize
+  uiCompressedBytes         compsize
+  uiUpdateProgressIndicator origsize
+
+-- |Отметить, что было обработано столько-то байт сжатых данных (неважно, результат
+-- ли это упаковки, входные данные для распаковки или просто упакованные данные, переданные
+-- из старого архива в новый без какой-либо перепаковки)
+uiCompressedBytes len = do
+  syncUI $ do
+  modifyIORef ref_ui_state $ \ui_state ->
+    case (datatype ui_state) of
+      File  ->  ui_state {     cbytes =     cbytes ui_state + len }
+      Dir   ->  ui_state { dir_cbytes = dir_cbytes ui_state + len }
+      CData ->  ui_state
+
+-- |Отметить, что было обработано столько-то байт распакованных данных (даже если реально
+-- эти байты никто в глаза не видел, поскольку они были переданы в сжатом виде из архива в архив)
+uiUnpackedBytes len = do
+  syncUI $ do
+  modifyIORef ref_ui_state $ \ui_state ->
+    case (datatype ui_state) of
+      File  ->  ui_state {     bytes =     bytes ui_state + len }
+      Dir   ->  ui_state { dir_bytes = dir_bytes ui_state + len }
+      CData ->  ui_state
+
+-- |Отметить начало упаковки или распаковки солид-блока
+uiStartDeCompression deCompression = do
+  x <- getCPUTime
+  newMVar (x,deCompression,[])
+
+-- |Добавить в список время работы одного из алгоритмов в цепочке
+-- (вычисленное в сишном треде время работы упаковщика/распаковщика)
+uiDeCompressionTime times t =  do
+  modifyMVar_ times (\(x,y,ts) -> return (x, y, ts++[t]))
+
+-- |Упаковка/распаковка солид-блока завершена - просуммировать время работы всех тредов
+-- или использовать wall clock time, если хотя бы одно из возвращённых времён == -1
+uiFinishDeCompression times = do
+  (timeStarted, deCompression, results) <- takeMVar times
+  timeFinished <- getCPUTime
+  let deCompressionTimes  =  map snd3 results
+  refArchiveProcessingTime +=  {-if (all (>=0) deCompressionTimes)      -- Commented out until all compression methods (lzma, grzip) will include timing for all threads
+                                 then sum deCompressionTimes
+                                 else-} i(timeFinished - timeStarted) / 1e12
+  let total_times = if (all (>=0) deCompressionTimes)
+                                 then " ("++showFFloat (Just 3) (sum deCompressionTimes) ""++" seconds)"
+                                 else ""
+  when (results>[]) $ do
+    debugLog0$ "  Solid block "++deCompression++" results"++total_times
+    for results $ \(method,time,size) -> do
+        debugLog0$ "    "++method++": "++show3 size++" bytes in "++showFFloat (Just 3) time ""++" seconds"
+
+-- |Обработка очередного архива завершена -> напечатать статистику и вернуть её вызывающей процедуре
+uiDoneArchive = do
+  command <- val ref_command
+  ui_state@UI_State { total_files   = total_files
+                      , total_bytes   = total_bytes
+                      , files         = files
+                      , bytes         = bytes
+                      , cbytes        = cbytes
+                      , dirs          = dirs
+                      , dir_bytes     = dir_bytes
+                      , dir_cbytes    = dir_cbytes
+                      , fake_files    = fake_files
+                      , fake_bytes    = fake_bytes
+                      , fake_cbytes   = fake_cbytes }  <-  val ref_ui_state
+  let cmd = cmd_name command
+  uiMessage =: ""
+  uiDoneProgressIndicator
+  when (opt_indicator command=="2" && files-fake_files>0) $ do
+    myPutStrLn ""
+    printLineNeedSeparator ""  -- нужда в разделителе перед выводом следующих строк исчезла
+
+  -- Статистика сжатия (не выводится для суб-команд, поскольку точно такую же статистику уже напечатала основная команда)
+  unless (cmd_subcommand command) $ do
+    condPrintLineLn "f" $ left_justify 75 $    -- без дополнительных пробелов может не переписаться полностью предыдущая строка
+      msgDone cmd ++ show_files3 files ++ ", " ++ show_ratio cmd bytes cbytes
+    -- Напечатать статистику по каталогу архива только если он достаточно велик
+    when (dir_bytes>10^4) $ do
+      condPrintLine   "d" $ "Directory " ++ (dirs>1 &&& "has " ++ show3 dirs ++ " chunks, ")
+      condPrintLineLn "d" $                 show_ratio cmd dir_bytes dir_cbytes
+
+  -- Информация о времени работы и скорости упаковки/распаковки
+  secs <- val refArchiveProcessingTime   -- время, затраченное непосредственно на упаковку/распаковку
+  real_secs <- return_real_secs          -- полное время выполнения команды над текущим архивом
+  condPrintLine                     "t" $ msgStat cmd ++ "time: "++(secs>0 &&& "cpu " ++ showTime secs ++ ", ")
+  condPrintLine                     "t" $ "real " ++ showTime real_secs
+  when (real_secs>=0.01) $ condPrintLine "t" $ ". Speed " ++ showSpeed (bytes-fake_bytes) real_secs
+
+  condPrintLineNeedSeparator "rdt" "\n"
+  myFlushStdout
+  resetConsoleTitle
+  return (1,files,bytes,cbytes)
+
+-- |Вызывается после всех вспомогательных операций (добавление recovery info, тестирование)
+uiDoneArchive2 = do
+  command <- val ref_command
+  unless (cmd_subcommand command) $ do
+    condPrintLineNeedSeparator "" "\n\n"
+
+-- |Выполнение подкоманды завершено
+uiDoneSubCommand command subCommand results = do
+  ref_command =: command
+  display_option' =: opt_display command
+
+-- |Выполнение команды завершено, напечатать суммарную статистику по всем обработанным архивам
+uiDoneCommand Command{cmd_name=cmd} totals = do
+  let sum4 (a0,b0,c0,d0) (a,b,c,d)   =  (a0+a,b0+b,c0+c,d0+d)
+      (counts, files, bytes, cbytes) =  foldl sum4 (0,0,0,0) totals
+  when (counts>1) $ do
+    condPrintLine "s" $ "Total: "++show_archives3 counts++", "
+                                 ++show_files3    files ++", "
+                                 ++if (cbytes>=0)
+                                     then show_ratio cmd bytes cbytes
+                                     else show_bytes3 bytes
+    condPrintLineNeedSeparator "s" "\n\n\n"
+
+-- |Завершить выполнение программы
+uiDoneProgram = do
+  condPrintLineNeedSeparator "" "\n"
+
+
+{-# NOINLINE uiStartProgram #-}
+{-# NOINLINE uiStartArchive #-}
+{-# NOINLINE uiStartProcessing #-}
+{-# NOINLINE uiStartFile #-}
+{-# NOINLINE uiCorrectTotal #-}
+{-# NOINLINE uiUnpackedBytes #-}
+{-# NOINLINE uiCompressedBytes #-}
+{-# NOINLINE uiDoneArchive #-}
+{-# NOINLINE uiDoneCommand #-}
+
+
+----------------------------------------------------------------------------------------------------
+---- Очередь операций r/w, по которым при упаковке вычисляется индикатор прогресса -----------------
+----------------------------------------------------------------------------------------------------
+
+-- Добавить операцию чтения/записи в голову списка, сливая вместе операции одного типа
+add_Read  a (UI_Write 0:UI_Read  0:ops) = (UI_Read a:ops)  -- избавиться от useless пары r0+w0
+add_Read  a (UI_Read  b:ops) = (UI_Read (a+b):ops)
+add_Read  a             ops  = (UI_Read  a   :ops)
+
+add_Write a (UI_Write b:ops) = (UI_Write(a+b):ops)
+add_Write a             ops  = (UI_Write a   :ops)
+
+-- |Алгоритм номер num в цепочке обещает записать bytes байт, соответствующих последнему блоку прочитанных
+-- данных (эта операция "обещания записи" позволяет поддерживать аккуратный индикатор прогресса)
+uiQuasiWriteData num bytes = do
+  -- Реализация устроена так, что последним прочитанным данным сопоставляются bytes записанных данных,
+  -- но при этом общий размер записанных данных не изменяется ни на йоту ;)
+  uiWriteData num bytes
+  uiReadData  num 0
+  uiWriteData num (-bytes)
+
+-- |Алгоритм номер num в цепочке записал bytes байт
+uiWriteData num bytes = do
+  UI_State {algorithmsCount=count, datatype=datatype} <- val ref_ui_state
+  when (datatype == File) $ do
+  -- Сохранить в список операций в/в операцию чтения
+  when (num>=1 && num<count) $ do
+    syncUI $ do
+    ui_state@UI_State {rw_ops=rw_ops0}  <-  val ref_ui_state
+    let rw_ops = updateAt num (add_Write bytes) rw_ops0
+    return $! length (take 4 (rw_ops!!num))   -- strictify operations list!
+    ref_ui_state =: ui_state {rw_ops=rw_ops}
+
+-- |Алгоритм номер num в цепочке прочитал bytes байт
+uiReadData num bytes = do
+  UI_State {algorithmsCount=count, datatype=datatype} <- val ref_ui_state
+  when (datatype == File) $ do
+  -- Сохранить в список операций в/в операцию записи
+  when (num>=1 && num<count) $ do
+    syncUI $ do
+    modifyIORef ref_ui_state $ \ui_state@UI_State {rw_ops=rw_ops} ->
+      ui_state {rw_ops = updateAt num (add_Read bytes) rw_ops}
+
+  -- Обновить индикатор прогресса, если это последний алгоритм сжатия в цепочке
+  when (num>=1 && num==count) $ do
+    unpBytes <- syncUI $ do
+      -- Состояние до обработки этих байт
+      ui_state@UI_State {r_bytes=r_bytes0, rnum_bytes=rnum_bytes0, rw_ops=rw_ops0}  <-  val ref_ui_state
+      -- К байтам на входе алгоритма num добавляется bytes байт,
+      -- высчитываем количество байт на входе первого алгоритма если этот блок не похож на просто заголовок (bytes>16)
+      let rnum_bytes = rnum_bytes0+bytes
+          (r_bytes, rw_ops) = if bytes>16
+                                 then calc num (reverse rw_ops0) [] rnum_bytes
+                                 else (r_bytes0, rw_ops0)
+      ref_ui_state =: ui_state {r_bytes=r_bytes, rnum_bytes=rnum_bytes, rw_ops=rw_ops}
+      --for rw_ops $ \x -> print (reverse x)
+      --print (rnum_bytes0, bytes, r_bytes0, r_bytes-r_bytes0)
+      -- Возвращаем количество байт на входе первого алгоритма относительно предыдущего значения этой величины
+      return (r_bytes-r_bytes0)
+    uiUpdateProgressIndicator ((unpBytes*9) `div` 10)
+  when (num==1) $ do  -- 90% на последний алгоритм в цепочке и 10% на первый (чтобы сгладить вывод для external compression and so on)
+    uiUpdateProgressIndicator (bytes `div` 10)
+
+ where
+  -- Рекурсивно пересчитать bytes байт на входе алгоритма num в количество байт на входе алгоритма 1
+  -- Заодно уж обновить очередь операций, просуммировав операции предшествуюшие текущей точке интереса
+  calc 1   _                new_ops bytes = (bytes, []:new_ops)
+  calc num (old_op:old_ops) new_ops bytes =
+    -- Пересчитать bytes байт на выходе алгоритма num-1 в байты на его входе
+    let (new_bytes, new_op) = go 0 bytes (0,0) (smart_reverse old_op)
+    in calc (num-1) old_ops (reverse new_op:new_ops) new_bytes
+
+  -- Реверсируем oplist или просто заменим его на две операции, если в нём больше 1000 элементов
+  -- (то есть скорей всего это операции перед tempfile)
+  smart_reverse oplist
+      | length oplist < 1000  =  reverse oplist
+      | otherwise             =  [UI_Read r, UI_Write w]  where (r,w) = go oplist
+                                                                go (UI_Read  r:ops) = mapFst (+r) (go ops)
+                                                                go (UI_Write w:ops) = mapSnd (+w) (go ops)
+                                                                go []               = (0,0)
+
+  -- Пересчитывает записанные байты (restW) в прочитанные (totalR) согласно последовательности операций ввода/вывода
+  go totalR restW (rsum,wsum) ops@(UI_Read r:UI_Write w:rest_ops)
+       -- Если следующий кусок упакованных данных больше нашего остатка, то увеличиваем totalR на него и движемся дальше
+       | w<restW    =  go (totalR+r) (restW-w) (rsum+r,wsum+w) rest_ops
+       -- Иначе делим его пропорционально (r/w * restW) и добавляем к totalR
+       | otherwise  =  (totalR + ((r*restW) `div` max w 1), UI_Read rsum:UI_Write wsum:ops)
+  -- Все прочие варианты
+  go totalR _ (rsum,wsum) ops  =  (totalR, UI_Read rsum:UI_Write wsum:ops)
+
+
+----------------------------------------------------------------------------------------------------
+---- Обновление индикатора прогресса ---------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Инициализировать индикатор прогресса
+uiStartProgressIndicator indType command bytes' total' = do
+  bytes <- bytes' 0;  total <- total'
+  arcname <- val uiArcname
+  let cmd        =  cmd_name command
+      direction  =  if (cmdType cmd == ADD_CMD)  then " => "  else " <= "
+      indicator  =  select_indicator command total
+  aProgressIndicatorState =: (indicator, indType, arcname, direction, 0, bytes', total')
+  indicator_start_real_secs =:: return_real_secs
+  uiResumeProgressIndicator
+
+-- |Вывести на экран и в заголовок окна индикатор прогресса (сколько процентов данных уже обработано)
+uiUpdateProgressIndicator add_b =
+  when (add_b/=0) $ do
+    -- Маленькая индейская хитрость: эта функция вызывается ПЕРЕД какой-либо обработкой
+    -- данных. При этом мы считаем, что предыдущие данные к данному моменту уже обработаны и
+    -- рапортуем об этом. Новые же данные только добавляются к счётчику, но не влияют
+    -- на выводимую СЕЙЧАС статистику. Вот такие вот приколы в нашем городке :)
+    syncUI $ do
+    (indicator, indType, arcname, direction, b, bytes', total') <- val aProgressIndicatorState
+    aProgressIndicatorState =: (indicator, indType, arcname, direction, b+add_b, bytes', total')
+
+-- |Завершить вывод индикатора прогресса
+uiDoneProgressIndicator = do
+  uiSuspendProgressIndicator
+  aProgressIndicatorState =: (NoIndicator, undefined, undefined, undefined, undefined, undefined, undefined)
+
+-- |Обернуть выполнение команды в открытие и закрытие индикатора прогресса
+uiWithProgressIndicator command arcsize action = do
+  uiStartProgressIndicator INDICATOR_PERCENTS command return (return arcsize)
+  ensureCtrlBreak "uiDoneProgressIndicator" uiDoneProgressIndicator action
+
+{-# NOINLINE uiUpdateProgressIndicator #-}
+

--- a/UIBase.hs
+++ b/UIBase.hs
@@ -1,3 +1,310 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4b7b54f7d3bc36d2be80506eadc3ab745d3719618f2b288a97a35a505affbcc5
-size 17326
+{-# OPTIONS_GHC -cpp #-}
+----------------------------------------------------------------------------------------------------
+---- Информирование пользователя о ходе выполнения программы (CUI - Console User Interface).  ------
+----------------------------------------------------------------------------------------------------
+module UIBase where
+
+import Prelude hiding (catch)
+import Control.Monad
+import Control.Concurrent
+import Control.Exception
+import Data.Char
+import Data.IORef
+import Foreign
+import Foreign.C
+import Numeric           (showFFloat)
+import System.CPUTime    (getCPUTime)
+import System.IO
+import System.IO.Unsafe
+import System.Time
+#ifdef FREEARC_UNIX
+import System.Posix.IO
+import System.Posix.Terminal
+#endif
+
+import Utils
+import Errors
+import Files
+import FileInfo
+import Options
+
+
+-- |Здесь хранится вся информация о команде и процессе её выполнения, требуемая для отображения
+-- индикатора прогресса и вывода финальной статистики
+data UI_State = UI_State {
+    total_files     :: !FileCount   -- Кол-во файлов, которые она должна обработать
+  , total_bytes     :: !FileSize    -- Общий объём этих файлов (в распакованном виде)
+  , archive_total_bytes      :: !FileSize    -- Общий объём файлов в архиве - устанавливается только для команд распаковки
+  , archive_total_compressed :: !FileSize    -- Общий объём файлов в архиве (в сжатом виде)
+  , datatype        ::  DataType    -- Обрабатываемая в данный момент часть архива: файл/каталог/служебные данные
+  , uiFileinfo      :: !(Maybe FileInfo)  -- Текущий обрабатываемый файл (если есть)
+  -- В зависимости от того, какая часть архива сейчас обрабатывается, статистика заносится
+  -- либо на счёт файлов:
+  ,    files        :: !FileCount   -- Кол-во уже обработанных файлов
+  ,    bytes        :: !FileSize    -- Объём уже обработанных данных в распакованном виде
+  ,    cbytes       :: !FileSize    -- Объём уже обработанных данных в упакованном виде
+  -- либо на счёт каталогов (служебная информация не подсчитывается):
+  ,    dirs         :: !FileCount   -- Кол-во созданных каталогов и других служебных блоков
+  ,    dir_bytes    :: !FileSize    -- Объём уже обработанных данных в распакованном виде
+  ,    dir_cbytes   :: !FileSize    -- Объём уже обработанных данных в упакованном виде
+  -- Кроме того, мы запоминаем, какая часть из этих данных - на самом деле не упаковывалась (это полезно для определения реальной скорости упаковки):
+  ,    fake_files   :: !FileCount   -- Кол-во уже обработанных файлов
+  ,    fake_bytes   :: !FileSize    -- Объём уже обработанных данных в распакованном виде
+  ,    fake_cbytes  :: !FileSize    -- Объём уже обработанных данных в упакованном виде
+  -- Информация о текущем солид-блоке
+  ,    algorithmsCount :: Int       -- Кол-во алгоритмов в цепочке
+  ,    rw_ops       :: [[UI_RW FileSize]] -- Последовательность операций чтения/записи с разбивкой по отдельным алгоритмам
+  ,    r_bytes      :: !FileSize     -- Объём уже обработанных данных на входе первого алгоритма сжатия
+  ,    rnum_bytes   :: !FileSize     -- Объём уже обработанных данных на входе последнего алгоритма сжатия
+  }
+
+-- |Обрабатываемая в данный момент часть архива: файл/каталог/служебные данные
+data DataType = File | Dir | CData   deriving Eq
+
+-- |Операции чтения и записи в списке операций
+data UI_RW a = UI_Read a | UI_Write a
+
+-- |Тип индикатора - только прценты или + файлы/...
+data IndicatorType = INDICATOR_PERCENTS | INDICATOR_FULL   deriving Eq
+
+
+-- Выполняемая сейчас команда
+ref_command               =  unsafePerformIO$ newIORef$ error "undefined UI::ref_command"
+-- Обрабатываемый архив (не совпадает с command.$cmd_arcname при тестировании временного архива после упаковки)
+uiArcname                 =  unsafePerformIO$ newIORef$ error "undefined UI::uiArcname"
+refStartArchiveTime       =  unsafePerformIO$ newIORef$ error "undefined UI::refStartArchiveTime"
+refStartPauseTime         =  unsafePerformIO$ newIORef$ error "undefined UI::refStartPauseTime"
+refArchiveProcessingTime  =  unsafePerformIO$ newIORef$ error "undefined UI::refArchiveProcessingTime"  :: IORef Double
+ref_ui_state              =  unsafePerformIO$ newIORef$ error "undefined UI::ref_ui_state"
+putHeader                 =  unsafePerformIO$ init_once
+-- Текущая стадия выполнения команды или имя файла из uiFileinfo
+uiMessage                 =  unsafePerformIO$ newIORef$ ""
+-- |Счётчик просканированных файлов
+files_scanned             =  unsafePerformIO$ newIORef$ (0::Integer)
+
+-- |Глобальная переменная, хранящая состояние индикатора прогресса
+aProgressIndicatorState    =  unsafePerformIO$ newIORef$ error "undefined UI::aProgressIndicatorState"
+aProgressIndicatorEnabled  =  unsafePerformIO$ newIORef$ False
+-- |Время начала отсчёта текущего индиатора
+indicator_start_real_secs  =  unsafePerformIO$ newIORef$ (0::Double)
+
+-- |Синхронизация доступа к UI
+syncUI = withMVar mvarSyncUI . const;  mvarSyncUI = unsafePerformIO$ newMVar "mvarSyncUI"
+
+
+-- |Тред, следящий за indicator, и выводящий время от времени его обновлённые значения
+indicatorThread secs output =
+  backgroundThread secs $ do
+    whenM (val aProgressIndicatorEnabled) $ do
+      operationTerminated' <- val operationTerminated
+      (indicator, indType, arcname, direction, b, bytes', total') <- val aProgressIndicatorState
+      when (indicator /= NoIndicator  &&  not operationTerminated') $ do
+        bytes <- bytes' b;  total <- total'
+        -- Отношение объёма обработанных данных к общему объёму
+        let processed = total>0 &&& (fromIntegral bytes / fromIntegral total :: Double)
+        secs <- return_real_secs
+        sec0 <- val indicator_start_real_secs
+        let remains  = if processed>0.001  then " "++showHMS(sec0+(secs-sec0)/processed-secs)  else ""
+            winTitle = "{"++trimLeft p++remains++"}" ++ direction ++ takeFileName arcname
+            p        = percents indicator bytes total
+        output indicator indType winTitle b bytes total processed p
+
+-- |Выполнять в бэкграунде action каждые secs секунд
+backgroundThread secs action =
+  forkIO $ do
+    foreverM $ do
+      threadDelay (round$ secs*1000000)
+      syncUI $ do
+        action
+
+{-# NOINLINE indicatorThread #-}
+{-# NOINLINE backgroundThread #-}
+
+----------------------------------------------------------------------------------------------------
+---- Индикатор прогресса ---------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Типы индикатора прогресса (молчаливый, проценты, десятые процента)
+data Indicator = NoIndicator | ShortIndicator | LongIndicator   deriving (Eq)
+
+bytes_per_sec = 1*mb  -- Typical (de)compression speed
+
+-- |Выбрать индикатор прогресса, основываясь на показаниях свидетелей :)
+select_indicator command total_bytes  =  case (opt_indicator command)
+  of "0"                                    ->  NoIndicator      -- опция "-i" - отключить индикатор!
+     _ | i total_bytes < bytes_per_sec*100  ->  ShortIndicator   -- индикатор в процентах, если общий объём данных меньше 100 мб (при этом в секунду обрабатывается больше одного процента данных)
+       | otherwise                          ->  LongIndicator    -- индикатор в десятых долях процента, если данных больше 100 мб
+
+-- |Вывести индикатор прогресса в соответствии с выбранной точностью
+percents NoIndicator    current total  =  ""
+percents ShortIndicator current total  =  right_justify 3 (ratio2 current total) ++ "%"
+percents LongIndicator  current total  =  right_justify 5 (ratio3 current total) ++ "%"
+
+-- |Создать место для индикатора прогресса
+open_percents     =  flip replicate ' '  . indicator_len
+-- |Вернуться назад на столько символов, сколько занимает индикатор прогресса
+back_percents     =  flip replicate '\b' . indicator_len
+-- |Напечатать пробелы поверх использовавшегося индикатора прогресса
+clear_percents i  =  back_percents i ++ open_percents i
+
+-- |Размер индикатора прогресса в символах
+indicator_len NoIndicator    = 0
+indicator_len ShortIndicator = 4
+indicator_len LongIndicator  = 6
+
+-- |Format percent ratio with 2 digits
+ratio2 count 0     =  "0"
+ratio2 count total =  show$ count*100 `div` total
+
+-- |Format percent ratio with 2+1 digits
+ratio3 count 0     =  "0.0"
+ratio3 count total =  case (show$ count*1000 `div` total) of
+                        [digit]  -> "0." ++ [digit]
+                        digits   -> init digits ++ ['.', last digits]
+
+-- |Вывести число, отделяя тысячи, миллионы и т.д.: "1.234.567"
+show3 :: (Show a) => a -> [Char]
+show3 = reverse . xxx . reverse . show
+          where xxx (a:b:c:d:e) = a:b:c:'.': xxx (d:e)
+                xxx a = a
+
+{-# NOINLINE ratio2 #-}
+{-# NOINLINE ratio3 #-}
+{-# NOINLINE show3 #-}
+
+
+----------------------------------------------------------------------------------------------------
+---- Вспомогательные функции для форматирования чисел/строк и работы с временем --------------------
+----------------------------------------------------------------------------------------------------
+
+-- |Разница между двумя временами в секундах - использует особенности внутреннего представления!!!
+diffTimes (TOD sa pa) (TOD sb pb)  =  i(sa - sb) + (i(pa-pb) / 1e12)
+
+-- |Добавить секунды к времени
+addTime (TOD sa pa) secs  = TOD (sa+sb+sc) pc
+  where
+    sb = i$ floor secs
+    pb = round$ (secs - fromIntegral sb)*1e12
+    (sc,pc) = (pa+pb) `divMod` (10^12)
+
+-- |Возвратить время в юниксовом формае (секунд бог знает с какого времени)
+getUnixTime = do
+  (TOD seconds picoseconds) <- getClockTime
+  return seconds
+
+-- |Напечатать объём исходных и упакованных данных, и степень сжатия
+show_ratio cmd bytes cbytes =
+  ""        ++ show3       (if (cmdType cmd == ADD_CMD) then bytes else cbytes) ++
+   " => "   ++ show_bytes3 (if (cmdType cmd == ADD_CMD) then cbytes else bytes) ++ ". " ++
+   "Ratio " ++ ratio3 cbytes bytes ++ "%"
+
+-- |Возвратить строку, описывающую заданное время
+showTime secs  =  showFFloat (Just 2) secs " secs"
+
+-- |Возвратить строку, описывающую заданную скорость
+showSpeed bytes secs  =  show3(round$ i bytes/1000/secs) ++ " kB/s"
+
+-- |Отформатировать время как H:MM:SS
+showHMS secs  =  show hour++":"++left_fill '0' 2 (show min)++":"++left_fill '0' 2 (show sec)
+  where
+    s = round secs
+    sec = (s `mod` 60)
+    min = (s `div` 60) `mod` 60
+    hour= (s `div` 3600)
+
+
+
+-- |Отметить время, когда была достигнута определённая точка программы (чисто для внутренних бенчмарков)
+debugLog label = do
+  condPrintLine   "$" $  label   -- вычислим label и напечатаем её значение
+  real_secs <- return_real_secs
+  condPrintLineLn "$" $  ": " ++ showTime real_secs
+
+-- |Вывести информацию о списке, если он содержит как минимум два элемента
+debugLogList label list = do
+  drop 1 list &&& debugLog (format label (show3$ length list))
+
+-- |Добавить строчку в отладочный вывод программы
+debugLog0 = condPrintLineLn "$"
+
+-- |Время, реально прошедшее с начала выполнения команды над текущим архивом
+return_real_secs = do
+  start_time    <- val refStartArchiveTime
+  current_time  <- getClockTime
+  return$ diffTimes current_time start_time
+
+-- Вычитаем время, проведённое в паузе, из реального времени выполнения команды
+pause_real_secs = do
+  refStartPauseTime =:: getClockTime
+
+resume_real_secs = do
+  start_time    <- val refStartPauseTime
+  current_time  <- getClockTime
+  let pause = diffTimes current_time start_time :: Double
+  refStartArchiveTime .= (`addTime` pause)
+
+pauseTiming = bracket_ pause_real_secs resume_real_secs
+
+{-# NOINLINE diffTimes #-}
+{-# NOINLINE show_ratio #-}
+{-# NOINLINE debugLog #-}
+
+
+----------------------------------------------------------------------------------------------------
+---- Выбор сообщений, соответствующих выполняемой команде ------------------------------------------
+----------------------------------------------------------------------------------------------------
+
+msgStart cmd arcExist =
+                case (cmdType cmd, arcExist) of
+                  (ADD_CMD,     False)  ->  "Creating archive: "
+                  (ADD_CMD,     True)   ->  "Updating archive: "
+                  (LIST_CMD,    _)      ->  "Listing archive: "
+                  (TEST_CMD,    _)      ->  "Testing archive: "
+                  (EXTRACT_CMD, _)      ->  "Extracting archive: "
+                  (RECOVER_CMD, _)      ->  "Recovering archive: "
+
+msgDo cmd    =  case (cmdType cmd) of
+                  ADD_CMD     -> "Compressing "
+                  TEST_CMD    -> "Testing "
+                  EXTRACT_CMD -> "Extracting "
+
+msgFile      =  ("  " ++) . msgDo
+
+msgDone cmd  =  case (cmdType cmd) of
+                  ADD_CMD     -> "Compressed "
+                  TEST_CMD    -> "Tested "
+                  EXTRACT_CMD -> "Extracted "
+
+msgStat cmd  =  case (cmdType cmd) of
+                  ADD_CMD     -> "Compression "
+                  TEST_CMD    -> "Testing "
+                  EXTRACT_CMD -> "Extraction "
+
+-- |Напечатать "file" или "files", в зависимости от кол-ва
+show_files3 1 = "1 file"
+show_files3 n = show3 n ++ " files"
+
+-- |Напечатать "archive" или "archives", в зависимости от кол-ва
+show_archives3 1 = "1 archive"
+show_archives3 n = show3 n ++ " archives"
+
+-- |Напечатать "byte" или "bytes", в зависимости от кол-ва
+show_bytes3 1 = "1 byte"
+show_bytes3 n = show3 n ++ " bytes"
+
+
+{-
+  Структура UI:
+  - один процесс, получающий информацию от упаковки/распаковки и определяющий структуру
+      взаимодействия с UI:
+        ui_PROCESS pipe = do
+          (StartCommand cmd) <- receiveP pipe
+            (StartArchive cmd) <- receiveP pipe
+              (StartFile fi fi) <- receiveP pipe
+                (UnpackedData n) <- receiveP pipe
+                (CompressedData n) <- receiveP pipe
+            (EndArchive) <- receiveP pipe
+          (EndCommand) <- receiveP pipe
+         (EndProgram) <- receiveP pipe
+      Этот процесс записывает текущее состояние UI в SampleVar
+-}

--- a/UTF8Z.hs
+++ b/UTF8Z.hs
@@ -1,3 +1,179 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3b420a4e71d6b9a0fbfcbd712af4ad9e01d2fb66dee94e0372145bfb4c197121
-size 8274
+{-# LANGUAGE CPP, MagicHash, UnboxedTuples, UnliftedFFITypes #-}
+----------------------------------------------------------------------------------------------------
+---- Имена файлов, храняющиеся в UTF8+\0 представлении.                                         ----
+---- Имена сортируются/сравниваются с учётом или без учёта регистра в зависимости от того,      ----
+----   откомпилирована ли программа под Windows или Unix                                        ----
+----------------------------------------------------------------------------------------------------
+-- |
+-- Module      :  UTF8Z
+-- Copyright   :  (c) Bulat Ziganshin <Bulat.Ziganshin@gmail.com>
+-- License     :  Public domain
+--
+-- Maintainer  :  Bulat.Ziganshin@gmail.com
+-- Stability   :  experimental
+-- Portability :  GHC
+--
+-----------------------------------------------------------------------------
+
+module UTF8Z where
+
+import Data.Bits
+import Data.Char
+import Data.Word
+import GHC.Exts
+import GHC.IO
+import GHC.Word
+import Foreign.C.Types
+
+
+data PackedString = PS ByteArray#
+
+instance Eq PackedString where
+  a==b  =  a `comparePS` b == EQ
+  {-# INLINE (==) #-}
+
+instance Ord PackedString where
+  compare  =  comparePS
+  {-# INLINE compare #-}
+
+packString :: String -> PackedString
+packString = inlinePerformIO.packStr
+
+packStr :: String -> IO PackedString
+packStr str = IO $ \s ->
+              case newByteArray# (utfCount str +# 1#) s of { (# s, arr #) ->
+              case go arr 0# str s of { s ->
+              case unsafeFreezeByteArray# arr s of { (# s, arr #) ->
+              (# s, PS arr #) } } }
+ where
+  go p i []     s#  =      writeWord8Array# p i (u 0) s#
+  go p i (x:xs) s#
+    | ord x<=0x07f  = case writeWord8Array# p i (u (ord x)) s# of { s# ->
+                           go p (i +# 1#) xs s# }
+    | ord x<=0x07ff = case writeWord8Array# p i         (u (0xC0 .|. ((ord x `shiftR` 6) .&. 0x1F))) s# of { s# ->
+                      case writeWord8Array# p (i +# 1#) (u (0x80 .|. (ord x .&. 0x3F))) s# of { s# ->
+                           go p (i +# 2#) xs s# } }
+    | ord x<=0xffff = case writeWord8Array# p i         (u (0xE0 .|. ((ord x `shiftR` 12) .&. 0x0F))) s# of { s# ->
+                      case writeWord8Array# p (i +# 1#) (u (0x80 .|. ((ord x `shiftR` 6) .&. 0x3F))) s# of { s# ->
+                      case writeWord8Array# p (i +# 2#) (u (0x80 .|. (ord x .&. 0x3F))) s# of { s# ->
+                           go p (i +# 3#) xs s# } } }
+    | otherwise     = case writeWord8Array# p i         (u (0xF0 .|. (ord x `shiftR` 18))) s# of { s# ->
+                      case writeWord8Array# p (i +# 1#) (u (0x80 .|. ((ord x `shiftR` 12) .&. 0x3F))) s# of { s# ->
+                      case writeWord8Array# p (i +# 2#) (u (0x80 .|. ((ord x `shiftR` 6) .&. 0x3F))) s# of { s# ->
+                      case writeWord8Array# p (i +# 3#) (u (0x80 .|. (ord x .&. 0x3F))) s# of { s# ->
+                           go p (i +# 4#) xs s# } } } }
+  u n = case fromIntegral n of { (W8# w) -> w }
+
+
+unpackPS :: PackedString -> String
+unpackPS (PS ba) = unpackFoldrUtf8# ba f [] where
+    f ch r = C# ch : r
+
+
+{-# INLINE comparePS #-}
+-- Выберем между strcmp и strcasecmp в зависмости от ОС
+#if defined(FREEARC_WIN)
+comparePS (PS x) (PS y) = case inlinePerformIO$ strcasecmp (unsafeCoerce# x) (unsafeCoerce# y) of
+#else
+comparePS (PS x) (PS y) = case inlinePerformIO$ strcmp (unsafeCoerce# x) (unsafeCoerce# y) of
+#endif
+                           x | x<0       -> LT
+                             | x>0       -> GT
+                             | otherwise -> EQ
+
+-- C functions that compare strings either case-sensitive or case-ignoring
+foreign import ccall unsafe
+    strcmp :: ByteArray# -> ByteArray# -> IO CInt
+
+foreign import ccall unsafe
+    strcasecmp :: ByteArray# -> ByteArray# -> IO CInt
+
+
+-- -----------------------------------------------------------------------------
+-- Local utility functions
+
+{-# INLINE utfCount #-}
+utfCount :: String -> Int#
+utfCount cs = uc 0# cs where
+    uc n []  = n
+    uc n (x:xs)
+        | ord x <= 0x7f = uc (n +# 1#) xs
+        | ord x <= 0x7ff = uc (n +# 2#) xs
+        | ord x <= 0xffff = uc (n +# 3#) xs
+        | ord x <= 0x1fffff = uc (n +# 4#) xs
+        | ord x <= 0x3ffffff = uc (n +# 5#) xs
+        | ord x <= 0x7fffffff = uc (n +# 6#) xs
+        | otherwise = error "invalid string"
+
+
+-- | Convert Unicode characters to UTF-8.
+utfList :: String -> [Word8]
+utfList [] = []
+utfList (x:xs)
+  | ord x<=0x007f = fromIntegral (ord x) : utfList xs
+  | ord x<=0x07ff = fromIntegral (0xC0 .|. ((ord x `shiftR` 6) .&. 0x1F)):
+                    fromIntegral (0x80 .|. (ord x .&. 0x3F)):
+                    utfList xs
+  | ord x<=0xffff = fromIntegral (0xE0 .|. ((ord x `shiftR` 12) .&. 0x0F)):
+                    fromIntegral (0x80 .|. ((ord x `shiftR` 6) .&. 0x3F)):
+                    fromIntegral (0x80 .|. (ord x .&. 0x3F)):
+                    utfList xs
+  | otherwise     = fromIntegral (0xF0 .|. (ord x `shiftR` 18)) :
+                    fromIntegral (0x80 .|. ((ord x `shiftR` 12) .&. 0x3F)) :
+                    fromIntegral (0x80 .|. ((ord x `shiftR` 6) .&. 0x3F)) :
+                    fromIntegral (0x80 .|. (ord x .&. 0x3F)) :
+                    utfList xs
+
+
+{-# INLINE unpackFoldrUtf8# #-}
+unpackFoldrUtf8# :: ByteArray# -> (Char# -> b -> b) -> b -> b
+unpackFoldrUtf8# addr f e = unpack 0# where
+    unpack nh
+      | isTrue# (ch `eqChar#` '\x00'#) =  e
+      | isTrue# (ch `leChar#` '\x7F'#) =  ch `f` unpack (nh +# 1#)
+      | isTrue# (ch `leChar#` '\xDF'#) =
+           (chr# (((ord# ch                                  -# 0xC0#) `uncheckedIShiftL#`  6#) +#
+                     (ord# (indexCharArray# addr (nh +# 1#)) -# 0x80#))) `f`
+          unpack (nh +# 2#)
+      | isTrue# (ch `leChar#` '\xEF'#) =
+           (chr# (((ord# ch                                  -# 0xE0#) `uncheckedIShiftL#` 12#) +#
+                    ((ord# (indexCharArray# addr (nh +# 1#)) -# 0x80#) `uncheckedIShiftL#`  6#) +#
+                     (ord# (indexCharArray# addr (nh +# 2#)) -# 0x80#))) `f`
+          unpack (nh +# 3#)
+      | otherwise            =
+           (chr# (((ord# ch                                  -# 0xF0#) `uncheckedIShiftL#` 18#) +#
+                    ((ord# (indexCharArray# addr (nh +# 1#)) -# 0x80#) `uncheckedIShiftL#` 12#) +#
+                    ((ord# (indexCharArray# addr (nh +# 2#)) -# 0x80#) `uncheckedIShiftL#`  6#) +#
+                     (ord# (indexCharArray# addr (nh +# 3#)) -# 0x80#))) `f`
+          unpack (nh +# 4#)
+      where
+        ch = indexCharArray# addr nh
+
+
+{-# INLINE unpackFoldlUtf8# #-}
+unpackFoldlUtf8# ::  (a -> Char# -> a) -> a -> ByteArray# -> Int# -> a
+unpackFoldlUtf8# f e addr count = unpack 0# e where
+    unpack nh e
+      | isTrue# (nh ==# count)  = e
+      | isTrue# (ch `leChar#` '\x7F'#) = let n = (f e ch) in n `seq` unpack (nh +# 1#) n
+      | isTrue# (ch `leChar#` '\xDF'#) =
+           let n = f e (chr# (((ord# ch                                  -# 0xC0#) `uncheckedIShiftL#`  6#) +#
+                     (ord# (indexCharArray# addr (nh +# 1#)) -# 0x80#))) in n `seq` unpack (nh +# 2#) n
+      | isTrue# (ch `leChar#` '\xEF'#) =
+         let n = f e (chr# (((ord# ch                        -# 0xE0#) `uncheckedIShiftL#` 12#) +#
+                    ((ord# (indexCharArray# addr (nh +# 1#)) -# 0x80#) `uncheckedIShiftL#`  6#) +#
+                     (ord# (indexCharArray# addr (nh +# 2#)) -# 0x80#))) in n `seq` unpack (nh +# 3#) n
+      | otherwise            =
+         let n = f e (chr# (((ord# ch                        -# 0xF0#) `uncheckedIShiftL#` 18#) +#
+                    ((ord# (indexCharArray# addr (nh +# 1#)) -# 0x80#) `uncheckedIShiftL#` 12#) +#
+                    ((ord# (indexCharArray# addr (nh +# 2#)) -# 0x80#) `uncheckedIShiftL#`  6#) +#
+                     (ord# (indexCharArray# addr (nh +# 3#)) -# 0x80#))) in n `seq` unpack (nh +# 4#) n
+      where
+        ch = indexCharArray# addr nh
+
+
+-- Just like unsafePerformIO, but we inline it.
+{-# INLINE inlinePerformIO #-}
+inlinePerformIO :: IO a -> a
+inlinePerformIO (IO m) = case m realWorld# of (# _, r #)   -> r
+

--- a/Utils.hs
+++ b/Utils.hs
@@ -1,3 +1,1091 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a6c1c158ff9e60747c033219497a82a5606ed5752c6ba6ce5eedeb2ebd02ac41
-size 51065
+{-# LANGUAGE CPP, FunctionalDependencies #-}
+---------------------------------------------------------------------------------------------------
+---- Вспомогательные функции: работа со строками, списками, регулярными выражениями,           ----
+----   аллокатор памяти. упрощение манипуляций с IORef-переменными,                            ----
+----   определение удобных операций и управляющих структур программы.                          ----
+---------------------------------------------------------------------------------------------------
+module Utils (module Utils, module CompressionLib) where
+
+import Prelude hiding (catch)
+import Control.Concurrent
+import Control.Exception
+import Control.Monad
+import Data.Array
+import Data.Bits
+import Data.Char
+import Data.Either
+import Data.IORef
+import Data.List hiding (sortOn)
+import Data.Maybe
+import Data.Word
+import Debug.Trace
+import Foreign.Marshal.Utils
+import Foreign.Ptr
+
+import CompressionLib (MemSize,b,kb,mb,gb,tb)
+
+---------------------------------------------------------------------------------------------------
+---- Проверим define's ----------------------------------------------------------------------------
+---------------------------------------------------------------------------------------------------
+
+#if !defined(FREEARC_WIN) && !defined(FREEARC_UNIX)
+#error "You must define OS!"
+#endif
+
+#if !defined(FREEARC_INTEL_BYTE_ORDER) && !defined(FREEARC_MOTOROLA_BYTE_ORDER)
+#error "You must define byte order!"
+#endif
+
+
+---------------------------------------------------------------------------------------------------
+---- Разное :) ------------------------------------------------------------------------------------
+---------------------------------------------------------------------------------------------------
+
+-- |Собрать 4-байтовое число из отдельных байтов
+#if defined(FREEARC_INTEL_BYTE_ORDER)
+make4byte b0 b1 b2 b3 = b0+256*(b1+256*(b2+256*b3)) :: Word32
+#else
+make4byte b0 b1 b2 b3 = b3+256*(b2+256*(b1+256*b0)) :: Word32
+#endif
+
+-- |Разборщик чисел, указываемых во всяких опциях. Толкование числа определяется символами,
+-- написанными после него (b/k/f/...), если их нет - используется `default_specifier`.
+-- Результат возвращается в виде пары, второй элемент в которой - `b`, если результат выражен в байтах,
+-- или другой символ, записанный после числа, или переданный как `default_specifier`.
+parseNumber num default_specifier =
+  case (span isDigit$ strLower$ num++[default_specifier]) of
+    (digits, 'b':_)  ->  (readI digits     , 'b')
+    (digits, 'k':_)  ->  (readI digits * kb, 'b')
+    (digits, 'm':_)  ->  (readI digits * mb, 'b')
+    (digits, 'g':_)  ->  (readI digits * gb, 'b')
+    (digits, 't':_)  ->  (readI digits * tb, 'b')
+    (digits, '^':_)  ->  (2 ^ readI digits , 'b')
+    (digits,  c :_)  ->  (readI digits     ,  c )
+
+-- |Расшифровать запись размера, по умолчанию - в байтах
+parseSize memstr =
+    case (parseNumber memstr 'b') of
+        (bytes, 'b')  ->  bytes
+        _             ->  error$ memstr++" - unrecognized size specifier"
+
+-- |Расшифровать запись объёма памяти: "512b", "32k", "8m" и так далее. "24" означает 24mb
+parseMem memstr =
+    case (parseNumber memstr 'm') of
+        (bytes, 'b')  ->  clipToMaxMemSize bytes
+        _             ->  error$ memstr++" - unrecognized size specifier"
+
+-- |Аналогично parseMem, но с добавлением поддержки записи в виде 75%/75p (от общего объёма памяти)
+parseMemWithPercents memory memstr =
+    case (parseNumber memstr 'm') of
+        (bytes,    'b')  ->  clipToMaxMemSize$ bytes
+        (percents, c) | c `elem` "%p"
+                         ->  clipToMaxMemSize$ (memory * percents) `div` 100
+        _                ->  error$ memstr++" - unrecognized size specifier"
+
+-- Должна усекать к максимальному позволенному в MemSize числу или может вообще выдавать ошибку?
+clipToMaxMemSize x | x < i(maxBound::MemSize) = i x
+                   | otherwise                = i(maxBound::MemSize)
+
+readI :: Num a => String -> a
+readI = foldl f 0
+  where f m c | isDigit c  =  fromIntegral (ord c - ord '0') + (m * 10)
+              | otherwise  =  error ("Non-digit "++[c]++" in readI")
+
+readInt :: String -> Int
+readInt = readI
+
+readSignedInt ('-':xs) = - readInt xs
+readSignedInt      xs  =   readInt xs
+
+isSignedInt :: String -> Bool
+isSignedInt = all isDigit . tryToSkip "-"
+
+lb :: Integral a =>  a -> Int
+lb 0 = 0
+lb 1 = 0
+lb n = 1 + lb (n `div` 2)
+
+
+{-# NOINLINE parseNumber          #-}
+{-# NOINLINE parseSize            #-}
+{-# NOINLINE parseMem             #-}
+{-# NOINLINE parseMemWithPercents #-}
+{-# NOINLINE readI                #-}
+{-# NOINLINE readInt              #-}
+
+
+-- |Некоторые операции для более изящной записи программ
+infixl 9  .$
+infixl 1  >>==, ==<<, =<<., .>>=, .>>, .>>==, ==<<.
+(.$)    :: a -> (a -> b) -> b
+a.$b         =  b a                -- вариант $ с перевёрнутым порядком аргументов
+(>>==)  :: Monad m => m a -> (a -> b) -> m b
+a>>==b       =  a >>= return . b     -- вариант >>=, в котором второй аргумент нуждаетcя в лифтинге
+(==<<)  :: Monad m => (a -> b) -> m a -> m b
+a==<<b       =  return . a =<< b     -- вариант =<<, в котором первый аргумент нуждаетcя в лифтинге
+(=<<.)  :: Monad m => (a -> m b) -> (c -> m a) -> c -> m b
+(a=<<.b) c   =  a =<< b c          -- вариант =<< для применения в mapM и тому подобных местах
+(.>>=)  :: Monad m => (a -> m b) -> (b -> m c) -> a -> m c
+(a.>>=b) c   =  a c >>= b          -- вариант >>= для применения в mapM и тому подобных местах
+(.>>)   :: Monad m => (a -> m b) -> m c -> a -> m c
+(a.>>b)  c   =  a c >> b           -- вариант >> для применения в mapM и тому подобных местах
+(==<<.) :: Monad m => (a -> b) -> (c -> m a) -> c -> m b
+(a==<<.b) c  =  return . a =<< b c   -- вариант ==<< для применения в mapM и тому подобных местах
+(.>>==) :: Monad m => (a -> m b) -> (b -> c) -> a -> m c
+(a.>>==b) c  =  a c >>= return . b   -- вариант >>== для применения в mapM и тому подобных местах
+
+-- Типы данных, имеющие значения по умолчанию
+class    Defaults a      where defaultValue :: a
+instance Defaults ()     where defaultValue = ()
+instance Defaults Bool   where defaultValue = False
+instance Defaults [a]    where defaultValue = []
+instance Defaults (a->a)               where defaultValue = id
+instance Defaults (Maybe a)            where defaultValue = Nothing
+instance Defaults (a->IO a)            where defaultValue = return
+instance {-# OVERLAPPING #-} Defaults a => Defaults (IO a) where defaultValue = return defaultValue
+instance Defaults Int                  where defaultValue = 0
+instance Defaults Integer              where defaultValue = 0
+instance Defaults Double               where defaultValue = 0
+
+class    TestDefaultValue a       where isDefaultValue :: a -> Bool
+instance TestDefaultValue Bool    where isDefaultValue = not
+instance TestDefaultValue [a]     where isDefaultValue = null
+instance TestDefaultValue Int     where isDefaultValue = (==0)
+instance TestDefaultValue Integer where isDefaultValue = (==0)
+instance TestDefaultValue Double  where isDefaultValue = (==0)
+
+infixr 3  &&&
+infixr 2  |||
+
+-- |Дать величине значение по умолчанию
+a ||| b | isDefaultValue a = b
+        | otherwise        = a
+
+-- |Возвратить второе значение, если первое не является значением по умолчанию
+a &&& b | isDefaultValue a = defaultValue
+        | otherwise        = b
+
+-- |Применить функцию f к списку только если он не пустой
+unlessNull f xs  =  xs &&& f xs
+
+-- |Монадический вариант concatMap
+concatMapM :: Monad io => (a -> io [b]) -> [a] -> io [b]
+concatMapM f x  =  mapM f x  >>==  concat
+
+-- |Условное выполнение
+whenM cond action = do
+  allow <- cond
+  when allow
+    action
+
+unlessM = whenM . liftM not
+
+-- |Выполнить `action` над значением, возвращённым `x`, если оно не Nothing
+whenJustM  x action  =  x >>= (`whenJust` action)
+
+whenJustM_ x action  =  x >>= (`whenJust_` action)
+
+whenJust   x action  =  x .$ maybe (return Nothing) (action .>>== Just)
+
+whenJust_  x action  =  x .$ maybe (return ()) (action .>> return ())
+
+-- |Выполнить `action` над значением, возвращённым `x`, если оно "Right _"
+whenRightM_ x action  =  x >>= either doNothing (action .>> return ())
+
+-- |Выполнить onLeft/onRight над значением, возвращённым `x`
+eitherM_ x onLeft onRight  =  x >>= either (onLeft  .>> return ())
+                                           (onRight .>> return ())
+
+-- |Выполнить для каждого элемента из списка и вовзратить результат как список
+foreach = flip mapM
+
+-- |Выполнить для каждого элемента из списка
+for = flip mapM_
+
+-- |Условное выполнение с условием в конце строки
+infixr 0 `on`
+on = flip (&&&)
+
+-- |Удобный способ записать сначала то, что должно обязательно быть выполнено в конце :)
+doFinally = flip finally
+
+-- |Выполнить onError при ошибке в acquire, и action в противном случае
+handleErrors onError acquire action =
+  (acquire >>= action) `catch` (\(_::SomeException) -> onError)
+
+-- |Записать в начале то, что нужно выполнить в конце
+atExit a b = (b>>a)
+
+-- |Выполнить действие только один раз, при var=True
+once var action = do whenM (val var) action; var =: False
+init_once       = ref True
+
+-- |Заглушки на место команд, которые не должны ничего выполнять
+doNothing0       = return ()
+doNothing  a     = return ()
+doNothing2 a b   = return ()
+doNothing3 a b c = return ()
+
+-- |Игнорировать исключения
+ignoreErrors  =  handle (\(_::SomeException) -> return ())
+
+-- |Создать новый Channel и записать в него начальный список значений
+newChanWith xs = do c <- newChan
+                    writeList2Chan c xs
+                    return c
+
+-- |Константные функции
+const2 x _ _ = x
+const3 x _ _ _ = x
+const4 x _ _ _ _ = x
+
+-- |Нафига вам этот ThreadId??
+forkIO_ action = forkIO action >> return ()
+
+-- |Повторять бесконечно
+foreverM action = do
+  action
+  foreverM action
+
+-- |Управляющая структура, аналогичная циклу 'while' в обычных языках
+repeat_while inp cond out = do
+  x <- inp
+  if (cond x)
+    then do out x
+            repeat_while inp cond out
+    else return x
+
+-- |Управляющая структура, аналогичная repeat-until в Паскале
+repeat_until action = do
+  done <- action
+  when (not done) $ do
+    repeat_until action
+
+-- |Управляющая структура, разбивающая выполнение операции размером size
+-- на отдельные операции размером не более chunk кажда
+doChunks size chunk action =
+  case size of
+    0 -> return ()
+    _ -> do let n = minI size chunk
+            action (fromIntegral n)
+            doChunks (size-n) chunk action
+
+-- |Выполнить `action` над x, затем над каждым элементом списка, возвращённого из `action`, и так далее рекурсивно
+recursiveM action x  =  action x >>= mapM_ (recursiveM action)
+
+-- |Выполнить рекурсивно, если верно условие `cond`, и однократно в противном случае
+recursiveIfM cond action x  =  if cond  then recursiveM action x  else (action x >> return ())
+
+-- |Выполняет действие `action` над элементами списка `list` поочерёдно, возвращая
+-- список результатов, возвращённых `action` - в общем, аналогично mapM.
+-- Но дополнительно к этому проверяет обработанные данные по критерию `crit_f` и выходит из цикла,
+-- если этот критерий удовлетворён. Поэтому дополнительно возвращается список необработанных
+-- значений из `list`
+mapMConditional (init,map_f,sum_f,crit_f) action list = do
+  let go []     ys summary = return (reverse ys, [])     -- завершено из-за исчерпания списка
+  let go (x:xs) ys summary = do
+        y <- action x
+        let summary  =  sum_f summary (map_f y)
+        if (crit_f summary)
+          then return (reverse$ y:ys, xs)                -- завершено согласно критерию
+          else go xs (y:ys) summary
+  go list [] init
+
+-- |Execute action with background computation
+withThread thread  =  bracket (forkIO thread) killThread . const
+
+-- |Выполнить действие в другом треде и возвратить конечный результат
+bg action = do
+  resultVar <- newEmptyMVar
+  forkIO (action >>= putMVar resultVar)
+  takeMVar resultVar
+
+-- |Run an action for each element concurrently (using forkIO + MVar),
+-- collecting all results.
+-- All actions are launched in parallel; the caller blocks until all complete.
+-- Exceptions in any thread are captured and re-thrown in the calling thread.
+forConcurrently :: [a] -> (a -> IO b) -> IO [b]
+forConcurrently xs f = do
+  mvars <- mapM (\x -> do { mvar <- newEmptyMVar
+                           ; forkIO (handle (\e -> putMVar mvar (Left (e::SomeException)))
+                                            (f x >>= putMVar mvar . Right))
+                           ; return mvar }) xs
+  mapM (takeMVar >=> either throwIO return) mvars
+
+-- |Run an action for each element concurrently, discarding results.
+-- Exceptions in any thread are captured and re-thrown in the calling thread.
+forConcurrently_ :: [a] -> (a -> IO ()) -> IO ()
+forConcurrently_ xs f = do
+  mvars <- mapM (\x -> do { mvar <- newEmptyMVar
+                           ; forkIO (handle (\e -> putMVar mvar (Left (e::SomeException)))
+                                            (f x >> putMVar mvar (Right ())))
+                           ; return mvar }) xs
+  mapM_ (takeMVar >=> either (throwIO :: SomeException -> IO ()) return) mvars
+
+
+{-# NOINLINE foreverM #-}
+{-# NOINLINE repeat_while #-}
+{-# NOINLINE repeat_until #-}
+{-# NOINLINE mapMConditional #-}
+{-# NOINLINE bg #-}
+{-# NOINLINE forConcurrently #-}
+{-# NOINLINE forConcurrently_ #-}
+
+
+-- |Отфильтровать список с помощью монадического (выполняемого) предиката
+filterM :: (Monad m) => (a -> m Bool) -> [a] -> m [a]
+filterM p  =  go []
+  where go accum []      =  return$ reverse accum
+        go accum (x:xs)  =  p x  >>=  bool (go    accum  xs)
+                                           (go (x:accum) xs)
+
+-- |mapMaybe, перенесённая в класс Monad
+mapMaybeM :: Monad m => (a -> m (Maybe b)) -> [a] -> m [b]
+mapMaybeM f  =  go []
+  where go accum []      =  return$ reverse accum
+        go accum (x:xs)  =  f x  >>=  maybe (      go    accum  xs)
+                                            (\r -> go (r:accum) xs)
+
+-- |@firstJust@ takes a list of @Maybes@ and returns the
+-- first @Just@ if there is one, or @Nothing@ otherwise.
+firstJust :: [Maybe a] -> Maybe a
+firstJust [] = Nothing
+firstJust (Just x  : ms) = Just x
+firstJust (Nothing : ms) = firstJust ms
+
+-- |Вернуть первый успешный (Just) результат применения f к списку или Nothing
+firstMaybe :: (a -> Maybe b) -> [a] -> Maybe b
+firstMaybe f  =  firstJust . map f
+
+-- |Заменить Nothing на значение по умолчанию
+defaultVal = flip fromMaybe
+
+-- |Заменить Nothing на значение по умолчанию - для императивной операции
+defaultValM = liftM2 defaultVal
+
+-- |Выбрать одно из двух значений в зависимости от последнего аргумента
+bool onFalse onTrue False  =  onFalse
+bool onFalse onTrue True   =  onTrue
+
+-- |if без синт. оверхеда
+iif True  onTrue onFalse  =  onTrue
+iif False onTrue onFalse  =  onFalse
+
+-- Применить к списку одну из двух функций в зависимости от того, пуст ли он
+list onNotNull onNull [] = onNull
+list onNotNull onNull xs = onNotNull xs
+
+-- |Возвратить True, если значение - не Nothing
+maybe2bool (Just _) = True
+maybe2bool Nothing  = False
+
+-- |Проверка на Left
+isLeft (Left _) = True
+isLeft _        = False
+
+-- |Удалить элементы, отвечающие заданному предикату
+deleteIf p = filter (not . p)
+
+-- |Удалить элементы, соответствующие любому из списка предикатов
+deleteIfs = deleteIf . anyf
+
+-- |Обновление lookup-списка
+update list a@(key,value)  =  a : [x | x@(k,v)<-list, k/=key]
+
+-- |Замена значений по списку
+changeTo list value  =  lookup value list `defaultVal` value
+
+-- |Напечатать и возвратить одно значение
+trace2 s = trace (show s) s
+
+-- |Evaluate list elements
+evalList (x:xs) = x `seq` evalList xs
+evalList []     = ()
+
+{-
+-- Cale Gibbard
+
+A useful little higher order function. Some examples of use:
+
+swing map :: forall a b. [a -> b] -> a -> [b]
+swing any :: forall a. [a -> Bool] -> a -> Bool
+swing foldr :: forall a b. b -> a -> [a -> b -> b] -> b
+swing zipWith :: forall a b c. [a -> b -> c] -> a -> [b] -> [c]
+swing find :: forall a. [a -> Bool] -> a -> Maybe (a -> Bool) -- applies each of the predicates to the given value, returning the first predicate which succeeds, if any
+swing partition :: forall a. [a -> Bool] -> a -> ([a -> Bool], [a -> Bool])
+
+-}
+
+swing :: (((a -> b) -> b) -> c -> d) -> c -> a -> d
+swing f = flip (f . flip ($))
+
+
+-- |Map on functions instead of its' arguments!
+map_functions []     x  =  []
+map_functions (f:fs) x  =  f x : map_functions fs x
+
+-- |Проверить, что все функции из списка дают True на (опущенном здесь) аргументе. Эффективней, чем swing all
+allf x = all_functions x
+all_functions []  = const True
+all_functions [f] = f
+all_functions fs  = and . map_functions fs
+
+-- |Проверить, что хоть одна функция из списка даёт True на (опущенном здесь) аргументе. Эффективней, чем swing any
+anyf x = any_function x
+any_function []  = const False
+any_function [f] = f
+any_function fs  = or . map_functions fs
+
+-- |Применить к аргументу последовательно все функции из списка
+applyAll []     x = x
+applyAll (f:fs) x = applyAll fs (f x)
+
+(f>>>g) x = g(f x)
+
+
+---------------------------------------------------------------------------------------------------
+---- Операции над строками ------------------------------------------------------------------------
+---------------------------------------------------------------------------------------------------
+
+-- |Разбить строку на две подстроки, разделённые заданным символом
+split2 :: (Eq a) => a -> [a] -> ([a],[a])
+split2 c s  =  (chunk, drop 1 rest)
+  where (chunk, rest) = break (==c) s
+
+-- |Соединить их назад как было :)
+join2 :: [a] -> ([a],[a]) -> [a]
+join2 between (a,b) = a++between++b
+
+-- |Разбить строку на подстроки, разделённые заданным символом
+split :: (Eq a) => a -> [a] -> [[a]]
+split c s =
+  let (chunk, rest) = break (==c) s
+  in case rest of  []     -> [chunk]
+                   _:rest -> chunk : split c rest
+
+-- |Соединить список строк в единый текст с разделителем: "one, two, three"
+joinWith :: [a] -> [[a]] -> [a]
+joinWith x  =  concat . intersperse x
+
+-- |Соединить список строк в единый текст, используя два разных разделителя:
+-- joinWith2 ", " " and " ["one","two","three","four"]  -->  "one, two, three and four"
+joinWith2 :: [a] -> [a] -> [[a]] -> [a]
+joinWith2 a b []    =  []
+joinWith2 a b [x]   =  x
+joinWith2 a b list  =  joinWith a (init list) ++ b ++ last list
+
+-- |Поставить x между s1 и s2, если обе строки непустые
+between s1 x [] = s1
+between [] x s2 = s2
+between s1 x s2 = s1++x++s2
+
+-- |Добавить двойные кавычки вокруг строки
+quote :: String -> String
+quote str  =  "\"" ++ str ++ "\""
+
+-- |Удалить двойные кавычки вокруг строки (если они есть)
+unquote :: String -> String
+unquote ('"':str) | str>"" && x=='"'  =  xs     where (x:xs) = reverse str
+unquote str = str
+
+contains = flip elem
+
+-- |Удалить n элементов в конце спсика
+dropEnd n  =  reverse . drop n . reverse
+
+-- |Истина, если `s` содержит хотя бы один из элементов множества `set`
+s `contains_one_of` set  =  any (`elem` set) s
+
+-- |Последние n элементов
+n `lastElems` xs  =  drop (length xs - n) xs
+
+-- |Заменить n'й элемент (считая с 0) в списке `xs` на `x`
+replaceAt n x xs  =  hd ++ x : drop 1 tl
+    where (hd,tl) = splitAt n xs
+
+-- |Изменить n'й элемент (считая с 0) в списке `xs` с `x` на `f x`
+updateAt n f xs  =  hd ++ f x : tl
+    where (hd,x:tl) = splitAt n xs
+
+-- |Заменить в списке все вхождения элемента 'from' на 'to'
+replace from to  =  map (\x -> if x==from  then to  else x)
+
+-- |Если первая строка является префиксом второй - возвратить остаток второй строки, иначе Nothing
+startFrom (x:xs) (y:ys) | x==y  =  startFrom xs ys
+startFrom [] str                =  Just str
+startFrom _  _                  =  Nothing
+
+-- |Проверка, что строка начинается или заканчивается заданными символами
+beginWith s = isJust . startFrom s
+endWith   s = beginWith (reverse s) . reverse
+
+-- |Попытаемся удалить строку substr в начале str
+tryToSkip substr str  =  (startFrom substr str) `defaultVal` str
+
+-- |Попытаться удалить строку substr в конце str
+tryToSkipAtEnd substr str = reverse (tryToSkip (reverse substr) (reverse str))
+
+-- | The 'isInfixOf' function takes two lists and returns 'True'
+-- if the second list is contained, wholy and intact,
+-- anywhere within the first.
+substr haystack needle  =  any (needle `isPrefixOf`) (tails haystack)
+
+-- |Список позиций подстроки в строке
+strPositions haystack needle  =  elemIndices True$ map (needle `isPrefixOf`) (tails haystack)
+
+-- |Заменить в строке `s` все вхождения `from` на `to`
+replaceAll from to = repl
+  where repl s      | Just remainder <- startFrom from s  =  to ++ repl remainder
+        repl (c:cs)                                       =  c : repl cs
+        repl []                                           =  []
+
+-- |Заменить %1 на заданную строку
+format msg s  =  replaceAll "%1" s msg
+
+-- |Заменить %1..%9 на заданные строки
+formatn msg s  =  go msg
+  where go ('%':d:rest) | isDigit d = (s !! (digitToInt d-1)) ++ go rest
+        go (x:rest)                 = x : go rest
+        go ""                       = ""
+
+-- |Заменить в строке `s` префикс `from` на `to`
+replaceAtStart from to s =
+  case startFrom from s of
+    Just remainder  -> to ++ remainder
+    Nothing         -> s
+
+-- |Заменить в строке `s` суффикс `from` на `to`
+replaceAtEnd from to s =
+  case startFrom (reverse from) (reverse s) of
+    Just remainder  -> reverse remainder ++ to
+    Nothing         -> s
+
+-- |Закодировать символы, запрещённые в URL
+urlEncode = concatMap (\c -> if isReservedChar(ord c) then '%':encode16 [c] else [c])
+  where
+        isReservedChar x
+            | x >= ord 'a' && x <= ord 'z' = False
+            | x >= ord 'A' && x <= ord 'Z' = False
+            | x >= ord '0' && x <= ord '9' = False
+            | x <= 0x20 || x >= 0x7F = True
+            | otherwise = x `elem` map ord [';','/','?',':','@','&'
+                                           ,'=','+',',','$','{','}'
+                                           ,'|','\\','^','[',']','`'
+                                           ,'<','>','#','%', chr 34]
+
+-- |Вернуть шестнадцатеричную запись строки символов с кодами <=255
+encode16 (c:cs) | n<256 = [intToDigit(n `div` 16), intToDigit(n `mod` 16)] ++ encode16 cs
+                             where n = ord c
+encode16 "" = ""
+
+-- |Декодировать шестнадцатеричную запись строки символов с кодами <=255
+decode16 (c1:c2:cs) = chr(digitToInt c1 * 16 + digitToInt c2) : decode16 cs
+decode16 ""         = ""
+
+-- |Взять первых n элементов списка и добавить к ним more для индикации того, что что-то было опущено
+takeSome n more s | (y>[])    = x ++ more
+                  | otherwise = x
+                  where  (x,y) = splitAt n s
+
+-- |Выровнять строку влево/вправо, дополнив её до заданной ширины пробелами или чем-нибудь ещё
+right_fill  c n s  =  s ++ replicate (n-length s) c
+left_fill   c n s  =  replicate (n-length s) c ++ s
+left_justify       =  right_fill ' '
+right_justify      =  left_fill  ' '
+
+-- Удалить пробелы в начале/конце строки или по обоим сторонам
+trimLeft  = dropWhile (==' ')
+trimRight = reverse . trimLeft . reverse
+trim      = trimLeft . trimRight
+
+-- |Перевести строку в нижний регистр
+strLower = map toLower
+
+-- |Сравнить две строки, игнорируя регистр
+strLowerEq a b  =  strLower a == strLower b
+
+-- |break начиная со второго элемента
+break1 f (x:xs)  =  mapFst (x:) (break f xs)
+
+-- |Возвратить значение по умолчанию вместо головы списка, если он пуст
+head1 [] = defaultValue
+head1 xs = head xs
+
+-- Аналог tail, спокойно реагирующий на пустые списки
+tail1 [] = []
+tail1 xs = tail xs
+
+-- Аналог init, спокойно реагирующий на пустые списки
+init1 [] = []
+init1 xs = init xs
+
+-- Аналог last, спокойно реагирующий на пустые списки
+last1 [] = defaultValue
+last1 xs = last xs
+
+-- |Map various parts of list
+mapHead f []      =  []
+mapHead f (x:xs)  =  f x : xs
+
+mapTail f []      =  []
+mapTail f (x:xs)  =  x : map f xs
+
+mapInit f []      =  []
+mapInit f xs      =  map f (init xs) : last xs
+
+mapLast f []      =  []
+mapLast f xs      =  init xs ++ [f (last xs)]
+
+{-# NOINLINE replaceAll #-}
+{-# NOINLINE replaceAtEnd #-}
+
+
+
+---------------------------------------------------------------------------------------------------
+---- Операции над списками ------------------------------------------------------------------------
+---------------------------------------------------------------------------------------------------
+
+-- |Sort list by function result (use Schwarznegian transform)
+sortOn  f  =  map snd . sortOn' fst . map (keyval f)
+
+-- |Sort list by function result (don't use Schwarznegian transform!)
+sortOn' f  =  sortBy (map2cmp f)
+
+-- |Group list by function result
+groupOn f  =  groupBy (map2eq f)
+
+-- |Sort and Group list by function result
+sort_and_groupOn  f  =  groupOn f . sortOn  f
+sort_and_groupOn' f  =  groupOn f . sortOn' f
+
+-- |Сгруппировать все элементы (a.b) с одинаковым значением 'a'
+groupFst :: (Ord a) =>  [(a,b)] -> [(a,[b])]
+groupFst = map (\xs -> (fst (head xs), map snd xs)) . sort_and_groupOn fst
+
+-- |Удаляет дубликаты из списка
+removeDups = removeDupsOn id
+
+-- |Оставляет только по одному элементу из каждой группы с одинаковым значением f
+removeDupsOn f = map head . sort_and_groupOn f
+
+-- |Проверить, что все последовательные значения в списке удовлетворяют заданному соотношению
+isAll f []       = True
+isAll f [x]      = True
+isAll f (x:y:ys) = f x y  &&  isAll f (y:ys)
+
+-- |Проверить, что хотя бы два каких-нибудь последовательных значения в списке удовлетворяют заданному соотношению
+isAny f []       = False
+isAny f [x]      = False
+isAny f (x:y:ys) = f x y  ||  isAny f (y:ys)
+
+-- |Check that list is sorted by given field/critery
+isSortedOn f  =  isAll (<=) . map f
+
+-- |Check that all elements in list are equal by given field/critery
+isEqOn f      =  isAll (==) . map f
+
+-- |Find maximum element by given comparison critery
+maxOn f (x:xs) = go x xs
+  where go x [] = x
+        go x (y:ys) | f x > f y  =  go x ys
+                    | otherwise  =  go y ys
+
+-- |Merge two lists, sorted by `cmp`, in one sorted list
+merge :: (a -> a -> Ordering) -> [a] -> [a] -> [a]
+merge cmp xs [] = xs
+merge cmp [] ys = ys
+merge cmp (x:xs) (y:ys)
+ = case x `cmp` y of
+        GT -> y : merge cmp (x:xs)   ys
+        _  -> x : merge cmp    xs (y:ys)
+
+-- |Разбить список на `numGroups` подсписков в соответствии со значением, возвращаемым `crit_f`
+partitionList numGroups crit_f list =
+  elems $ accumArray (flip (:)) [] (0, numGroups-1) (map (keyval crit_f) (reverse list))
+
+-- partitionList numGroups crit_f list =
+--   let xs = map (keyval crit_f) list
+--       go 0 [] all = all
+--       go n list prev = let (this, next) = partition (\(a,b) -> a==n-1) list
+--                        in go (n-1) next (map snd this:prev)
+--   in go numGroups xs []
+
+-- |Разбить список на группы в соответствии с предикатами из списка `groups`:
+--   splitList [(=='a'), (=='c')] 2 "cassa"  ->  ["aa","c","ss"]
+--
+splitList groups default_group filelist =
+  let go [] filelist sorted  =  replaceAt default_group filelist (reverse sorted)
+      go (group:groups) filelist sorted =
+        let (found, notfound)  =  partition group filelist
+        in go groups notfound (found:sorted)
+  in go groups filelist []
+
+-- |Найти номер первого предиката из списка `groups`, которому удовлетворяет значение `value`
+findGroup groups default_group value  =  (findIndex ($ value) groups) `defaultVal` default_group
+
+-- Utility functions for list operations
+keyval  f x    =  (f x, x)                -- |Return pair containing computed key and original value
+map2cmp f x y  =  (f x) `compare` (f y)   -- |Converts "key_func" to "compare_func"
+map2eq  f x y  =  (f x) == (f y)          -- |Converts "key_func" to "eq_func"
+
+
+-- |Рекурсивная обработка списка
+recursive :: ([a]->(b,[a])) -> [a] -> [b]
+recursive f list  =  list &&& (x:recursive f xs)   where (x,xs) = f list
+
+-- |Разбить список на подсписки, длина которых определяется вызовом функции `len_f` на остатке списка
+splitByLen :: ([a]->Int) -> [a] -> [[a]]
+splitByLen len_f  =  recursive (\xs -> splitAt (len_f xs) xs)
+
+-- |Эта функция получает список длин подсписков и разбивает `xs` в соответствии с ним
+splitByLens (len:lens) list  =  (x:splitByLens lens xs)    where (x,xs) = splitAt len list
+splitByLens []         []    =  []
+
+-- |Возвращает длину начального сегмента списка, удовлетворяющего комбинированному условию,
+-- например "groupLen (fiSize) (+) (<16*mb) files" возвращает длину начального сегмента списка,
+-- содержащую файлы суммарным объёмом не более 16 мегабайт
+groupLen mapper combinator tester  =  length . takeWhile tester . scanl1 combinator . map mapper
+
+-- |Объединить результаты span и break: spanBreak isDigit "100a10b2c" = ("100a", "10b2c")
+spanBreak crit xs  = let (s1,tail1) = span  crit xs
+                         (s2,tail2) = break crit tail1
+                     in (s1++s2, tail2)
+
+-- |Разбить список на группы, заголовки которых - элементы, отвечающие критерию 'crit'
+makeGroups              :: (a -> Bool) -> [a] -> [[a]]
+makeGroups crit []      =  []
+makeGroups crit (x:xs)  =  (x:ys) : makeGroups crit zs
+                             where (ys,zs) = break crit xs
+
+-- |Разбить список на группы, разделённые элементами, отвечающими критерию 'crit':
+-- splitOn even [1,2,4,8,3,5,7] == [[1],[2],[4],[8],[3,5,7]]
+splitOn crit []  =  []
+splitOn crit xs  =  (not(null ys)  &&&  (ys :))
+                    (not(null zs)  &&&  ([head zs] : splitOn crit (tail zs)))
+                      where (ys,zs) = break crit xs
+
+-- |Удалить в списке дубликаты по заданному критерию. O(n^2), зато сохраняет порядок элементов в списке
+keepOnlyFirstOn f [] = []
+keepOnlyFirstOn f (x:xs) = x : keepOnlyFirstOn f (filter (\a -> f x /= f a) xs)
+
+-- |Оставить в списке только последний из дубликатов по заданному критерию
+keepOnlyLastOn f = reverse . keepOnlyFirstOn f . reverse
+
+-- |Удалить элементы с заданными номерами из списка
+deleteElems = go 0
+  where go n xs [] = xs  -- Удалять больше нечего
+        go n (x:xs) iis@(i:is) | n<i  = x:go (n+1) xs iis  -- мы ещё не дошли до i-го элемента
+                               | n==i =   go (n+1) xs is   -- дошли - удаляем!
+
+
+{-# NOINLINE partitionList #-}
+{-# NOINLINE splitList #-}
+
+
+---------------------------------------------------------------------------------------------------
+---- Операции с массивами -------------------------------------------------------------------------
+---------------------------------------------------------------------------------------------------
+
+-- |Превратить список в 0-based array
+listArray0 list  =  listArray (0,length(list)-1) list
+
+-- |Найти миним. и макс. индексы в списке пар и создать из них массив,
+populateArray defaultValue castValue pairs =
+  accumArray (\a b -> castValue b) defaultValue (minimum indexes, maximum indexes) pairs
+  where indexes = map fst pairs
+
+
+---------------------------------------------------------------------------------------------------
+---- Операции с tuples ----------------------------------------------------------------------------
+---------------------------------------------------------------------------------------------------
+
+-- Операции над tuple/2
+mapFst    f (a,b)  =  (f a,   b)
+mapSnd    f (a,b)  =  (  a, f b)
+mapFstSnd f (a,b)  =  (f a, f b)
+map2      (f,g) a  =  (f a, g a)
+mapFsts = map . mapFst
+mapSnds = map . mapSnd
+map2s   = map . map2
+
+-- |Слить вторые элементы пар в списке и оставить один (общий) первый элемент
+concatSnds xs = (fst (head xs), concatMap snd xs)
+
+-- Операции над tuple/3
+fst3 (a,_,_)    =  a
+snd3 (_,a,_)    =  a
+thd3 (_,_,a)    =  a
+map3 (f,g,h) a  =  (f a, g a, h a)
+
+
+---------------------------------------------------------------------------------------------------
+---- Эмуляция обычных переменных ------------------------------------------------------------------
+---------------------------------------------------------------------------------------------------
+
+infixl 0 =:, +=, -=, ++=, =::, .=, .<-, <<=, <=>
+
+-- Simple variables
+class Variable v a | v->a where
+  new  :: a -> IO v
+  val  :: v -> IO a
+  (=:) :: v -> a -> IO ()
+  (.=) :: v -> (a->a) -> IO ()
+  (=::) :: v -> IO a -> IO ()
+  (.<-) :: v -> (a->IO a) -> IO ()
+  -- Default implementations
+  a.=f = do x<-val a; a=:f x
+  a=::b = (a=:) =<< b
+  a.<-f = do x<-val a>>=f; a=:x
+
+ref = newIORef
+instance Variable (IORef a) a where
+  new = newIORef
+  val = readIORef
+  a=:b = writeIORef a b
+  a.=b = modifyIORef a b
+  a.<-b = modifyIORefIO a b
+
+mvar = newMVar
+instance Variable (MVar a) a where
+  new = newMVar
+  val = readMVar
+  a=:b = swapMVar a b >> return ()
+  a.=b = modifyMVar_ a (return . b)
+  a.<-b = modifyMVar_ a b
+
+a+=b = a.=(\a->a+b)
+a-=b = a.=(\a->a-b)
+a++=b = a.=(\a->a++b)
+(<=>) :: Variable v x => v -> x -> IO x
+a<=>b = do x <- val a; a =: b; return x
+withRef init  =  with' (ref init) val
+
+
+-- Accumulation lists
+newtype AccList a = AccList [a]
+newList   = ref$ AccList []
+a<<=b     = a .= (\(AccList x) -> AccList$ b:x)
+pushList  = (<<=)
+listVal a = val a >>== (\(AccList x) -> reverse x)
+withList  =  with' newList listVal
+
+
+-- |Добавить значение в список, хранимый по ссылке IORef
+addToIORef :: IORef [a] -> a -> IO ()
+addToIORef var x  =  var .= (x:)
+
+-- |Использовать значение, хранящееся по ссылке IORef, в процедуре,
+-- и записать на его место новое значение, возвращённое этой процедурой
+modifyIORefIO :: IORef a -> (a -> IO a) -> IO ()
+modifyIORefIO var action = do
+  readIORef var  >>=  action  >>=  writeIORef var
+
+-- |Ещё одна полезная управляющая структура
+with' init finish action  =  do a <- init;  action a;  finish a
+
+-- |Выполнить операцию и возвратить её результат внутри обрамления init/finish операций
+inside init finish action  =  do init;  x <- action;  finish; return x
+
+-- |Выполнить "add key" c кешированием результатов
+lookupMVarCache mvar add key = do
+  modifyMVar mvar $ \assocs -> do
+    case (lookup key assocs) of
+      Just value -> return (assocs, value)
+      Nothing    -> do value <- add key
+                       return ((key,value):assocs, value)
+
+
+-- JIT-переменные инициализируются только в момент их первого использовани
+newJIT :: IO a -> IO (IORef (Either (IO a) a))
+newJIT init        = ref (Left init)
+delJIT :: IORef (Either (IO a) a) -> (a -> IO ()) -> IO ()
+delJIT a    finish = whenRightM_ (readIORef a) finish
+valJIT :: IORef (Either (IO a) a) -> IO a
+valJIT a           = do x <- readIORef a
+                        case x of
+                          Left init -> do x<-init; writeIORef a (Right x); return x
+                          Right x   -> return x
+
+withJIT :: IO a -> (a -> IO ()) -> (IORef (Either (IO a) a) -> IO b) -> IO b
+withJIT init finish action = do a <- newJIT init;  action a  `finally`  delJIT a finish
+
+
+---------------------------------------------------------------------------------------------------
+---- Ссылочная арифметика и операций над целыми ---------------------------------------------------
+---------------------------------------------------------------------------------------------------
+
+infixl 6 +:, -:
+ptr+:n   = ptr `plusPtr` (fromIntegral n)
+ptr-:buf = fromIntegral  (ptr `minusPtr` buf)
+copyBytesI dst src len  =  copyBytes dst src (fromIntegral len)
+minI a b                =  i$ min (i a) (i b)
+maxI a b                =  i$ max (i a) (i b)
+clipToMaxInt            =  i. min (i (maxBound::Int))
+atLeast                 =  max
+i :: (Integral a, Num b) => a -> b
+i                       =  fromIntegral
+clipTo low high         =  min high . max low
+divRoundUp   x chunk    = ((x-1) `div` i chunk) + 1
+roundUp      x chunk    = divRoundUp x chunk * i chunk
+divRoundDown x chunk    = x `div` i chunk
+roundDown    x chunk    = divRoundDown x chunk * i chunk
+roundTo      x chunk    = i (((((toInteger(x)*2) `divRoundDown` chunk)+1) `divRoundDown` 2) * i chunk) `asTypeOf` x
+
+
+---------------------------------------------------------------------------------------------------
+---- Распределение памяти в циклическом буфере ----------------------------------------------------
+---------------------------------------------------------------------------------------------------
+
+-- |Распределение памяти в циклическом буфере с выравниванием выделяемых блоков
+--   heapsize     - размер буфера
+--   aBUFFER_SIZE - максимальный размер распределяемого блока
+--   aALIGN       - все выделяемые блоки выравниваются на границу, кратную этому числу
+--   returnBlock  - процедура получения буфера, освобождённого потребителем. Вызывается,
+--                    когда памяти становится недостаточно для удовлетворения очередного запроса
+--
+allocator heapsize aBUFFER_SIZE aALIGN returnBlock = do
+  let aHEAP_START = 0          -- начало буфера, должно быть = 0
+      aHEAP_END   = heapsize   -- конец буфера
+
+  start <- ref aHEAP_START     -- указатель начала свободного места в буфере
+  end   <- ref aHEAP_END       -- указатель конца свободного места
+                               -- если эти указатели равны, то свободного места нет
+#if 0
+  let debug = putStr         -- отладочная печать
+
+  let printStats s = do      -- Напечатать состояние буфера при отладке
+        astart <- val start
+        aend <- val end
+        debug$ left_justify 48 s++"STATE start:"++show astart++", end:"++show aend++", avail:"++show ((aend-astart) `mod` aHEAP_END)++"\n"
+
+  debug "\n"
+#else
+  let debug      = return
+      printStats = return
+#endif
+
+  -- Выравнять значение на ближайшую величину, кратную aALIGN
+  let align n  =  (((n-1) `div` aALIGN) + 1) * aALIGN
+
+  -- Возвращает адрес блока: >=n, выровненного на aALIGN и имеющего как минимум aBUFFER_SIZE байт до конца буфера
+  let nextAvail n = if (aHEAP_END-aligned<aBUFFER_SIZE)
+                      then aHEAP_END
+                      else aligned
+                    where aligned = align n
+
+  -- Возвратить количество свободной памяти в буфере
+  let available = do
+        astart <- val start
+        aend   <- val end
+        if (astart<=aend) then
+           return (aend-astart)
+         else if (astart<aHEAP_END) then
+           return (aHEAP_END-astart)
+         else do
+           -- Перевести указатель начала свободной памяти на начало буфера
+           start =: aHEAP_START
+           debug "===================================\n"
+           printStats ""
+           available
+
+  -- Дождаться освобождения блока памяти и отметить его освобождение
+  let waitReleasingMemory = do
+        (addr,size) <- returnBlock
+        astart <- val start
+        aend   <- val end
+        unless (addr == aend || (addr==aHEAP_START && (aHEAP_END-aend<aBUFFER_SIZE)))$  fail "addToAvail!"
+        let new_end = nextAvail(addr+size)
+        if new_end == astart
+          then do start=:aHEAP_START; end=:aHEAP_END -- now all memory is free
+          else end =: new_end
+        printStats$ "*** returned buf:"++show addr++" size:"++show size++"   "
+
+  -- Получить очередной блок размера aBUFFER_SIZE. Если свободных блоков нет - дождатьс
+  --   возвращения необходимого количества выделенной прежде памяти
+  let getBlock = do
+        avail <- available
+        if (avail >= aBUFFER_SIZE) then do
+           block <- val start
+           start =: error "Block not shrinked"
+           return block
+         else do
+           waitReleasingMemory
+           getBlock
+
+  -- Укоротить выделенный блок до размера `size`. Должна быть обязательно вызвана после getBlock
+  let shrinkBlock block size = do
+        astart <- val start
+        --unless (astart == block)$      fail "Tryed to shrink another block"
+        unless (size <= aBUFFER_SIZE)$  fail "Growing instead of shrinking :)"
+        start =: nextAvail(block+size)
+        printStats$ "getBlock buf:"++show block++", size: "++show aBUFFER_SIZE++" --> "++show size++"    "
+
+  -- Возвратить интерфейс к использованию циклического буфера
+  return (getBlock, shrinkBlock)
+
+
+-- |Циклический аллокатор, использующий блок памяти `heap`.
+-- Преобразует функции, с которыми работает функция `allocator`
+memoryAllocator heap size chunksize align returnBlock = do
+  let returnBlock2            =  do (buf,len) <- returnBlock; return (buf-:heap, len)
+  (getBlock2, shrinkBlock2)  <-  allocator size chunksize align returnBlock2
+  let getBlock                =  do block <- getBlock2; return (heap+:block)
+      shrinkBlock buf len     =  do shrinkBlock2 (buf-:heap) len
+  return (getBlock, shrinkBlock)
+
+
+---------------------------------------------------------------------------------------------------
+---- Поддержка регулярных выражений.                                                           ----
+---- todo: #define FULL_REGEXP включает использование расширенных рег. выражений: r[0-9][0-9]  ----
+---------------------------------------------------------------------------------------------------
+
+-- |Скомпилированное представление регулярного выражения                            ПРИМЕР
+data RegExpr = RE_End                     -- конец маски                            ""
+             | RE_Anything                -- любая строка                           "*"
+             | RE_AnyStr  RegExpr         -- '*', после которой будут ещё '*'       '*':"bc*"
+             | RE_FromEnd RegExpr         -- проверить соответствие RE конца строки '*':"bc"
+             | RE_AnyChar RegExpr         -- любой символ, затем RE                 '?':"bc"
+             | RE_Char    Char RegExpr    -- заданный символ, затем RE              'a':"bc"
+
+-- |Проверить, что строка содержит один из символов,
+-- имеющих специальное значение в регулярных выражениях
+is_wildcard s  =  s `contains_one_of` "?*"
+
+-- |Скомпилировать текстовое представление регулярного выражения в структуру RegExpr
+compile_RE s  =  case s of
+  ""                         -> RE_End
+  "*"                        -> RE_Anything
+  '*':cs | cs `contains` '*' -> RE_AnyStr   (compile_RE  cs)
+         | otherwise         -> RE_FromEnd  (compile_RE$ reverse s)
+  '?':cs                     -> RE_AnyChar  (compile_RE  cs)
+  c  :cs                     -> RE_Char   c (compile_RE  cs)
+
+-- |Проверить соответствие строки скомпилированному регулярному выражению
+match_RE r = case r of
+  RE_End        -> null
+  RE_Anything   -> const True
+  RE_AnyStr   r -> let re = match_RE r in \s -> any re (tails s)
+  RE_FromEnd  r -> let re = match_RE r in re . reverse
+  RE_AnyChar  r -> let re = match_RE r in \s -> case s of
+                     ""   -> False
+                     _:xs -> re xs
+  RE_Char   c r -> let re = match_RE r in \s -> case s of
+                     ""   -> False
+                     x:xs -> x==c && re xs
+
+-- |Проверить соответствие строки `s` регулярному выражению `re`
+match re {-s-}  =  match_RE (compile_RE re) {-s-}
+
+-- Perl-like names for matching routines
+infix 4 ~=, !~
+(~=)    = flip match
+a !~ b  = not (a~=b)
+
+-- |Convert a list to a 0-based array
+toP :: [a] -> Array Int a
+toP xs = listArray (0, length xs - 1) xs
+
+-- |Array indexing as an operator (array on the left, index on the right)
+infixl 9 !:
+(!:) :: (Ix i) => Array i a -> i -> a
+(!:) = (!)

--- a/Win32Files.hs
+++ b/Win32Files.hs
@@ -1,3 +1,310 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5a371a86b5b0c1d9cfbb84afe1308b67246af013c9e2f499547f5d0d286cd9e7
-size 10732
+{-# OPTIONS_GHC -cpp #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Win32Files
+-- Copyright   :  (c) Bulat Ziganshin <Bulat.Ziganshin@gmail.com>
+-- License     :  Public domain
+--
+-- Maintainer  :  Bulat.Ziganshin@gmail.com
+-- Stability   :  experimental
+-- Portability :  GHC/mingw32
+--
+-----------------------------------------------------------------------------
+
+module Win32Files where
+
+import Prelude hiding (catch)
+import Control.Exception
+import Data.Bits
+import Data.Int
+import Data.Word
+import Foreign.C.Types
+import Foreign.C.Error
+import Foreign.Marshal.Alloc
+import Foreign.Ptr
+import System.IO.Error hiding (catch)
+import System.Posix.Internals (s_isdir, o_NONBLOCK, o_NOCTTY, o_CREAT, o_RDONLY, o_WRONLY, o_RDWR, o_APPEND)
+import System.Posix.Types
+import System.Win32
+import System.Win32.File
+
+import Utils
+
+
+type FD = CInt                -- handle of open file
+
+#if 1
+type CWFilePath   = LPCTSTR   -- filename in C land
+type CWFileOffset = Int64     -- filesize or filepos in C land
+withCWFilePath = withTString  -- FilePath->CWFilePath conversion
+peekCWFilePath = peekTString  -- CWFilePath->FilePath conversion
+#else
+type CWFilePath   = CString
+type CWFileOffset = COff
+withCWFilePath = withCString
+peekCWFilePath = peekCString
+#endif
+
+
+waccess :: String -> CMode -> IO Int
+waccess name mode =
+  modifyIOError (`ioeSetFileName` name) $
+  withCWFilePath name $ \ p_name ->
+  c_waccess p_name mode
+foreign import ccall unsafe "Win32Files.h _waccess"
+  c_waccess :: CWFilePath -> CMode -> IO Int
+
+wchmod :: String -> CMode -> IO ()
+wchmod name mode =
+  modifyIOError (`ioeSetFileName` name) $
+  withCWFilePath name $ \ p_name ->
+  throwErrnoIfMinus1Retry_ "chmod" $ c_wchmod p_name mode
+foreign import ccall unsafe "Win32Files.h _wchmod"
+  c_wchmod :: CWFilePath -> CMode -> IO Int
+
+wunlink :: String -> IO ()
+wunlink name =
+  modifyIOError (`ioeSetFileName` name) $
+  withCWFilePath name $ \ p_name ->
+  throwErrnoIfMinus1Retry_ "unlink" $ c_wunlink p_name
+foreign import ccall unsafe "Win32Files.h _wunlink"
+  c_wunlink :: CWFilePath -> IO Int
+
+wrename :: String -> String -> IO ()
+wrename oldname newname =
+  modifyIOError (`ioeSetFileName` oldname) $
+  withCWFilePath oldname $ \ p_oldname ->
+  withCWFilePath newname $ \ p_newname ->
+  throwErrnoIfMinus1Retry_ "rename" $ c_wrename p_oldname p_newname
+foreign import ccall unsafe "Win32Files.h _wrename"
+  c_wrename :: CWFilePath -> CWFilePath -> IO Int
+
+wcreat :: String -> Int -> IO FD
+wcreat name mode =
+  modifyIOError (`ioeSetFileName` name) $
+  withCWFilePath name $ \ p_name ->
+  throwErrnoIfMinus1Retry "creat" $ c_wcreat p_name mode
+foreign import ccall unsafe "Win32Files.h _wcreat"
+  c_wcreat :: CWFilePath -> Int -> IO FD
+
+wopen :: String -> CInt -> CMode -> IO FD
+wopen name access mode =
+  modifyIOError (`ioeSetFileName` name) $
+  withCWFilePath name $ \ p_name ->
+  throwErrnoIfMinus1Retry "open" $ c_wopen p_name access mode
+foreign import ccall safe "Win32Files.h _wopen"
+  c_wopen :: CWFilePath -> CInt -> CMode -> IO FD
+
+wclose :: FD -> IO ()
+wclose h =
+  throwErrnoIfMinus1Retry_ "wclose" $ c_close h
+foreign import ccall safe "Win32Files.h _close"
+  c_close :: FD -> IO Int
+
+wread :: Integral int => FD -> Ptr a -> int -> IO int
+wread h buf size =
+  (throwErrnoIfMinus1Retry "read" $ c_read h (castPtr buf) (i size)) >>== i
+foreign import ccall safe "Win32Files.h _read"
+  c_read :: FD -> Ptr a -> Int -> IO Int
+
+wwrite :: Integral int => FD -> Ptr a -> int -> IO ()
+wwrite h buf size =
+  throwErrnoIfMinus1Retry_ "write" $ c_write h (castPtr buf) (i size)
+foreign import ccall safe "Win32Files.h _write"
+  c_write :: FD -> Ptr a -> Int -> IO Int
+
+wtell :: Integral int => FD -> IO int
+wtell h =
+  (throwErrnoIfMinus1Retry "tell" $ c_telli64 h) >>== i
+foreign import ccall unsafe "Win32Files.h _telli64"
+  c_telli64 :: FD -> IO CWFileOffset
+
+wseek :: Integral int => FD -> int -> CInt -> IO ()
+wseek h offset direction =
+  throwErrnoIfMinus1Retry_ "seek" $ c_lseeki64 h (i offset) direction
+foreign import ccall unsafe "Win32Files.h _lseeki64"
+  c_lseeki64 :: FD -> CWFileOffset -> CInt -> IO CWFileOffset
+
+wfilelength :: Integral int => FD -> IO int
+wfilelength h =
+  (throwErrnoIfMinus1Retry "filelength" $ c_filelengthi64 h) >>== i
+foreign import ccall safe "Win32Files.h _filelengthi64"
+  c_filelengthi64 :: FD -> IO CWFileOffset
+
+wmkdir :: FilePath -> IO ()
+wmkdir name = do
+  modifyIOError (`ioeSetFileName` name) $ do
+  withCWFilePath name $ \ p_name -> do
+  throwErrnoIfMinus1Retry_ "mkdir" $ c_wmkdir p_name
+foreign import ccall unsafe "Win32Files.h _wmkdir"
+   c_wmkdir :: CWFilePath -> IO CInt
+
+wrmdir :: FilePath -> IO ()
+wrmdir name = do
+  modifyIOError (`ioeSetFileName` name) $ do
+  withCWFilePath name $ \ p_name -> do
+  throwErrnoIfMinus1Retry_ "rmdir" (c_wrmdir p_name)
+foreign import ccall unsafe "Win32Files.h _wrmdir"
+   c_wrmdir :: CWFilePath -> IO CInt
+
+
+
+type CWFindData = ()
+
+foreign import ccall unsafe "Win32Files.h __w_find_sizeof"      w_find_sizeof      :: Int
+foreign import ccall unsafe "Win32Files.h __w_find_time_create" w_find_time_create :: Ptr CWFindData -> IO CTime
+foreign import ccall unsafe "Win32Files.h __w_find_time_access" w_find_time_access :: Ptr CWFindData -> IO CTime
+foreign import ccall unsafe "Win32Files.h __w_find_time_write"  w_find_time_write  :: Ptr CWFindData -> IO CTime
+foreign import ccall unsafe "Win32Files.h __w_find_attrib"      c_w_find_attrib    :: Ptr CWFindData -> IO Word
+foreign import ccall unsafe "Win32Files.h __w_find_size"        c_w_find_size      :: Ptr CWFindData -> IO CWFileOffset
+foreign import ccall unsafe "Win32Files.h __w_find_name"        c_w_find_name      :: Ptr CWFindData -> IO CWFilePath
+
+w_find_name   =  c_w_find_name   .>>=  peekCWFilePath
+w_find_size   =  c_w_find_size   .>>== i
+w_find_attrib =  c_w_find_attrib .>>== i
+w_find_isDir  =  w_find_attrib   .>>== (\a -> a.&.fILE_ATTRIBUTE_DIRECTORY /= 0)
+
+wfindfirst :: String -> Ptr CWFindData -> IO (Maybe Int)
+wfindfirst name p_find = do
+  modifyIOError (`ioeSetFileName` name) $ do
+  withCWFilePath name $ \ p_name -> do
+  res <- c_wfindfirsti64 p_name p_find
+  case res of
+    -1 -> do err <- getErrno
+             if err `elem` [eMFILE, eNOENT]
+               then return Nothing  -- no files found
+               else throwErrno "findfirst"
+    _  -> return (Just res)
+foreign import ccall unsafe "Win32Files.h _wfindfirsti64"
+  c_wfindfirsti64 :: CWFilePath -> Ptr CWFindData -> IO Int
+
+wfindnext :: Int -> Ptr CWFindData -> IO Bool
+wfindnext h p_find = do
+  res <- c_wfindnexti64 h p_find
+  case res of
+    -1 -> do err <- getErrno
+             if err `elem` [eMFILE, eNOENT]
+               then return True  -- no more files
+               else throwErrno "findnext"
+    _  -> return False
+foreign import ccall unsafe "Win32Files.h _wfindnexti64"
+  c_wfindnexti64 :: Int -> Ptr CWFindData -> IO Int
+
+findclose :: Int -> IO ()
+findclose h = do
+  c_findclose h
+  return ()
+foreign import ccall unsafe "Win32Files.h _findclose"
+  c_findclose :: Int -> IO Int
+
+wfindfiles :: String -> (Ptr CWFindData -> IO ()) -> IO ()
+wfindfiles name action = do
+  allocaBytes w_find_sizeof $ \ p_find -> do
+  res <- wfindfirst name p_find
+  case res of
+    Nothing -> return ()
+    Just h ->  do repeat_until $ do
+                    action p_find
+                    wfindnext h p_find
+                  findclose h
+
+
+
+type CWStat = ()
+
+foreign import ccall unsafe "Win32Files.h __w_stat_sizeof"  wst_sizeof  :: Int
+foreign import ccall unsafe "Win32Files.h __w_stat_mode"    wst_mode    :: Ptr CWStat -> IO CMode
+foreign import ccall unsafe "Win32Files.h __w_stat_ctime"   wst_ctime   :: Ptr CWStat -> IO CTime
+foreign import ccall unsafe "Win32Files.h __w_stat_atime"   wst_atime   :: Ptr CWStat -> IO CTime
+foreign import ccall unsafe "Win32Files.h __w_stat_mtime"   wst_mtime   :: Ptr CWStat -> IO CTime
+foreign import ccall unsafe "Win32Files.h __w_stat_size"    c_wst_size  :: Ptr CWStat -> IO CWFileOffset
+
+wst_size  =  c_wst_size .>>== i
+
+wfstat :: FD -> Ptr CWStat -> IO ()
+wfstat h p_stat =
+  throwErrnoIfMinus1Retry_ "wfstat" $ c_fstati64 h p_stat
+foreign import ccall unsafe "Win32Files.h _fstati64"
+  c_fstati64 :: FD -> Ptr CWStat -> IO Int
+
+wstat :: String -> Ptr CWStat -> IO ()
+wstat name p_stat =
+  modifyIOError (`ioeSetFileName` name) $
+  withCWFilePath name $ \ p_name ->
+  throwErrnoIfMinus1Retry_ "stat" $ c_wstati64 p_name p_stat
+foreign import ccall unsafe "Win32Files.h _wstati64"
+  c_wstati64 :: CWFilePath -> Ptr CWStat -> IO Int
+
+{- |The operation 'doesDirectoryExist' returns 'True' if the argument file
+exists and is a directory, and 'False' otherwise.
+-}
+
+wDoesDirectoryExist :: FilePath -> IO Bool
+wDoesDirectoryExist name =
+ catch
+   (wWithFileStatus "doesDirectoryExist" name $ \st -> wIsDirectory st)
+   (\ (_ :: SomeException) -> return False)
+
+{- |The operation 'doesFileExist' returns 'True'
+if the argument file exists and is not a directory, and 'False' otherwise.
+-}
+
+wDoesFileExist :: FilePath -> IO Bool
+wDoesFileExist name = do
+ catch
+   (wWithFileStatus "wDoesFileExist" name $ \st -> do b <- wIsDirectory st; return (not b))
+   (\ (_ :: SomeException) -> return False)
+
+wWithFileStatus :: String -> FilePath -> (Ptr CWStat -> IO a) -> IO a
+wWithFileStatus loc name f = do
+  modifyIOError (`ioeSetFileName` name) $
+    allocaBytes wst_sizeof $ \p_stat ->
+      withCWFilePath name $ \p_name -> do
+        throwErrnoIfMinus1Retry_ loc $
+          c_wstati64 p_name p_stat
+        f p_stat
+
+wIsDirectory :: Ptr CWStat -> IO Bool
+wIsDirectory stat = do
+  mode <- wst_mode stat
+  return (s_isdir mode)
+
+
+
+
+foreign import ccall unsafe "HsBase.h __hscore_seek_cur" sEEK_CUR :: CInt
+foreign import ccall unsafe "HsBase.h __hscore_seek_set" sEEK_SET :: CInt
+foreign import ccall unsafe "HsBase.h __hscore_seek_end" sEEK_END :: CInt
+
+std_flags    = o_NONBLOCK   .|. o_NOCTTY
+output_flags = std_flags    .|. o_CREAT
+read_flags   = std_flags    .|. o_RDONLY
+write_flags  = output_flags .|. o_WRONLY
+rw_flags     = output_flags .|. o_RDWR
+append_flags = write_flags  .|. o_APPEND
+
+
+{-# NOINLINE waccess #-}
+{-# NOINLINE wchmod #-}
+{-# NOINLINE wunlink #-}
+{-# NOINLINE wrename #-}
+{-# NOINLINE wcreat #-}
+{-# NOINLINE wopen #-}
+{-# NOINLINE wclose #-}
+{-# NOINLINE wread #-}
+{-# NOINLINE wwrite #-}
+{-# NOINLINE wtell #-}
+{-# NOINLINE wseek #-}
+{-# NOINLINE wfilelength #-}
+{-# NOINLINE wmkdir #-}
+{-# NOINLINE wrmdir #-}
+{-# NOINLINE wfindfirst #-}
+{-# NOINLINE wfindnext #-}
+{-# NOINLINE findclose #-}
+{-# NOINLINE wfindfiles #-}
+{-# NOINLINE wfstat #-}
+{-# NOINLINE wstat #-}
+{-# NOINLINE wDoesDirectoryExist #-}
+{-# NOINLINE wDoesFileExist #-}
+{-# NOINLINE wWithFileStatus #-}
+{-# NOINLINE wIsDirectory #-}

--- a/compat-ghc/System/Locale.hs
+++ b/compat-ghc/System/Locale.hs
@@ -1,3 +1,7 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f2ab9abea2f65ba470a77ae71c75a56983e3109b0a22bca2a60edebb83f7f431
-size 237
+-- Compatibility shim: System.Locale for GHC
+-- Re-exports TimeLocale from Data.Time.Format (time package)
+module System.Locale (
+  TimeLocale(..),
+  defaultTimeLocale,
+) where
+import Data.Time.Format (TimeLocale(..), defaultTimeLocale)

--- a/compat-ghc/System/Time.hs
+++ b/compat-ghc/System/Time.hs
@@ -1,3 +1,164 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:569805c9e752ed5bfe58c59bbe52933b4c0e01185cd346e171cea73e599067c6
-size 5349
+-- Compatibility shim: System.Time for GHC
+-- Wraps Data.Time to provide the old-time API
+module System.Time (
+  ClockTime(TOD),
+  CalendarTime(..),
+  TimeDiff(..),
+  Month(..),
+  Day(..),
+  noTimeDiff,
+  getClockTime,
+  toCalendarTime,
+  toUTCTime,
+  toClockTime,
+  addToClockTime,
+  diffClockTimes,
+  formatCalendarTime,
+) where
+
+import Data.Time.Clock
+import Data.Time.Clock.POSIX
+import qualified Data.Time.Calendar as Cal
+import Data.Time.Calendar.OrdinalDate (toOrdinalDate)
+import Data.Time.LocalTime
+import Data.Time.Format (formatTime, TimeLocale)
+import System.IO.Unsafe (unsafePerformIO)
+
+-- | ClockTime is a POSIX time: seconds + picoseconds
+data ClockTime = TOD !Integer !Integer deriving (Eq, Ord)
+instance Show ClockTime where
+  show (TOD s ps) = "TOD " ++ show s ++ " " ++ show ps
+
+-- | Calendar time broken down into components
+data CalendarTime = CalendarTime
+  { ctYear    :: Int
+  , ctMonth   :: Month
+  , ctDay     :: Int
+  , ctHour    :: Int
+  , ctMin     :: Int
+  , ctSec     :: Int
+  , ctPicosec :: Integer
+  , ctWDay    :: Day
+  , ctYDay    :: Int
+  , ctTZName  :: String
+  , ctTZ      :: Int       -- offset in seconds from UTC
+  , ctIsDST   :: Bool
+  } deriving (Eq, Ord, Show)
+
+-- | Month enumeration (January = 0 in old-time API)
+data Month = January | February | March | April | May | June
+           | July | August | September | October | November | December
+           deriving (Eq, Ord, Enum, Bounded, Show, Read)
+
+-- | Day of week (Sunday = 0 in old-time API)
+data Day = Sunday | Monday | Tuesday | Wednesday | Thursday | Friday | Saturday
+         deriving (Eq, Ord, Enum, Bounded, Show, Read)
+
+-- | Time difference
+data TimeDiff = TimeDiff
+  { tdYear    :: Int
+  , tdMonth   :: Int
+  , tdDay     :: Int
+  , tdHour    :: Int
+  , tdMin     :: Int
+  , tdSec     :: Int
+  , tdPicosec :: Integer
+  } deriving (Eq, Ord, Show)
+
+noTimeDiff :: TimeDiff
+noTimeDiff = TimeDiff 0 0 0 0 0 0 0
+
+getClockTime :: IO ClockTime
+getClockTime = do
+  t <- getPOSIXTime
+  let secs = floor t :: Integer
+      ps   = round ((t - fromIntegral secs) * 1e12) :: Integer
+  return (TOD secs ps)
+
+toCalendarTime :: ClockTime -> IO CalendarTime
+toCalendarTime (TOD secs _ps) = do  -- sub-second (_ps) precision is not preserved
+  tz <- getCurrentTimeZone
+  let utct = posixSecondsToUTCTime (fromIntegral secs)
+      lt   = utcToLocalTime tz utct
+      (y, m, d) = Cal.toGregorian (localDay lt)
+      tod  = localTimeOfDay lt
+      wday = toEnum $ (fromEnum (Cal.dayOfWeek (localDay lt)) `mod` 7) :: Day
+      yday = snd (toOrdinalDate (localDay lt)) - 1
+      tzOffset = timeZoneMinutes tz * 60
+  return CalendarTime
+    { ctYear    = fromIntegral y
+    , ctMonth   = toEnum (m - 1)
+    , ctDay     = d
+    , ctHour    = todHour tod
+    , ctMin     = todMin tod
+    , ctSec     = floor (todSec tod)
+    , ctPicosec = 0
+    , ctWDay    = wday
+    , ctYDay    = yday
+    , ctTZName  = timeZoneName tz
+    , ctTZ      = tzOffset
+    , ctIsDST   = timeZoneSummerOnly tz
+    }
+
+toUTCTime :: ClockTime -> CalendarTime
+toUTCTime (TOD secs _ps) =
+  let utct = posixSecondsToUTCTime (fromIntegral secs)
+      lt   = utcToLocalTime utc utct
+      (y, m, d) = Cal.toGregorian (localDay lt)
+      tod  = localTimeOfDay lt
+      wday = toEnum $ (fromEnum (Cal.dayOfWeek (localDay lt)) `mod` 7) :: Day
+      yday = snd (toOrdinalDate (localDay lt)) - 1
+  in CalendarTime
+    { ctYear    = fromIntegral y
+    , ctMonth   = toEnum (m - 1)
+    , ctDay     = d
+    , ctHour    = todHour tod
+    , ctMin     = todMin tod
+    , ctSec     = floor (todSec tod)
+    , ctPicosec = 0
+    , ctWDay    = wday
+    , ctYDay    = yday
+    , ctTZName  = "UTC"
+    , ctTZ      = 0
+    , ctIsDST   = False
+    }
+
+toClockTime :: CalendarTime -> ClockTime
+toClockTime ct =
+  let day  = Cal.fromGregorian (fromIntegral (ctYear ct)) (fromEnum (ctMonth ct) + 1) (ctDay ct)
+      tod  = TimeOfDay (ctHour ct) (ctMin ct) (fromIntegral (ctSec ct))
+      lt   = LocalTime day tod
+      tz   = minutesToTimeZone (ctTZ ct `div` 60)
+      utct = localTimeToUTC tz lt
+      secs = floor (utcTimeToPOSIXSeconds utct) :: Integer
+  in TOD secs 0
+
+addToClockTime :: TimeDiff -> ClockTime -> ClockTime
+addToClockTime td (TOD secs ps) =
+  let deltaSecs = fromIntegral (tdDay td) * 86400
+                + fromIntegral (tdHour td) * 3600
+                + fromIntegral (tdMin td) * 60
+                + fromIntegral (tdSec td)
+  in TOD (secs + deltaSecs) ps
+
+diffClockTimes :: ClockTime -> ClockTime -> TimeDiff
+diffClockTimes (TOD s1 _) (TOD s2 _) =
+  let diff = s1 - s2
+      days = diff `div` 86400
+      rest = diff `mod` 86400
+      hrs  = rest `div` 3600
+      rest2 = rest `mod` 3600
+      mins = rest2 `div` 60
+      secs = rest2 `mod` 60
+  in noTimeDiff { tdDay = fromIntegral days, tdHour = fromIntegral hrs
+                , tdMin = fromIntegral mins, tdSec = fromIntegral secs }
+
+-- | Format a calendar time using a format string.
+-- Uses Data.Time.Format's formatTime under the hood.
+formatCalendarTime :: TimeLocale -> String -> CalendarTime -> String
+formatCalendarTime locale fmt ct =
+  let day  = Cal.fromGregorian (fromIntegral (ctYear ct)) (fromEnum (ctMonth ct) + 1) (ctDay ct)
+      tod  = TimeOfDay (ctHour ct) (ctMin ct) (fromIntegral (ctSec ct))
+      tz   = minutesToTimeZone (ctTZ ct `div` 60)
+      zt   = ZonedTime (LocalTime day tod) tz
+  in formatTime locale fmt zt


### PR DESCRIPTION
## Summary

Fixes to make `arc a -mstoring` and `arc x` work under MicroHs 0.15.0.0 on Linux.

- **`Process.hs`**: Replace `Chan`/`MVar` with custom `OurChan` (unbounded FIFO using `takeMVar` not `readMVar`) to fix deadlocks — MicroHs's `put_mvar` only wakes `mv_takeput` waiters, not `mv_read` waiters. Applied to `|>>>` forward channel and `inner_back` back channel in `createP`.
- **`ArcCreate.hs`**: Change `backdoor` channel from `newChan` to `newEmptyMVar`.
- **`ArcvProcessExtract.hs`**: Fix `deCompressProcess` closure bug — move `copyData`/`processNextInstruction` from `where` clause to shared `let` block with explicit `prevlen`/`dstbuf`/`dstlen` parameters (MicroHs failed to capture correct per-call values via `where`-clause closures in recursive `let` bindings).
- **`Options.hs`**: Change `aDEFAULT_DIR_COMPRESSION` from `"lzma:bt4:1m"` to `"storing"` — C-based compressors need `mkCALL_BACK` which returns `nullFunPtr` in MicroHs (→ SIGSEGV).
- **`ArcvProcessCompress.hs`**: Fix `mdo` → `do` for `CompressData` handler; move `times` binding before `compressa` `let`.
- Various `.hs` files: MicroHs compatibility updates (compat-ghc shims, strict evaluation adjustments).

## Result

`arc a -mstoring test.arc test.txt` and `arc x test.arc` now complete successfully under MicroHs 0.15.0.0 on Linux.

## Test plan

- [ ] `arc a -mstoring test.arc test.txt` → exits 0, "Compressed 1 file, 12 => 12 bytes"
- [ ] `arc l test.arc` → lists test.txt correctly
- [ ] `arc x test.arc` (in empty dir) → file extracted, contents match original

🤖 Generated with [Claude Code](https://claude.com/claude-code)