### PR TITLE
Rust port: Delta, Dict decode and LZP, byte-identical to the C originals

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,6 +214,81 @@ jobs:
         chmod +x Tests/win-test.sh
         Tests/win-test.sh
 
+  # ── Rust codec ports ────────────────────────────────────────────────────────
+  # Two things are checked, and they are not the same thing:
+  #
+  #   1. The ported codec produces byte-identical output to the C original, over
+  #      inputs built to exercise its heuristics (rust/difftest).
+  #   2. The archiver built against it produces byte-identical archives, and the
+  #      whole suite still passes.
+  #
+  # The second is what actually protects the archive format, and it is the check
+  # that caught the port being linked in name only: an earlier wiring produced a
+  # binary byte-identical to the C build because both defined the same symbol and
+  # the linker never pulled the Rust one.
+  rust-codecs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6.0.2
+      with:
+        lfs: false
+    - name: Install LLVM and Clang
+      uses: KyleMayes/install-llvm-action@v2
+      with:
+        version: "21.1.8"
+    - name: Install packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y liblua5.1-dev libncurses-dev libcurl4-openssl-dev cpphs
+    - name: Install MicroHs
+      run: |
+        microhs_sha="05a3fbd5d73ae6a37111a6ced5b57bb1717b8975"
+        microhs_tar="/tmp/microhs.tar.gz"
+        microhs_expected_sha256="a1f85821cbae877d0ea3e173235d45c833d9145b2ca9e92e77d284b6730c63b6"
+        curl -fsSL "https://github.com/augustss/MicroHs/archive/$microhs_sha.tar.gz" -o "$microhs_tar"
+        echo "$microhs_expected_sha256  $microhs_tar" | sha256sum -c -
+        tar -xzf "$microhs_tar" -C /tmp
+        cd "/tmp/MicroHs-$microhs_sha"
+        make minstall
+        echo "$HOME/.mcabal/bin" >> "$GITHUB_PATH"
+
+    - name: Codec differential test (Rust vs C)
+      run: |
+        chmod +x rust/difftest/run.sh
+        rust/difftest/run.sh diff
+
+    # A differential test that has never failed proves nothing. This mutates the
+    # port and asserts every mutation is caught by at least one input; it also
+    # aborts if a mutation pattern no longer matches, because a mutation that
+    # silently fails to apply reports as "0 detected" and reads like coverage.
+    - name: Prove the differential test can fail
+      run: rust/difftest/run.sh sabotage
+
+    # Build the archiver twice and require identical archives. This is the check
+    # that actually guards the format.
+    - name: Archives identical with and without the Rust codecs
+      run: |
+        chmod +x compile* Tests/*.sh
+        ./compile > /tmp/build-c.log 2>&1 || { tail -30 /tmp/build-c.log; exit 1; }
+        cp Tests/arc /tmp/arc-c
+        Tests/run-tests.sh /tmp/arc-c > /tmp/suite-c.log 2>&1 || { tail -40 /tmp/suite-c.log; exit 1; }
+
+        rm -rf /tmp/out/FreeArc
+        DARC_RUST=1 ./compile > /tmp/build-rs.log 2>&1 || { tail -30 /tmp/build-rs.log; exit 1; }
+        # If the Rust library were not really linked the binary would be
+        # unchanged, which is exactly how this went wrong once.
+        cmp -s /tmp/arc-c Tests/arc && { echo "::error::DARC_RUST build is byte-identical to the C build -- the Rust codecs were not linked"; exit 1; }
+        Tests/run-tests.sh Tests/arc > /tmp/suite-rs.log 2>&1 || { tail -40 /tmp/suite-rs.log; exit 1; }
+
+        grep -E "^[a-z0-9-]+ +(ok|FAIL) " /tmp/suite-c.log  | awk '{print $1, $NF}' | sort > /tmp/fp-c.txt
+        grep -E "^[a-z0-9-]+ +(ok|FAIL) " /tmp/suite-rs.log | awk '{print $1, $NF}' | sort > /tmp/fp-rs.txt
+        test -s /tmp/fp-c.txt || { echo "::error::no fingerprints parsed from the C run"; exit 1; }
+        if ! diff -u /tmp/fp-c.txt /tmp/fp-rs.txt; then
+          echo "::error::archives differ between the C and Rust codec builds"
+          exit 1
+        fi
+        echo "archives identical across $(wc -l < /tmp/fp-c.txt) configurations"
+
   # ── AddressSanitizer on x86-64 ──────────────────────────────────────────────
   # Added to diagnose a double free that only appeared on this runner. It found
   # that one and an out-of-bounds read in Dict/phase1 on its first two runs, and

--- a/Compression/Delta/C_Delta.cpp
+++ b/Compression/Delta/C_Delta.cpp
@@ -4,7 +4,20 @@ extern "C" {
 
 
 #define DELTA_LIBRARY
+// DARC_RUST=1 selects the Rust port of this codec (rust/darc-codecs).
+//
+// Note this whole file is wrapped in extern "C" (line 1), so Delta.cpp's
+// definitions already have C linkage here -- the same names the Rust crate
+// exports. That is why the switch has to be an exclusion rather than a
+// declaration change: with both present the linker resolves delta_compress from
+// this object and never pulls the archive member, producing a binary
+// byte-identical to the C build while appearing to have "linked Rust in".
+//
+// The port is verified byte-identical to Delta.cpp over 23 inputs and ~280
+// detected tables, in both directions -- see rust/difftest.
+#ifndef DARC_RUST
 #include "Delta.cpp"
+#endif
 
 /*-------------------------------------------------*/
 /* DELTA_METHOD class implementation                 */

--- a/Compression/Dict/C_Dict.cpp
+++ b/Compression/Dict/C_Dict.cpp
@@ -3,9 +3,15 @@ extern "C" {
 }
 
 #define DICT_LIBRARY
+// DARC_RUST=1 selects the Rust port. Both halves are ported now -- the
+// encoder (phases 1-7) and the decoder -- so the whole C implementation is
+// excluded, not just one entry point.
+#ifndef DARC_RUST
 #include "dict.cpp"
+#endif
 
 #ifndef FREEARC_DECOMPRESS_ONLY
+#ifndef DARC_RUST
 int dict_compress (MemSize BlockSize, int MinCompression, int MinWeakChars, int MinLargeCnt, int MinMediumCnt, int MinSmallCnt, int MinRatio, CALLBACK_FUNC *callback, void *auxdata)
 {
     BYTE* In = NULL;  // pointer to the input data
@@ -37,14 +43,11 @@ int dict_compress (MemSize BlockSize, int MinCompression, int MinWeakChars, int 
 finished:
     FreeAndNil(In); FreeAndNil(Out); return x;  // 0 if everything is fine, otherwise the error code
 }
+#endif  // !DARC_RUST
 #endif  // !defined (FREEARC_DECOMPRESS_ONLY)
 
 
 // DARC_RUST=1 selects the Rust port of the decoder (rust/darc-codecs).
-//
-// Only the decoder is excluded here, not the whole dict.cpp include: the
-// encoder (DictEncode and its seven phases) has not been ported yet and is
-// still needed by dict_compress below.
 //
 // This file wraps its body in extern "C", so this definition and the Rust
 // export are the same symbol. With both present the linker resolves from this

--- a/Compression/Dict/C_Dict.cpp
+++ b/Compression/Dict/C_Dict.cpp
@@ -40,6 +40,21 @@ finished:
 #endif  // !defined (FREEARC_DECOMPRESS_ONLY)
 
 
+// DARC_RUST=1 selects the Rust port of the decoder (rust/darc-codecs).
+//
+// Only the decoder is excluded here, not the whole dict.cpp include: the
+// encoder (DictEncode and its seven phases) has not been ported yet and is
+// still needed by dict_compress below.
+//
+// This file wraps its body in extern "C", so this definition and the Rust
+// export are the same symbol. With both present the linker resolves from this
+// object and never pulls the Rust one, producing a binary that looks correctly
+// linked while running the C code -- so the switch has to remove this
+// definition, not merely add a declaration elsewhere.
+//
+// The port is verified byte-identical to DictDecode over 11 inputs including
+// prose, records, source and binary -- see rust/difftest.
+#ifndef DARC_RUST
 int dict_decompress (MemSize BlockSize, int MinCompression, int MinWeakChars, int MinLargeCnt, int MinMediumCnt, int MinSmallCnt, int MinRatio, CALLBACK_FUNC *callback, void *auxdata)
 {
   BYTE* In = NULL;  // pointer to the input data
@@ -75,6 +90,7 @@ finished:
   FreeAndNil(In); FreeAndNil(Out);
   return x<=0? x : FREEARC_ERRCODE_IO;  // 0 if everything is fine, otherwise the error code
 }
+#endif  // !DARC_RUST
 
 
 /*-------------------------------------------------*/

--- a/Compression/Dict/dict.cpp
+++ b/Compression/Dict/dict.cpp
@@ -337,8 +337,20 @@ int common_prefix_length (Word *a, Word *b)
     return i;
 }
 
-// Comparison function for sorting words by descending frequency
-int __cdecl count_desc_order (const Word *a, const Word *b)   { return b->count - a->count; }
+// Comparison function for sorting words by descending frequency.
+//
+// The tie-break on ptr is not cosmetic. qsort is not stable and its order among
+// equal elements is implementation-defined, so without a total order the same
+// input produces different dictionaries on different platforms -- and that
+// reaches the archive. Measured before this was added: source.bin encoded to
+// 78120 bytes both on macOS/ARM64 and Linux/x86-64, with different bytes
+// (a36b53f3... vs ad4fc2c0...). Ordering equal counts by position in the input
+// makes the result depend only on the input.
+int __cdecl count_desc_order (const Word *a, const Word *b)
+{
+    if (b->count != a->count)  return b->count - a->count;
+    return a->ptr < b->ptr ? -1 : a->ptr > b->ptr ? 1 : 0;
+}
 
 #ifdef DEBUG
 // Comparison function for sorting words by descending actual usage frequency
@@ -350,7 +362,10 @@ int lexicographical_order (const Word *a, const Word *b)
 {
   unsigned alen = a->len, blen = b->len;
   int cmp = memcmp (a->ptr, b->ptr, mymin(alen,blen));
-  return cmp? cmp : alen-blen;
+  if (cmp)         return cmp;
+  if (alen != blen) return alen-blen;
+  // Identical text and length: still order them, for the same reason as above.
+  return a->ptr < b->ptr ? -1 : a->ptr > b->ptr ? 1 : 0;
 }
 
 
@@ -366,8 +381,20 @@ struct char_stats {
     count_t  count;   // its frequency counter
 };
 
-// Comparison function for sorting characters by ascending frequency
-int char_count_asc_order (const char_stats *a, const char_stats *b)   { return a->count - b->count; }
+// Comparison function for sorting characters by ascending frequency.
+//
+// Ties here are the rule rather than the exception -- on a text file most of the
+// 256 characters have count 0 -- and the last element of this sort becomes
+// PREFIX_FOR_WEAK_CHARS, which is written into the dictionary. Without a
+// tie-break the chosen prefix differed by platform (zeros.bin: 255 on macOS, 1
+// on Linux), so the same file compressed to different archives. Breaking ties
+// by character value keeps the result identical everywhere, and matches what
+// glibc's qsort already produced.
+int char_count_asc_order (const char_stats *a, const char_stats *b)
+{
+    if (a->count != b->count)  return a->count - b->count;
+    return (int)a->chr - (int)b->chr;
+}
 
 
 

--- a/Compression/Dict/dict.cpp
+++ b/Compression/Dict/dict.cpp
@@ -478,6 +478,25 @@ struct stats {
 // Disabling the speculative search (WORD_STEP = 1) improves compression a little at the cost of speed
 int phase1 (byte *buf, unsigned bufsize)
 {
+    // char_counts is a global and DictEncode is called once per block, so it
+    // has to be cleared here or every block inherits the character statistics
+    // of every block before it in the same process. phase3 then sees no
+    // characters free for encoding, returns -1, and the block is stored
+    // uncompressed.
+    //
+    // This is not theoretical, and it is not a small effect. Compressing the
+    // binary corpus as one stream of 64KB blocks, the tail block compresses
+    // 48160 -> 40573 on its own but is declined outright when four unrelated
+    // binary blocks precede it -- the whole stream is stored, 310324 bytes
+    // instead of 301127.
+    //
+    // It also made dict's output depend on how the pipeline happened to chunk
+    // the data, which varies with buffer sizes and -mt, so the same input
+    // could compress differently between runs. phase3 additionally *writes*
+    // into char_counts (marking characters conditionally free), so the state
+    // that leaked forward was already corrupted, not merely stale.
+    memset (char_counts, 0, sizeof(char_counts));
+
     // Maximum allowed number of words - 1/32 of the input data volume
     unsigned max_words = roundup_to_power_of (mymax(bufsize/32,32768), 2);
     FirstWord = (Word*) malloc (max_words * sizeof (Word));

--- a/Compression/LZP/C_LZP.cpp
+++ b/Compression/LZP/C_LZP.cpp
@@ -127,6 +127,17 @@ int LZPDecode(BYTE* In,UINT Size,BYTE* Out,int MinLen,int HashSize,int Barrier,i
 /*-------------------------------------------------------------------------*/
 
 #ifndef FREEARC_DECOMPRESS_ONLY
+// DARC_RUST=1 selects the Rust port of this codec (rust/darc-codecs).
+//
+// Excluded rather than redeclared: with both definitions present the linker
+// resolves from this object and never pulls the Rust one, producing a binary
+// that looks correctly linked while running the C code. Same arrangement as
+// C_Delta.cpp and C_Dict.cpp.
+//
+// LZPEncode/LZPDecode above stay compiled -- they are only reachable through
+// these two entry points. Verified byte-identical over 8 inputs in both
+// directions; see rust/difftest.
+#ifndef DARC_RUST
 int lzp_compress (MemSize BlockSize, int MinCompression, int MinMatchLen, int HashSizeLog, int Barrier, int SmallestLen, CALLBACK_FUNC *callback, void *auxdata)
 {
     int errcode = FREEARC_OK;   // Error code returned by last operation or FREEARC_OK
@@ -160,9 +171,11 @@ finished:
     FreeAndNil(In); FreeAndNil(Out);
     return errcode;
 }
+#endif  // !DARC_RUST
 #endif  // !defined (FREEARC_DECOMPRESS_ONLY)
 
 
+#ifndef DARC_RUST
 int lzp_decompress (MemSize BlockSize, int MinCompression, int MinMatchLen, int HashSizeLog, int Barrier, int SmallestLen, CALLBACK_FUNC *callback, void *auxdata)
 {
     int errcode = FREEARC_OK;   // Error code returned by last operation or FREEARC_OK
@@ -194,6 +207,7 @@ finished:
     FreeAndNil(In); FreeAndNil(Out);
     return errcode;
 }
+#endif  // !DARC_RUST
 
 
 /*-------------------------------------------------*/

--- a/Tests/run-tests.sh
+++ b/Tests/run-tests.sh
@@ -150,7 +150,16 @@ echo "preflight (partition):"
 raw "--print-config (no archive at all)"  --print-config
 raw "a on an EMPTY dir"                   a -y -m0 "$WORK/e0.arc" "$WORK/empty"
 raw "a on ONE named file (no dir scan)"   a -y -m0 "$WORK/e1.arc" "$WORK/tiny/one.txt"
-raw "a writing to /tmp"                   a -y -m0 /tmp/e2.arc "$WORK/tiny/one.txt"
+# Deliberately outside $WORK, to catch anything that depends on writing next to
+# the source. The path must still be unique and removed first: a fixed
+# /tmp/e2.arc survives every run, so the second invocation onwards became an
+# *update* of an existing archive rather than a create -- a different operation
+# that can block waiting on the earlier archive's contents. That turned this
+# step into an intermittent multi-minute hang whose cause looked like whatever
+# had last been changed.
+rm -f "/tmp/darc-e2-$$.arc"
+raw "a writing to /tmp"                   a -y -m0 "/tmp/darc-e2-$$.arc" "$WORK/tiny/one.txt"
+rm -f "/tmp/darc-e2-$$.arc"
 raw "t on a non-archive"                  t -y "$WORK/tiny/one.txt"
 raw "lb on a non-archive"                 lb "$WORK/tiny/one.txt"
 

--- a/compile
+++ b/compile
@@ -77,7 +77,7 @@ if [ -n "${DARC_RUST:-}" ]; then
   command -v cargo >/dev/null 2>&1 || {
     echo "error: DARC_RUST is set but cargo was not found in PATH" >&2; exit 1; }
   echo "building Rust codecs"
-  ( cd rust/darc-codecs && cargo build --release ) || {
+  ( cd rust/darc-codecs && cargo build --release --features dropin ) || {
     echo "error: cargo build failed" >&2; exit 1; }
   rust_lib="$PWD/rust/darc-codecs/target/release/libdarc_codecs.a"
   [ -f "$rust_lib" ] || { echo "error: cargo produced no $rust_lib" >&2; exit 1; }

--- a/compile
+++ b/compile
@@ -57,6 +57,36 @@ if [ -n "${DARC_SANITIZE:-}" ]; then
   export DARC_DEBUG_FLAGS="-g -fsanitize=${DARC_SANITIZE} -fno-omit-frame-pointer"
   echo "sanitizer build: -fsanitize=${DARC_SANITIZE}"
 fi
+# Optional Rust codecs: DARC_RUST=1 ./compile
+#
+# This must run BEFORE any C is compiled. C_Delta.h keys off DARC_RUST, and
+# C_Delta.cpp is built by Compression/compile below -- adding the define after
+# that point would leave the C++ symbols bound while the Rust library sat
+# unused in the link. Exactly the mistake the libcurl probe above documents.
+#
+# Builds rust/darc-codecs and links it, and defines DARC_RUST so the affected
+# headers declare their codec entry points extern "C" -- which is what makes the
+# archiver bind to the Rust symbols instead of the C++ ones. Off by default
+# while the port is partial.
+#
+# Keeping it a switch rather than a replacement is deliberate: it makes the two
+# implementations directly comparable through the real archiver, so the test
+# suite's archive fingerprints can prove they produce identical bytes.
+rust_lib=""
+if [ -n "${DARC_RUST:-}" ]; then
+  command -v cargo >/dev/null 2>&1 || {
+    echo "error: DARC_RUST is set but cargo was not found in PATH" >&2; exit 1; }
+  echo "building Rust codecs"
+  ( cd rust/darc-codecs && cargo build --release ) || {
+    echo "error: cargo build failed" >&2; exit 1; }
+  rust_lib="$PWD/rust/darc-codecs/target/release/libdarc_codecs.a"
+  [ -f "$rust_lib" ] || { echo "error: cargo produced no $rust_lib" >&2; exit 1; }
+  defines="$defines -DDARC_RUST"
+  # Reaches the per-codec makefiles through unix-common.mak, which appends
+  # DARC_EXTRA_DEFINES to DEFINES; make imports it from the environment.
+  export DARC_EXTRA_DEFINES="-DDARC_RUST"
+fi
+
 cp unix-common.mak common.mak
 cd Compression
 chmod +x compile
@@ -125,7 +155,7 @@ fi
 optc_args="-optc -I. -optc -ICompression -optc -IHsLua/src -optc -Wno-incompatible-function-pointer-types"
 for f in $lua_cflags; do optc_args="$optc_args -optc $f"; done
 optl_args=""
-for o in $c_objs $lua_objs; do optl_args="$optl_args -optl $o"; done
+for o in $c_objs $lua_objs $rust_lib; do optl_args="$optl_args -optl $o"; done
 for l in $c_libs; do optl_args="$optl_args -optl $l"; done
 mhs Arc \
   -iCompression -icompat-ghc -icompat-oldtime -iHsLua/src \

--- a/rust/darc-codecs/Cargo.lock
+++ b/rust/darc-codecs/Cargo.lock
@@ -3,5 +3,226 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "darc-codecs"
 version = "0.1.0"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"

--- a/rust/darc-codecs/Cargo.toml
+++ b/rust/darc-codecs/Cargo.toml
@@ -13,4 +13,5 @@ crate-type = ["staticlib", "rlib"]   # staticlib to link; rlib so tests can use 
 [profile.release]
 overflow-checks = true   # see the note in src/ffi.rs
 
-[dev-dependencies]
+[build-dependencies]
+bindgen = "0.72"

--- a/rust/darc-codecs/Cargo.toml
+++ b/rust/darc-codecs/Cargo.toml
@@ -13,5 +13,12 @@ crate-type = ["staticlib", "rlib"]   # staticlib to link; rlib so tests can use 
 [profile.release]
 overflow-checks = true   # see the note in src/ffi.rs
 
+[features]
+# The drop-in aliases (delta_compress, dict_decompress, ...) collide with the C
+# implementations when both are linked, which is exactly what rust/difftest
+# does to compare them. So they are opt-in: the archiver build enables this,
+# the differential harness does not.
+dropin = []
+
 [build-dependencies]
 bindgen = "0.72"

--- a/rust/darc-codecs/build.rs
+++ b/rust/darc-codecs/build.rs
@@ -1,0 +1,53 @@
+// Generate the C ABI declarations from DArc's own headers.
+//
+// These types were hand-transcribed at first. That works right up until a
+// header changes and nobody re-transcribes -- which is exactly how this
+// codebase ended up with 41 helpers whose declarations disagreed with their
+// definitions, 8 of them truncating a `long` return to `int` at every call
+// site. Generating them means the compiler reads the same header the C side
+// compiles against, so the two cannot silently drift apart.
+use std::{env, path::PathBuf};
+
+fn main() {
+    let root = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap())
+        .join("../..")
+        .canonicalize()
+        .expect("repo root");
+    let compression = root.join("Compression");
+
+    println!("cargo:rerun-if-changed=wrapper.h");
+    println!("cargo:rerun-if-changed={}", compression.join("Compression.h").display());
+    println!("cargo:rerun-if-changed={}", compression.join("Common.h").display());
+
+    // The same defines the C build uses. Compression/Common.h errors out
+    // without an OS and a byte-order define, so these are mandatory, not
+    // decoration -- see Utils.hs:31 for the Haskell-side equivalent.
+    let os_define = if cfg!(target_os = "windows") { "-DFREEARC_WIN" } else { "-DFREEARC_UNIX" };
+
+    let bindings = bindgen::Builder::default()
+        .header("wrapper.h")
+        .clang_args([
+            os_define,
+            "-DFREEARC_INTEL_BYTE_ORDER",
+            "-DFREEARC_64BIT",
+            "-x",
+            "c++",
+            "-std=c++17",
+        ])
+        .clang_arg(format!("-I{}", compression.display()))
+        .clang_arg(format!("-I{}", root.display()))
+        // Only what the codec boundary actually needs. Without an allowlist
+        // bindgen emits thousands of items from the C++ headers and the
+        // signal is lost.
+        .allowlist_type("CALLBACK_FUNC")
+        .allowlist_type("MemSize")
+        .allowlist_var("FREEARC_OK")
+        .allowlist_var("FREEARC_ERRCODE_.*")
+        .layout_tests(false)
+        .generate()
+        .expect("bindgen failed to generate DArc ABI bindings");
+
+    bindings
+        .write_to_file(PathBuf::from(env::var("OUT_DIR").unwrap()).join("darc_abi.rs"))
+        .expect("failed to write bindings");
+}

--- a/rust/darc-codecs/src/bin/dict_phase1.rs
+++ b/rust/darc-codecs/src/bin/dict_phase1.rs
@@ -1,0 +1,15 @@
+//! Dump the Rust phase1's result in the same format as
+//! rust/difftest/dict_phase1_ref.cpp, so the two can be diffed directly.
+//!
+//! Exists because DictEncode runs all seven phases: without a per-phase
+//! comparison the port has no validation until it is finished, which means
+//! debugging ~600 lines at once.
+use std::io::Read;
+
+fn main() {
+    let mut buf = Vec::new();
+    std::io::stdin().read_to_end(&mut buf).expect("read stdin");
+    let mut e = darc_codecs::dict_encode::Encoder::new();
+    e.phase1(&buf);
+    print!("{}", e.dump_phase1());
+}

--- a/rust/darc-codecs/src/bin/dict_phase1.rs
+++ b/rust/darc-codecs/src/bin/dict_phase1.rs
@@ -9,7 +9,28 @@ use std::io::Read;
 fn main() {
     let mut buf = Vec::new();
     std::io::stdin().read_to_end(&mut buf).expect("read stdin");
+    let upto: u32 = std::env::var("DICT_PHASE").ok().and_then(|v| v.parse().ok()).unwrap_or(1);
     let mut e = darc_codecs::dict_encode::Encoder::new();
     e.phase1(&buf);
-    print!("{}", e.dump_phase1());
+    if upto == 1 {
+        print!("{}", e.dump_phase1());
+        return;
+    }
+    // Same tuning defaults as the C driver (parse_DICT).
+    if e.phase2(200, 200, 200, 0).is_err() {
+        println!("phase2 rejected");
+        return;
+    }
+    if upto == 2 {
+        print!("{}", e.dump_words());
+        return;
+    }
+    match e.phase3(0) {
+        Err(_) => { println!("phase3 rejected"); }
+        Ok(nodes) => {
+            println!("nodes {} prefix {}", nodes, e.prefix());
+            print!("{}", e.dump_words());
+            print!("{}", e.dump_char_counts());
+        }
+    }
 }

--- a/rust/darc-codecs/src/bin/dict_phase1.rs
+++ b/rust/darc-codecs/src/bin/dict_phase1.rs
@@ -28,9 +28,27 @@ fn main() {
     match e.phase3(0) {
         Err(_) => { println!("phase3 rejected"); }
         Ok(nodes) => {
-            println!("nodes {} prefix {}", nodes, e.prefix());
-            print!("{}", e.dump_words());
-            print!("{}", e.dump_char_counts());
+            if upto == 3 {
+                println!("nodes {} prefix {}", nodes, e.prefix());
+                print!("{}", e.dump_words());
+                print!("{}", e.dump_char_counts());
+                return;
+            }
+            if e.phase4(nodes).is_err() { println!("phase4 rejected"); return; }
+            if upto == 4 { print!("{}", e.dump_coded_words()); return; }
+            match e.phase5() {
+                Err(_) => println!("phase5 rejected"),
+                Ok(mut dict) => {
+                    use std::io::Write;
+                    if upto == 5 {
+                        std::io::stdout().write_all(&dict).unwrap();
+                        return;
+                    }
+                    if e.phase6().is_err() { println!("phase6 rejected"); return; }
+                    dict.extend_from_slice(&e.phase7());
+                    std::io::stdout().write_all(&dict).unwrap();
+                }
+            }
         }
     }
 }

--- a/rust/darc-codecs/src/delta.rs
+++ b/rust/darc-codecs/src/delta.rs
@@ -1,0 +1,239 @@
+//! Delta: binary table preprocessor, ported from Compression/Delta/Delta.cpp
+//! (originally Bulat Ziganshin, 2008).
+//!
+//! Delta does not compress. It finds tables of fixed-width binary records,
+//! subtracts each row from the previous one column-wise, and moves near-constant
+//! columns to the front, so that a *later* codec in the chain compresses the
+//! result better. Output is therefore about the same size as input by design.
+//!
+//! The port must be bit-exact. These transforms are part of the archive format:
+//! a decompressor that produces different bytes than the C original silently
+//! corrupts every archive it touches, and one that writes different bytes than
+//! the C compressor makes archives older builds cannot read.
+//!
+//! Decompression is ported first, deliberately. It carries no heuristics -- the
+//! table layout is recorded in the stream, so this code only replays decisions
+//! the compressor already made -- and it can be validated immediately by
+//! decompressing output the C compressor produced.
+//!
+//! Stream format, one or more blocks until EOF (all integers little-endian,
+//! matching FREEARC_INTEL_BYTE_ORDER):
+//!
+//!   u32   data_size
+//!   u32   table_size            bytes in each of the three descriptor arrays
+//!   u8    skip[table_size]      per table: bytes to skip since the previous one
+//!   u8    type[table_size]      per table: packed column layout, see decode_type
+//!   u8    rows[table_size]      per table: number of rows
+//!   u8    data[data_size]
+//!
+//! There are `table_size / 4` tables, the arrays being u32 each.
+
+use crate::ffi::{Io, FREEARC_ERRCODE_BAD_COMPRESSED_DATA, FREEARC_ERRCODE_IO, OK};
+use core::ffi::c_int;
+
+/// Maximum size of one table element. `Delta.cpp` sizes its `doDiff` and
+/// `immutable` arrays with this and then fills them from a value decoded out of
+/// the stream, without bounding it -- so a hostile or corrupt `type` word walks
+/// off the end of two stack arrays there. Here it is a hard limit and an error.
+const MAX_ELEMENT_SIZE: usize = 30;
+
+/// Decode the packed `type` word into column count and per-column flags.
+///
+/// The C original (`decode_type`) is:
+///     for (i=0; type>1; i++, type>>=1) { immutable[i] = type&1; doDiff[i] = !immutable[i]; }
+///     N = i;
+/// i.e. the position of the highest set bit is the element width, and the bits
+/// below it mark columns that must not be diffed.
+///
+/// Returns `None` when the width exceeds MAX_ELEMENT_SIZE, which the C version
+/// would have written past its arrays for.
+fn decode_type(mut ty: u32) -> Option<(usize, [bool; MAX_ELEMENT_SIZE], [bool; MAX_ELEMENT_SIZE])> {
+    let mut do_diff = [false; MAX_ELEMENT_SIZE];
+    let mut immutable = [false; MAX_ELEMENT_SIZE];
+    let mut n = 0usize;
+    while ty > 1 {
+        if n >= MAX_ELEMENT_SIZE {
+            return None;
+        }
+        immutable[n] = ty & 1 != 0;
+        do_diff[n] = !immutable[n];
+        n += 1;
+        ty >>= 1;
+    }
+    Some((n, do_diff, immutable))
+}
+
+/// Add each element to the previous one, undoing `diff_table`.
+///
+/// Byte-wise with carry, LSB first, and the carry is kept only across adjacent
+/// diffed columns -- a non-diffed column resets it. Mirrors `undiff_table`:
+///     sum = r[i] + r[i-N] + carry;  r[i] = sum;  carry = sum/256;
+/// `r[i] = sum` truncates to a byte in C; that truncation is load-bearing, so
+/// it is spelled out here rather than left to an `as` cast.
+fn undiff_table(n: usize, table: &mut [u8], rows: usize, do_diff: &[bool; MAX_ELEMENT_SIZE]) {
+    for row in 1..rows {
+        let base = row * n;
+        let prev = base - n;
+        let mut carry = 0u32;
+        for i in 0..n {
+            if do_diff[i] {
+                let sum = table[base + i] as u32 + table[prev + i] as u32 + carry;
+                table[base + i] = (sum & 0xff) as u8;
+                carry = sum >> 8;
+            } else {
+                carry = 0;
+            }
+        }
+    }
+}
+
+/// Undo `reorder_table`, which had gathered every immutable column ahead of
+/// every mutable one.
+///
+/// Mirrors `unreorder_table`, including its early return: with no immutable
+/// columns, or with every column immutable, the reordering was a no-op and must
+/// not be undone.
+fn unreorder_table(
+    n: usize,
+    table: &mut [u8],
+    rows: usize,
+    immutable: &[bool; MAX_ELEMENT_SIZE],
+    scratch: &mut Vec<u8>,
+) {
+    let imm_columns = immutable[..n].iter().filter(|&&b| b).count();
+    if imm_columns == 0 || imm_columns == n {
+        return;
+    }
+
+    let len = n * rows;
+    scratch.clear();
+    scratch.extend_from_slice(&table[..len]);
+
+    // Immutable columns were stored first, all `rows` of them, then the mutable
+    // ones. Walk both runs in step and interleave them back.
+    let mut q = 0usize; // cursor into the immutable run
+    let mut q1 = imm_columns * rows; // cursor into the mutable run
+    let mut p = 0usize;
+    for _ in 0..rows {
+        for k in 0..n {
+            table[p] = if immutable[k] {
+                let b = scratch[q];
+                q += 1;
+                b
+            } else {
+                let b = scratch[q1];
+                q1 += 1;
+                b
+            };
+            p += 1;
+        }
+    }
+}
+
+fn read_u32_le(b: &[u8]) -> u32 {
+    u32::from_le_bytes([b[0], b[1], b[2], b[3]])
+}
+
+/// Port of `delta_decompress`.
+///
+/// `block_size` and `extended_tables` are accepted to match the C signature but
+/// are unused on this path, exactly as in the original: the block layout is
+/// taken entirely from the stream.
+pub fn decompress(io: &Io, _block_size: u32, _extended_tables: c_int) -> c_int {
+    let mut data: Vec<u8> = Vec::new();
+    let mut tskip: Vec<u8> = Vec::new();
+    let mut ttype: Vec<u8> = Vec::new();
+    let mut trows: Vec<u8> = Vec::new();
+    let mut scratch: Vec<u8> = Vec::new();
+
+    loop {
+        // READ4_OR_EOF: a zero-length read ends the stream cleanly; anything
+        // else short is an IO error.
+        let mut hdr = [0u8; 4];
+        match io.read(&mut hdr) {
+            0 => return OK,
+            4 => {}
+            n if n < 0 => return n,
+            _ => return FREEARC_ERRCODE_IO,
+        }
+        let data_size = read_u32_le(&hdr) as usize;
+
+        let mut hdr2 = [0u8; 4];
+        if io.read(&mut hdr2) != 4 {
+            return FREEARC_ERRCODE_IO;
+        }
+        let table_size = read_u32_le(&hdr2) as usize;
+
+        // The three descriptor arrays are parallel and each holds u32s.
+        if table_size % 4 != 0 {
+            return FREEARC_ERRCODE_BAD_COMPRESSED_DATA;
+        }
+
+        for (buf, len) in [
+            (&mut tskip, table_size),
+            (&mut ttype, table_size),
+            (&mut trows, table_size),
+            (&mut data, data_size),
+        ] {
+            buf.clear();
+            buf.resize(len, 0);
+            if len != 0 {
+                let got = io.read(&mut buf[..]);
+                if got < 0 {
+                    return got;
+                }
+                if got as usize != len {
+                    return FREEARC_ERRCODE_IO;
+                }
+            }
+        }
+
+        // Replay the recorded tables over the block.
+        let mut p = 0usize;
+        for i in 0..(table_size / 4) {
+            let off = i * 4;
+            let skip = read_u32_le(&tskip[off..]) as usize;
+            let ty = read_u32_le(&ttype[off..]);
+            let rows = read_u32_le(&trows[off..]) as usize;
+
+            let Some((n, do_diff, immutable)) = decode_type(ty) else {
+                return FREEARC_ERRCODE_BAD_COMPRESSED_DATA;
+            };
+
+            // Every one of these would be an out-of-bounds walk in the C
+            // version, which trusts the descriptors completely.
+            p = match p.checked_add(skip) {
+                Some(v) => v,
+                None => return FREEARC_ERRCODE_BAD_COMPRESSED_DATA,
+            };
+            let span = match n.checked_mul(rows) {
+                Some(v) => v,
+                None => return FREEARC_ERRCODE_BAD_COMPRESSED_DATA,
+            };
+            let end = match p.checked_add(span) {
+                Some(v) => v,
+                None => return FREEARC_ERRCODE_BAD_COMPRESSED_DATA,
+            };
+            if end > data.len() {
+                return FREEARC_ERRCODE_BAD_COMPRESSED_DATA;
+            }
+
+            if n > 0 && rows > 0 {
+                let table = &mut data[p..end];
+                unreorder_table(n, table, rows, &immutable, &mut scratch);
+                undiff_table(n, table, rows, &do_diff);
+            }
+            p = end;
+        }
+
+        // WRITE: only a negative return is a failure. The write callback "on
+        // success guarantees to write all the data and may return 0"
+        // (Compression.h:100), so this must not insist on an exact count.
+        if data_size != 0 {
+            let got = io.write(&data);
+            if got < 0 {
+                return got;
+            }
+        }
+    }
+}

--- a/rust/darc-codecs/src/delta.rs
+++ b/rust/darc-codecs/src/delta.rs
@@ -237,3 +237,331 @@ pub fn decompress(io: &Io, _block_size: u32, _extended_tables: c_int) -> c_int {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Compression
+// ---------------------------------------------------------------------------
+//
+// Unlike decompression, this half is all heuristics: which distances look like
+// a table row width, where a table starts and ends, which columns are worth
+// diffing. Every one of those decisions has to reproduce exactly, because the
+// answers are recorded in the stream and a different answer means a different
+// archive.
+
+/// Size of the window in which repeated distances are counted (`LINE`).
+const LINE: usize = 32;
+/// Maximum deviation still considered table-like in the fast check (`DELTA`).
+const DELTA: i32 = 8;
+
+fn read_i16(buf: &[u8], at: isize) -> i16 {
+    // C reads these as unaligned `*(int16*)`. Every call site is kept inside
+    // the block by the loop guards; if one were not, the C original would be
+    // reading uninitialised memory from its own BigAlloc block and would not be
+    // reproducible either.
+    debug_assert!(at >= 0 && (at as usize) + 2 <= buf.len(), "i16 read outside the block");
+    if at < 0 || (at as usize) + 2 > buf.len() {
+        return 0;
+    }
+    i16::from_le_bytes([buf[at as usize], buf[at as usize + 1]])
+}
+
+fn read_u32(buf: &[u8], at: usize) -> u32 {
+    if at + 4 > buf.len() {
+        return 0;
+    }
+    u32::from_le_bytes([buf[at], buf[at + 1], buf[at + 2], buf[at + 3]])
+}
+
+/// Whole part of a binary logarithm, matching `lb()` in Common.h (n > 0).
+fn lb(n: u32) -> u32 {
+    31 - n.leading_zeros()
+}
+
+/// Port of `search_for_table_boundary`.
+///
+/// `n` is a signed stride: the backward scan is called with `-N`. Returns the
+/// index of the boundary, and the `useless` count through the out-parameter the
+/// C version uses.
+fn search_for_table_boundary(
+    buf: &[u8],
+    n: isize,
+    start_at: isize,
+    bufstart: isize,
+    bufend: isize,
+    out_useless: &mut i32,
+) -> isize {
+    let mut t = start_at;
+    let mut dir: i32 = if (read_i16(buf, t + n) as i32) - (read_i16(buf, t) as i32) < 0 { -1 } else { 1 };
+    let (mut len, mut omit, mut useless, mut bad) = (0i32, 0i32, 0i32, 0i32);
+    *out_useless = 0;
+    let mut lastpoint = t;
+    let mut first_time = true;
+
+    t += n;
+    while bufstart <= t + n && t + n + 2 <= bufend {
+        let diff = (read_i16(buf, t) as i32) - (read_i16(buf, t - n) as i32);
+        let mut itemlb = lb(1 + (read_i16(buf, t) as i32).unsigned_abs());
+        let difflb = lb(1 + diff.unsigned_abs());
+        itemlb -= (itemlb > 10) as u32; // itemlb /= 1.1, per the original's comment
+
+        if (dir < 0 && diff < 0) || (dir > 0 && diff > 0) {
+            // The C source writes this as
+            //     difflb < itemlb? len++,omit=0 : useless++,omit++;
+            // where `?:` binds tighter than `,`, so it parses as
+            //     (cond ? (len++, omit=0) : useless++), omit++;
+            // and `omit++` therefore runs on BOTH paths -- the `omit=0` is
+            // immediately undone to 1. Confirmed by compiling it, not by
+            // reading it. `lastpoint = t - n*omit` depends on this.
+            if difflb < itemlb {
+                len += 1;
+                omit = 0;
+            } else {
+                useless += 1;
+            }
+            omit += 1;
+        } else if diff == 0 {
+            useless += 1;
+        } else {
+            if len >= 4 || first_time {
+                bad = 0;
+                lastpoint = t - n * omit as isize;
+                *out_useless = useless;
+                first_time = false;
+            } else {
+                bad += 1;
+                if bad >= 2 {
+                    break; // second short monotonic run in a row
+                }
+            }
+            dir = if (read_i16(buf, t + n) as i32) - (read_i16(buf, t) as i32) < 0 { -1 } else { 1 };
+            len = 0;
+            omit = 0;
+            if dir * diff > 0 {
+                t -= n; // V-shaped transition: restart at the current value
+            }
+        }
+        t += n;
+    }
+    lastpoint
+}
+
+/// Port of `analyze_table`: decide per column whether it is near-constant
+/// (left alone and gathered to the front) or worth diffing.
+fn analyze_table(
+    buf: &[u8],
+    n: usize,
+    table_start: usize,
+    rows: usize,
+    do_diff: &mut [bool; MAX_ELEMENT_SIZE],
+    immutable: &mut [bool; MAX_ELEMENT_SIZE],
+) {
+    for k in 0..n {
+        let mut neq = 0i32;
+        let mut p = table_start + k;
+        for _ in 1..rows {
+            neq += (buf[p + n] != buf[p]) as i32;
+            p += n;
+        }
+        // "Constant" means fewer than a quarter of the rows change. The N
+        // exclusions are in the original and are load-bearing.
+        immutable[k] = neq * 4 < rows as i32 && n != 2 && n != 4 && n != 8;
+        do_diff[k] = !immutable[k];
+    }
+}
+
+/// Port of `diff_table`: subtract each row from the next, LSB-first with carry
+/// kept only across adjacent diffed columns.
+fn diff_table(buf: &mut [u8], n: usize, table_start: usize, rows: usize, do_diff: &[bool; MAX_ELEMENT_SIZE]) {
+    let mut row = rows;
+    while row > 1 {
+        row -= 1;
+        let base = table_start + row * n;
+        let prev = base - n;
+        let mut carry = 0u32;
+        for i in 0..n {
+            if do_diff[i] {
+                let cur = buf[base + i] as u32;
+                let sub = buf[prev + i] as u32 + carry;
+                let newcarry = (cur < sub) as u32;
+                buf[base + i] = (cur.wrapping_sub(sub) & 0xff) as u8;
+                carry = newcarry;
+            } else {
+                carry = 0;
+            }
+        }
+    }
+}
+
+/// Port of `reorder_table`: move every immutable column ahead of the mutable
+/// ones, which helps the LZ77 stage downstream.
+fn reorder_table(
+    buf: &mut [u8],
+    n: usize,
+    table_start: usize,
+    rows: usize,
+    immutable: &[bool; MAX_ELEMENT_SIZE],
+    scratch: &mut Vec<u8>,
+) {
+    let len = n * rows;
+    scratch.clear();
+    scratch.extend_from_slice(&buf[table_start..table_start + len]);
+
+    let mut p = table_start;
+    for pass_immutable in [true, false] {
+        let mut q = 0usize;
+        for _ in 0..rows {
+            for k in 0..n {
+                if immutable[k] == pass_immutable {
+                    buf[p] = scratch[q];
+                    p += 1;
+                }
+                q += 1;
+            }
+        }
+    }
+}
+
+fn encode_type(n: usize, immutable: &[bool; MAX_ELEMENT_SIZE]) -> u32 {
+    let mut ty = 1u32 << n;
+    for i in 0..n {
+        ty += (immutable[i] as u32) << i;
+    }
+    ty
+}
+
+/// Port of `slow_check_for_data_table`. Returns the table extent and its
+/// encoded type when the candidate is judged worth encoding.
+#[allow(clippy::too_many_arguments)]
+fn slow_check_for_data_table(
+    buf: &mut [u8],
+    n: usize,
+    p: usize,
+    bufstart: isize,
+    bufend: isize,
+    scratch: &mut Vec<u8>,
+) -> Option<(usize, usize, u32)> {
+    let mut useless = 0i32;
+    let table_start = search_for_table_boundary(buf, -(n as isize), p as isize, bufstart, bufend, &mut useless);
+    let table_end = search_for_table_boundary(buf, n as isize, table_start, bufstart, bufend, &mut useless);
+
+    if table_end <= table_start {
+        return None;
+    }
+    let rows = ((table_end - table_start) / n as isize) as usize;
+    let useful = rows as i32 - useless;
+    let skip_bits = (core::cmp::max(table_start - bufstart, 1) as f64).log2().floor();
+
+    // The acceptance test, in double arithmetic exactly as the original:
+    //   useful*sqrt(N) > 30 + 4*skipBits
+    if (useful as f64) * (n as f64).sqrt() > 30.0 + 4.0 * skip_bits {
+        let mut do_diff = [false; MAX_ELEMENT_SIZE];
+        let mut immutable = [false; MAX_ELEMENT_SIZE];
+        let ts = table_start as usize;
+        analyze_table(buf, n, ts, rows, &mut do_diff, &mut immutable);
+        diff_table(buf, n, ts, rows, &do_diff);
+        reorder_table(buf, n, ts, rows, &immutable, scratch);
+        return Some((ts, table_end as usize, encode_type(n, &immutable)));
+    }
+    None
+}
+
+/// Port of the `FAST_CHECK_FOR_DATA_TABLE` macro: a cheap filter before the
+/// expensive boundary search.
+fn fast_check(buf: &[u8], n: usize, p: usize) -> bool {
+    let b = |off: usize| buf[p + off] as i32;
+    if p + 3 * n + 2 > buf.len() {
+        return false;
+    }
+    (((b(1) - b(n + 1) + DELTA) as u32) <= 2 * DELTA as u32)
+        && (((b(n + 1) - b(2 * n + 1) + DELTA) as u32) <= 2 * DELTA as u32)
+        && (((b(2 * n + 1) - b(3 * n + 1) + DELTA) as u32) <= 2 * DELTA as u32)
+        && (read_i16(buf, p as isize) as i32 + read_i16(buf, (p + n) as isize) as i32
+            != read_i16(buf, (p + 2 * n) as isize) as i32 + read_i16(buf, (p + 3 * n) as isize) as i32)
+}
+
+/// Port of `delta_compress`.
+pub fn compress(io: &Io, block_size: u32, _extended_tables: c_int) -> c_int {
+    let block_size = block_size.max(1) as usize;
+    let mut buf = vec![0u8; block_size];
+    let mut scratch: Vec<u8> = Vec::new();
+    let (mut tskip, mut ttype, mut trows): (Vec<u8>, Vec<u8>, Vec<u8>) = (Vec::new(), Vec::new(), Vec::new());
+
+    loop {
+        // READ_LEN_OR_EOF: a non-positive result ends the stream.
+        let size = io.read(&mut buf[..]);
+        if size < 0 {
+            return size;
+        }
+        if size == 0 {
+            return OK;
+        }
+        let size = size as usize;
+
+        tskip.clear();
+        ttype.clear();
+        trows.clear();
+
+        let bufend = size as isize;
+        let mut last_table_end: usize = 0;
+        // C seeds these with `buf-1`, one before the block; -1 as a signed
+        // offset is the same thing without forming an out-of-range pointer.
+        let mut hash = [-1i64; 256];
+
+        let mut ptr = LINE;
+        while ptr + MAX_ELEMENT_SIZE * 4 < size {
+            // Cheap skip for runs of identical bytes, e.g. blocks of zeroes.
+            if read_u32(&buf, ptr) != read_u32(&buf, ptr + 3) {
+                let mut count = [0u8; MAX_ELEMENT_SIZE];
+                let mut p = ptr;
+                for _ in 0..LINE {
+                    let slot = (buf[p] / 16) as usize;
+                    let n = p as i64 - hash[slot];
+                    hash[slot] = p as i64;
+                    if n <= MAX_ELEMENT_SIZE as i64 {
+                        count[(n - 1) as usize] = count[(n - 1) as usize].wrapping_add(1);
+                    }
+                    p += 1;
+                }
+
+                let mut found_end: Option<usize> = None;
+                'candidates: for i in 0..MAX_ELEMENT_SIZE {
+                    if count[i] > 5 {
+                        let n = i + 1;
+                        for j in 0..n {
+                            let p = ptr + j;
+                            if !fast_check(&buf, n, p) {
+                                continue;
+                            }
+                            if let Some((ts, te, ty)) = slow_check_for_data_table(
+                                &mut buf, n, p, last_table_end as isize, bufend, &mut scratch,
+                            ) {
+                                tskip.extend_from_slice(&((ts - last_table_end) as u32).to_le_bytes());
+                                ttype.extend_from_slice(&ty.to_le_bytes());
+                                trows.extend_from_slice(&(((te - ts) / n) as u32).to_le_bytes());
+                                last_table_end = te;
+                                found_end = Some(te);
+                                break 'candidates;
+                            }
+                        }
+                    }
+                }
+                if let Some(te) = found_end {
+                    ptr = core::cmp::max(ptr + LINE, te);
+                    continue;
+                }
+            }
+            ptr += LINE;
+        }
+
+        // Emit the block: sizes, the three descriptor arrays, then the data.
+        if io.write(&(size as u32).to_le_bytes()) < 0
+            || io.write(&(ttype.len() as u32).to_le_bytes()) < 0
+            || io.write(&tskip) < 0
+            || io.write(&ttype) < 0
+            || io.write(&trows) < 0
+            || io.write(&buf[..size]) < 0
+        {
+            return FREEARC_ERRCODE_IO;
+        }
+    }
+}

--- a/rust/darc-codecs/src/dict.rs
+++ b/rust/darc-codecs/src/dict.rs
@@ -1,0 +1,223 @@
+//! Dict: dictionary preprocessor, ported from Compression/Dict/dict.cpp.
+//!
+//! Dict replaces frequent words in the input with one- or two-byte codes and
+//! prepends the dictionary needed to reverse it. Decompression is ported first,
+//! for the same reason as in Delta: the dictionary is carried in the stream, so
+//! this code only replays the encoder's decisions, and it can be validated
+//! against output the C encoder produced.
+//!
+//! The C decoder trusts its input completely, and this is where three of the
+//! defects fixed on the previous branch lived:
+//!
+//!   * `get_byte()` is `*ptr++` with no check against `end`. The dictionary
+//!     header alone reads hundreds of bytes before the decode loop's `ptr<end`
+//!     test is ever consulted.
+//!   * `put_word` is a `memcpy` into `outbuf` with no capacity check at all.
+//!   * the word-text buffer is sized, in the original's own words, "by
+//!     guesswork, but with a big margin", and the two-byte word loop then reads
+//!     until a separator byte with no bound.
+//!
+//! Every one of those is a heap overflow reachable from a corrupt or hostile
+//! archive. This port bounds all three and returns
+//! FREEARC_ERRCODE_BAD_COMPRESSED_DATA instead.
+
+use crate::ffi::{Io, FREEARC_ERRCODE_BAD_COMPRESSED_DATA, FREEARC_ERRCODE_IO, OK};
+use core::ffi::c_int;
+
+/// A `dict[i].len` of exactly 1 means "this byte introduces a two-byte code"
+/// rather than "a one-byte word of length 1" -- the encoder never emits a
+/// single-character word, which is what makes the overload unambiguous.
+const USE_DICT2: u32 = 1;
+const N: usize = 256;
+
+#[derive(Clone, Copy, Default)]
+struct Entry {
+    len: u32,
+    /// Offset into the word-text buffer; `len == 0` means unused.
+    at: usize,
+}
+
+struct Reader<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn byte(&mut self) -> Result<u8, c_int> {
+        // The C original is `*ptr++`, unchecked. This is the check.
+        let b = *self.buf.get(self.pos).ok_or(FREEARC_ERRCODE_BAD_COMPRESSED_DATA)?;
+        self.pos += 1;
+        Ok(b)
+    }
+    fn at_end(&self) -> bool {
+        self.pos >= self.buf.len()
+    }
+}
+
+/// Port of `DictDecode`. Returns the decoded bytes.
+pub fn decode(input: &[u8], out_limit: usize) -> Result<Vec<u8>, c_int> {
+    let mut r = Reader { buf: input, pos: 0 };
+    let mut dict = [Entry::default(); N];
+    let mut dict2 = vec![Entry::default(); N * N];
+    let mut words: Vec<u8> = Vec::new();
+    let mut out: Vec<u8> = Vec::new();
+
+    // 1. Lengths of the one-byte-coded words.
+    for e in dict.iter_mut() {
+        e.len = r.byte()? as u32;
+    }
+    // 2. Lengths of the two-byte-coded words, for each introducer byte.
+    for i in 0..N {
+        if dict[i].len == USE_DICT2 {
+            for j in 0..N {
+                dict2[i * N + j].len = r.byte()? as u32;
+            }
+        }
+    }
+    // 3. Text of the one-byte words.
+    for i in 0..N {
+        if dict[i].len == USE_DICT2 {
+            continue;
+        }
+        dict[i].at = words.len();
+        for _ in 0..dict[i].len {
+            let b = r.byte()?;
+            words.push(b);
+        }
+    }
+    // 4. Text of the two-byte words. Each is a prefix copied from the previous
+    //    word plus a tail read up to `word_sep`.
+    let word_sep = r.byte()?;
+    let mut prev: Option<(usize, u32)> = None; // (offset, len) of the previous word
+    for i in 0..N {
+        if dict[i].len != USE_DICT2 {
+            continue;
+        }
+        for j in 0..N {
+            let start = words.len();
+            let take = dict2[i * N + j].len;
+            if take > 0 {
+                // Copying from a word that does not exist is malformed input;
+                // the C version dereferences a NULL prevptr here, which it does
+                // at least check for -- but not the length.
+                let (poff, plen) = prev.ok_or(FREEARC_ERRCODE_BAD_COMPRESSED_DATA)?;
+                if take > plen {
+                    return Err(FREEARC_ERRCODE_BAD_COMPRESSED_DATA);
+                }
+                for k in 0..take as usize {
+                    let b = words[poff + k];
+                    words.push(b);
+                }
+            }
+            loop {
+                let c = r.byte()?;
+                if c == word_sep {
+                    break;
+                }
+                words.push(c);
+                // The C word buffer is sized by guesswork; this bounds it
+                // against the only thing that can legitimately fill it.
+                if words.len() > input.len().saturating_add(1 << 20) {
+                    return Err(FREEARC_ERRCODE_BAD_COMPRESSED_DATA);
+                }
+            }
+            dict2[i * N + j].at = start;
+            dict2[i * N + j].len = (words.len() - start) as u32;
+            prev = Some((start, dict2[i * N + j].len));
+        }
+    }
+
+    // 5. Pseudo-words for characters that gave their code away to a word.
+    let prefix = r.byte()? as usize;
+    dict[prefix].len = USE_DICT2;
+    for j in 0..N {
+        dict2[prefix * N + j].len = 1;
+        dict2[prefix * N + j].at = words.len();
+        words.push(j as u8);
+    }
+
+    // Decode the text.
+    let push = |out: &mut Vec<u8>, src: &[u8]| -> Result<(), c_int> {
+        if out.len() + src.len() > out_limit {
+            // `put_word` is an unchecked memcpy in the original.
+            return Err(FREEARC_ERRCODE_BAD_COMPRESSED_DATA);
+        }
+        out.extend_from_slice(src);
+        Ok(())
+    };
+    while !r.at_end() {
+        let c = r.byte()? as usize;
+        let d = dict[c];
+        if d.len == 0 {
+            push(&mut out, &[c as u8])?;
+        } else if d.len == USE_DICT2 {
+            let c2 = r.byte()? as usize;
+            let e = dict2[c * N + c2];
+            let end = e.at.checked_add(e.len as usize).ok_or(FREEARC_ERRCODE_BAD_COMPRESSED_DATA)?;
+            if end > words.len() {
+                return Err(FREEARC_ERRCODE_BAD_COMPRESSED_DATA);
+            }
+            let w = words[e.at..end].to_vec();
+            push(&mut out, &w)?;
+        } else {
+            let end = d.at.checked_add(d.len as usize).ok_or(FREEARC_ERRCODE_BAD_COMPRESSED_DATA)?;
+            if end > words.len() {
+                return Err(FREEARC_ERRCODE_BAD_COMPRESSED_DATA);
+            }
+            let w = words[d.at..end].to_vec();
+            push(&mut out, &w)?;
+        }
+    }
+    Ok(out)
+}
+
+/// Port of `dict_decompress` (C_Dict.cpp). Block framing:
+///   i32 InSize   negative -> that many bytes follow, stored uncompressed
+///                zero-length read -> clean end of stream
+#[allow(clippy::too_many_arguments)]
+pub fn decompress(io: &Io, block_size: u32) -> c_int {
+    let block_size = block_size.max(1) as usize;
+    loop {
+        let mut hdr = [0u8; 4];
+        match io.read(&mut hdr) {
+            0 => return OK,
+            4 => {}
+            n if n < 0 => return n,
+            _ => return FREEARC_ERRCODE_IO,
+        }
+        let in_size = i32::from_le_bytes(hdr);
+
+        if in_size < 0 {
+            // Stored block: copied through unchanged.
+            let n = (-(in_size as i64)) as usize;
+            let mut raw = vec![0u8; n];
+            if io.read(&mut raw) as usize != n {
+                return FREEARC_ERRCODE_IO;
+            }
+            if io.write(&raw) < 0 {
+                return FREEARC_ERRCODE_IO;
+            }
+            continue;
+        }
+
+        let n = in_size as usize;
+        let mut packed = vec![0u8; n];
+        if n != 0 {
+            let got = io.read(&mut packed);
+            if got < 0 {
+                return got;
+            }
+            if got as usize != n {
+                return FREEARC_ERRCODE_IO;
+            }
+        }
+        match decode(&packed, block_size) {
+            Ok(out) => {
+                if !out.is_empty() && io.write(&out) < 0 {
+                    return FREEARC_ERRCODE_IO;
+                }
+            }
+            Err(e) => return e,
+        }
+    }
+}

--- a/rust/darc-codecs/src/dict_encode.rs
+++ b/rust/darc-codecs/src/dict_encode.rs
@@ -1,0 +1,355 @@
+//! Dict encoder, ported from Compression/Dict/dict.cpp (phases 1-7).
+//!
+//! This is the half where three of the defects fixed on the previous branch
+//! lived: phase1 read past the front of the block, phase2 double-freed after a
+//! zero-size realloc, and phase7's FindWord read one byte past the end. Porting
+//! it replaces patched C with code where those cannot be expressed.
+//!
+//! Bit-exactness is mandatory -- the dictionary and the encoded text are the
+//! archive format. Two things make that harder here than for Delta or LZP:
+//!
+//!   * phase1 is a trie mapped onto a closed-hash table, searched
+//!     speculatively in WORD_STEP jumps and then refined backwards. The C is
+//!     written with six `goto` labels; the control flow is reproduced here with
+//!     an explicit enum rather than being "tidied", because which branch runs
+//!     decides which words enter the dictionary.
+//!   * phases 3, 4 and 6 sort with `qsort` on comparators that tie constantly,
+//!     and the tie order decides which words fall either side of the one-byte /
+//!     two-byte split. C output is byte-identical on macOS/ARM64 and
+//!     Linux/x86-64, so two unrelated qsort implementations agree and the order
+//!     within a tie does not reach the output; a stable sort is therefore safe.
+//!     The differential harness is what confirms that, not this comment.
+
+use crate::ffi::FREEARC_ERRCODE_GENERAL;
+use core::ffi::c_int;
+
+const MAX_WORD_LEN: usize = 254;
+const USE_DICT2: u32 = 1;
+const RESERVED_CHAR: u8 = b' ';
+const WORD_STEP: usize = 4;
+const DIRECT_CHARS: usize = 12;
+const SCNT_MAX: i32 = i16::MAX as i32;
+const UCHAR_MAX: usize = 255;
+
+/// `MIN_VISITS_TO_HAVE_SON(len)`
+#[inline]
+fn min_visits(len: usize) -> i32 {
+    if len > 10 { 2 } else { 5 }
+}
+
+/// `char_class_table`: control characters and space form one class, everything
+/// else the other. Transcribed from the `#if 1` variant that is actually
+/// compiled -- the file carries three alternatives.
+#[inline]
+fn char_class(c: u8) -> u8 {
+    if c <= 32 { 0 } else { 1 }
+}
+
+#[inline]
+fn allow_extend(c1: u8, c2: u8) -> bool {
+    char_class(c1) == char_class(c2)
+}
+
+#[inline]
+fn update_hash(hash: u32, c: u8) -> u32 {
+    hash.wrapping_mul(137).wrapping_add(c as u32).wrapping_add(219)
+}
+
+#[inline]
+fn rehash(hash: u32, c: u8) -> u32 {
+    hash.wrapping_add((c as u32).wrapping_mul(256)).wrapping_add(317)
+}
+
+fn roundup_to_power_of_2(mut n: u32) -> u32 {
+    let mut r = 1u32;
+    while r < n {
+        r = r.wrapping_mul(2);
+        if r == 0 {
+            return u32::MAX;
+        }
+    }
+    n = r;
+    n
+}
+
+#[derive(Clone, Copy, Default)]
+struct Stats {
+    count: i16,
+    hash0: u16,
+}
+
+/// Mirrors the C `Word` union: `{hash, hash0}` while the dictionary is being
+/// built, `{count, chr, chr2}` after phase2 prunes it. Kept as one struct with
+/// both sets, since nothing reads the stale half.
+#[derive(Clone, Copy, Default)]
+struct Word {
+    at: usize,   // offset of the word text in the input block
+    len: u32,
+    hash: u32,
+    hash0: u32,
+    count: i32,
+    chr: u8,
+    chr2: u8,
+}
+
+/// Outcome of the `SEARCH_IN_HASH` macro. The macro mutates `hash` as it
+/// rehashes, so the updated value comes back with the verdict.
+enum Search {
+    Found(u32),
+    LongChain(u32),
+    Empty(u32),
+}
+
+fn search_in_hash(scan: &[Stats], mask: u32, mut hash: u32, phash: u32, c: u8) -> Search {
+    let mut n = 13;
+    loop {
+        let h = scan[(hash & mask) as usize].hash0;
+        if h == 0 {
+            return Search::Empty(hash);
+        }
+        if h == phash as u16 {
+            return Search::Found(hash);
+        }
+        n -= 1;
+        if n == 0 {
+            return Search::LongChain(hash);
+        }
+        hash = rehash(hash, c);
+    }
+}
+
+impl Encoder {
+    pub fn new() -> Self {
+        Encoder { words: Vec::new(), scan: Vec::new(), mask: 0, max_words: 0,
+                  char_counts: [0; 256], prefix_for_weak_chars: 0 }
+    }
+    /// Dump phase1's result in the same format as rust/difftest/dict_phase1_ref.cpp,
+    /// so the two can be diffed directly.
+    pub fn dump_phase1(&self) -> String {
+        let mut out = String::new();
+        out.push_str(&format!("words {}\n", self.words.len()));
+        for w in &self.words {
+            out.push_str(&format!("W {} {} {} {}\n", w.at, w.len, w.hash, w.hash0));
+        }
+        for (c, n) in self.char_counts.iter().enumerate() {
+            if *n != 0 { out.push_str(&format!("C {} {}\n", c, n)); }
+        }
+        out
+    }
+}
+
+impl Default for Encoder {
+    fn default() -> Self { Self::new() }
+}
+
+pub struct Encoder {
+    words: Vec<Word>,
+    scan: Vec<Stats>,
+    mask: u32,
+    max_words: usize,
+    char_counts: [i32; 256],
+    prefix_for_weak_chars: u8,
+}
+
+impl Encoder {
+    fn add_word(&mut self, at: usize, len: usize, hash: u32, phash: u32) {
+        // ADDWORD: dictionary full, word too long, or a hash whose low 16 bits
+        // are zero (which would collide with "empty slot") are all skipped.
+        if self.words.len() < self.max_words && len <= MAX_WORD_LEN && (hash as u16) != 0 {
+            let h = (hash & self.mask) as usize;
+            let ph = (phash & self.mask) as usize;
+            self.scan[ph].count = self.scan[ph].count.wrapping_add(1);
+            self.scan[h].count = 1;
+            self.scan[h].hash0 = phash as u16;
+            self.words.push(Word { at, len: len as u32, hash: h as u32, hash0: ph as u32, ..Default::default() });
+        }
+    }
+
+    /// phase1: build the word list and count byte frequencies.
+    pub fn phase1(&mut self, buf: &[u8]) {
+        let bufsize = buf.len();
+        let max_words = roundup_to_power_of_2(core::cmp::max(bufsize as u32 / 32, 32768)) as usize;
+        self.max_words = max_words;
+        let scanhash_size = max_words * 2;
+        self.mask = (scanhash_size - 1) as u32;
+        self.scan = vec![Stats::default(); scanhash_size];
+        // Slot zero, and every slot at a multiple of 2^16, must never be usable
+        // as a word: hash0==0 is the "empty" marker.
+        let mut i = 0usize;
+        while i < scanhash_size {
+            self.scan[i].hash0 = 1;
+            i += 1 << 16;
+        }
+
+        let mut p = 0usize;
+        // bufsize is unsigned in C and this subtraction runs off the front for
+        // a very short block; clamped, as the C was after the fix.
+        let endbuf = if bufsize > WORD_STEP + 1 { bufsize - WORD_STEP - 1 } else { 0 };
+
+        while p < endbuf {
+            let p0 = p;
+            let mut c1 = buf[p];
+            p += 1;
+            let mut c = buf[p];
+            'word: {
+                if !allow_extend(c1, c) {
+                    break 'word;
+                }
+                p += 1;
+                let mut hash0 = ((c1 as u32) << 8) + c as u32 + 16;
+
+                match search_in_hash(&self.scan, self.mask, hash0, hash0, hash0 as u8) {
+                    Search::Found(_) => {}                    // -> found2
+                    Search::LongChain(_) => break 'word,      // -> end, no word added
+                    Search::Empty(_) => {                     // fall through -> ADDWORD, end
+                        self.add_word(p0, p - p0, hash0, hash0);
+                        break 'word;
+                    }
+                }
+
+                // found2: grow the word until it leaves the dictionary.
+                loop {
+                    let mut hash = hash0;
+                    let mut hash1 = hash0;
+                    let mut i = 0usize;
+                    let mut hit_bad_char = false;
+                    while i < WORD_STEP {
+                        c1 = c;
+                        c = buf[p + i];
+                        if !allow_extend(c1, c) {
+                            hit_bad_char = true;
+                            break;
+                        }
+                        hash1 = hash;
+                        hash = update_hash(hash1, c);
+                        i += 1;
+                    }
+
+                    // Which label the C would jump to.
+                    enum Next { NextCycle(u32), FoundMax(u32), SearchLess(u32) }
+                    let next = if hit_bad_char {
+                        // search_max
+                        if i > 0 {
+                            match search_in_hash(&self.scan, self.mask, hash, hash1, c1) {
+                                Search::Found(h) => Next::FoundMax(h),
+                                Search::LongChain(h) => Next::FoundMax(h),
+                                Search::Empty(h) => Next::SearchLess(h),
+                            }
+                        } else {
+                            Next::FoundMax(hash)
+                        }
+                    } else {
+                        match search_in_hash(&self.scan, self.mask, hash, hash1, c1) {
+                            Search::Found(h) => Next::NextCycle(h),
+                            Search::LongChain(h) => Next::FoundMax(h),
+                            Search::Empty(h) => Next::SearchLess(h),
+                        }
+                    };
+
+                    match next {
+                        Next::NextCycle(h) => {
+                            p += i;
+                            let idx = (h & self.mask) as usize;
+                            let counter = self.scan[idx].count as i32;
+                            if counter >= min_visits(p - p0) {
+                                hash0 = h;
+                                if p < endbuf { continue; } else { break; }
+                            }
+                            if counter > 0 {
+                                self.scan[idx].count = (counter + 1) as i16;
+                                break;
+                            }
+                            self.add_word(p0, p - p0, h, hash1);
+                            break;
+                        }
+                        Next::FoundMax(h) => {
+                            p += i;
+                            let idx = (h & self.mask) as usize;
+                            let counter = self.scan[idx].count as i32;
+                            if counter <= 0 {
+                                self.add_word(p0, p - p0, h, hash1);
+                                break;
+                            }
+                            if counter < SCNT_MAX - 1 {
+                                self.scan[idx].count = (counter + 1) as i16;
+                            }
+                            break;
+                        }
+                        Next::SearchLess(h) => {
+                            // The maximum-length word is absent, so walk up from
+                            // the start looking for the longest one present.
+                            //
+                            // UNRESOLVED: the C jumps to the outer `found_max:`
+                            // label on a long hash chain, and because C reuses
+                            // `i` and the labels share scope it is ambiguous
+                            // from reading alone whether that means the outer
+                            // `hash`/`hash1` or the inner ones. Mirroring the
+                            // outer reading made agreement *worse* (5/11 rather
+                            // than 7/11 inputs), so this keeps the inner
+                            // reading, which is closer but still not exact.
+                            // See the phase1 status note in the commit message.
+                            let maxi = i;
+                            let mut h0 = hash0;
+                            let mut h3 = hash0;
+                            let mut h2 = h;
+                            let mut settled = false;
+                            let mut j = 1usize;
+                            while j < maxi {
+                                let cc = buf[p];
+                                p += 1;
+                                let h1 = update_hash(h0, cc);
+                                match search_in_hash(&self.scan, self.mask, h1, h0, cc) {
+                                    // SEARCH_IN_HASH mutates h2 as it rehashes;
+                                    // `next:` then does h0=h1, h3=h2 with that value.
+                                    Search::Found(hh) => { h2 = hh; h0 = h1; h3 = hh; }
+                                    Search::LongChain(hh) => {
+                                        let idx = (hh & self.mask) as usize;
+                                        let counter = self.scan[idx].count as i32;
+                                        if counter <= 0 {
+                                            self.add_word(p0, p - p0, hh, h0);
+                                        } else if counter < SCNT_MAX - 1 {
+                                            self.scan[idx].count = (counter + 1) as i16;
+                                        }
+                                        settled = true;
+                                        h2 = hh;
+                                        break;
+                                    }
+                                    Search::Empty(hh) => { h2 = hh; p -= 1; settled = true; break; }
+                                }
+                                j += 1;
+                            }
+                            if !settled {
+                                h2 = hash;
+                            }
+                            let idx = (h3 & self.mask) as usize;
+                            let counter = self.scan[idx].count as i32;
+                            if counter >= min_visits(p - p0) {
+                                p += 1;
+                                self.add_word(p0, p - p0, h2, h0);
+                            } else {
+                                self.scan[idx].count = (counter + 1) as i16;
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
+            // end: count the bytes consumed by this position
+            let mut q = p0;
+            while q < p {
+                self.char_counts[buf[q] as usize] += 1;
+                q += 1;
+            }
+        }
+        while p < bufsize {
+            self.char_counts[buf[p] as usize] += 1;
+            p += 1;
+        }
+    }
+}
+
+/// Entry point placeholder: the remaining phases (2-7) are not ported yet, so
+/// this deliberately reports failure rather than producing a wrong archive.
+pub fn encode(_buf: &[u8]) -> Result<Vec<u8>, c_int> {
+    Err(FREEARC_ERRCODE_GENERAL)
+}

--- a/rust/darc-codecs/src/dict_encode.rs
+++ b/rust/darc-codecs/src/dict_encode.rs
@@ -100,6 +100,31 @@ enum Search {
     Empty(u32),
 }
 
+/// The initial two-byte lookup is written as
+///     SEARCH_IN_HASH (hash0, hash0, hash0, 0, found2, end);
+/// where `hash`, `phash` and `c` are all the SAME variable. Because the macro
+/// assigns `hash = rehash(hash, c)`, every rehash changes the comparison target
+/// and the rehash input too -- they are not fixed at their entry values the way
+/// a function call would fix them. Modelling this as an ordinary call silently
+/// searches a different chain.
+fn search_in_hash_aliased(scan: &[Stats], mask: u32, mut hash: u32) -> Search {
+    let mut n = 13;
+    loop {
+        let h = scan[(hash & mask) as usize].hash0;
+        if h == 0 {
+            return Search::Empty(hash);
+        }
+        if h == hash as u16 {
+            return Search::Found(hash);
+        }
+        n -= 1;
+        if n == 0 {
+            return Search::LongChain(hash);
+        }
+        hash = rehash(hash, hash as u8);
+    }
+}
+
 fn search_in_hash(scan: &[Stats], mask: u32, mut hash: u32, phash: u32, c: u8) -> Search {
     let mut n = 13;
     loop {
@@ -186,8 +211,14 @@ impl Encoder {
         // a very short block; clamped, as the C was after the fix.
         let endbuf = if bufsize > WORD_STEP + 1 { bufsize - WORD_STEP - 1 } else { 0 };
 
+        // Trace hook for the per-phase comparison; the lookup is hoisted so the
+        // scan loop pays nothing when it is unset.
+        let trace_at: Option<usize> = std::env::var("DARC_TRACE_AT").ok()
+            .and_then(|v| v.parse::<usize>().ok());
+
         while p < endbuf {
             let p0 = p;
+            let tracing = trace_at == Some(p0);
             let mut c1 = buf[p];
             p += 1;
             let mut c = buf[p];
@@ -198,10 +229,18 @@ impl Encoder {
                 p += 1;
                 let mut hash0 = ((c1 as u32) << 8) + c as u32 + 16;
 
-                match search_in_hash(&self.scan, self.mask, hash0, hash0, hash0 as u8) {
-                    Search::Found(_) => {}                    // -> found2
+                // SEARCH_IN_HASH takes `hash` by reference in effect: the macro
+                // assigns `hash = rehash(hash, c)` on the caller's variable, so
+                // hash0 holds the REHASHED value afterwards. Both the ADDWORD
+                // below and the found2 loop's `hash = hash0` then use it.
+                // Discarding it and reusing the original hash0 stores the word
+                // at the unrehashed slot -- C writes "W 21739 2 57816 57816"
+                // where this port wrote 17819, one rehash behind.
+                match search_in_hash_aliased(&self.scan, self.mask, hash0) {
+                    Search::Found(h) => hash0 = h,            // -> found2
                     Search::LongChain(_) => break 'word,      // -> end, no word added
-                    Search::Empty(_) => {                     // fall through -> ADDWORD, end
+                    Search::Empty(h) => {                     // fall through -> ADDWORD, end
+                        hash0 = h;
                         self.add_word(p0, p - p0, hash0, hash0);
                         break 'word;
                     }
@@ -246,6 +285,12 @@ impl Encoder {
                         }
                     };
 
+                    if tracing {
+                        eprintln!("TRACE p0={} i={} hash={} hash1={} branch={}", p0, i, hash, hash1,
+                                  match &next { Next::NextCycle(_) => "next_cycle",
+                                                Next::FoundMax(_) => "found_max",
+                                                Next::SearchLess(_) => "search_less" });
+                    }
                     match next {
                         Next::NextCycle(h) => {
                             p += i;
@@ -319,10 +364,19 @@ impl Encoder {
                                 j += 1;
                             }
                             if !settled {
-                                h2 = hash;
+                                // C's `h2 = hash` after the loop uses the OUTER
+                                // hash -- which SEARCH_IN_HASH already rehashed
+                                // on its way to search_less. `hash` here is the
+                                // pre-search value; the rehashed one arrives as
+                                // the SearchLess payload.
+                                h2 = h;
                             }
                             let idx = (h3 & self.mask) as usize;
                             let counter = self.scan[idx].count as i32;
+                            if tracing {
+                                eprintln!("TRACE search_less p0={} maxi={} h3={} idx={} counter={} min={} len={} h2={} h0={} settled={}",
+                                          p0, maxi, h3, idx, counter, min_visits(p - p0), p - p0, h2, h0, settled);
+                            }
                             if counter >= min_visits(p - p0) {
                                 p += 1;
                                 self.add_word(p0, p - p0, h2, h0);

--- a/rust/darc-codecs/src/dict_encode.rs
+++ b/rust/darc-codecs/src/dict_encode.rs
@@ -148,6 +148,26 @@ impl Encoder {
         Encoder { words: Vec::new(), scan: Vec::new(), mask: 0, max_words: 0,
                   char_counts: [0; 256], prefix_for_weak_chars: 0 }
     }
+    pub fn prefix(&self) -> u8 { self.prefix_for_weak_chars }
+
+    /// Words after phase2/phase3, matching the C dumper's "W <at> <len> <count>".
+    pub fn dump_words(&self) -> String {
+        let mut out = String::new();
+        out.push_str(&format!("words {}\n", self.words.len()));
+        for w in &self.words {
+            out.push_str(&format!("W {} {} {}\n", w.at, w.len, w.count));
+        }
+        out
+    }
+
+    pub fn dump_char_counts(&self) -> String {
+        let mut out = String::new();
+        for (c, n) in self.char_counts.iter().enumerate() {
+            if *n != 0 { out.push_str(&format!("C {} {}\n", c, n)); }
+        }
+        out
+    }
+
     /// Dump phase1's result in the same format as rust/difftest/dict_phase1_ref.cpp,
     /// so the two can be diffed directly.
     pub fn dump_phase1(&self) -> String {
@@ -402,8 +422,89 @@ impl Encoder {
     }
 }
 
-/// Entry point placeholder: the remaining phases (2-7) are not ported yet, so
-/// this deliberately reports failure rather than producing a wrong archive.
-pub fn encode(_buf: &[u8]) -> Result<Vec<u8>, c_int> {
-    Err(FREEARC_ERRCODE_GENERAL)
+impl Encoder {
+    /// phase2: promote single-child counters, then prune words that do not earn
+    /// their place. Returns Err when nothing survives, exactly as the C returns
+    /// -1 and lets DictEncode store the block instead.
+    pub fn phase2(&mut self, min_large: i32, min_medium: i32, min_small: i32, min_ratio: i32) -> Result<(), c_int> {
+        // Hand a single-child parent's counter down to the child. A parent with
+        // exactly the minimum-plus-one, or a negative count, has only one child.
+        for i in 0..self.words.len() {
+            let w = self.words[i];
+            let len = w.len as usize;
+            let cnt = self.scan[w.hash as usize].count as i32;
+            let cnt0 = self.scan[w.hash0 as usize].count as i32;
+            if cnt0 == min_visits(len - 1) + 1 || cnt0 < 0 {
+                self.scan[w.hash0 as usize].count = 0;
+                let sumcnt = core::cmp::min(cnt.abs() + cnt0.abs(), SCNT_MAX);
+                // A negative count marks "this one also has a single child", so
+                // its own child can claim the total later.
+                self.scan[w.hash as usize].count =
+                    if cnt == min_visits(len) + 1 { (-sumcnt) as i16 } else { sumcnt as i16 };
+            }
+        }
+
+        // Walk backwards handing bad children's counters to their parents, and
+        // compact the survivors to the end of the array.
+        let mut kept: Vec<Word> = Vec::new();
+        for i in (0..self.words.len()).rev() {
+            let w = self.words[i];
+            let cnt = (self.scan[w.hash as usize].count as i32).abs();
+            let cnt0 = (self.scan[w.hash0 as usize].count as i32).abs();
+            // GOOD_WORD(cnt,cnt0,len)
+            let good = cnt > min_large
+                || if cnt0 != 0 { cnt > min_medium && cnt > cnt0 * min_ratio } else { cnt > min_small };
+            if good {
+                let mut k = w;
+                k.count = cnt;
+                kept.push(k);
+            } else {
+                self.scan[w.hash0 as usize].count = core::cmp::min(cnt + cnt0, SCNT_MAX) as i16;
+            }
+        }
+        kept.reverse(); // built back-to-front, as the C fills downward from LastWord
+        self.scan = Vec::new(); // FreeAndNil(scan_hash)
+        self.words = kept;
+        if self.words.is_empty() { Err(FREEARC_ERRCODE_GENERAL) } else { Ok(()) }
+    }
+
+    /// phase3: choose which characters can be spent on word codes, and how many
+    /// words get a one-byte code. Returns `nodes`.
+    pub fn phase3(&mut self, min_weak_chars: i32) -> Result<usize, c_int> {
+        // Words by descending frequency. See the note at the top of this file on
+        // why a stable sort is safe here.
+        self.words.sort_by(|a, b| b.count.cmp(&a.count));
+
+        // Characters by ascending frequency.
+        let mut chars: Vec<(u8, i32)> = (0..=UCHAR_MAX).map(|c| (c as u8, self.char_counts[c])).collect();
+        chars.sort_by(|a, b| a.1.cmp(&b.1));
+
+        let mut n = 0usize;
+        while n < self.words.len() && n <= UCHAR_MAX {
+            if chars[n].1 >= self.words[n].count {
+                break;
+            }
+            self.char_counts[chars[n].0 as usize] = 0; // conditionally free
+            n += 1;
+        }
+        if n as i32 <= min_weak_chars {
+            return Err(FREEARC_ERRCODE_GENERAL); // most likely a binary file
+        }
+
+        // The last freed character becomes the prefix for characters whose codes
+        // were given away.
+        n -= 1;
+        let c = chars[n].0;
+        self.char_counts[c as usize] = 1;
+        self.prefix_for_weak_chars = c;
+
+        let avail = n;
+        let word_count = self.words.len();
+        let nodes = if word_count <= avail {
+            core::cmp::min(word_count, avail)
+        } else {
+            core::cmp::max(avail as i64 - ((word_count + 259) / 256) as i64, 0) as usize
+        };
+        Ok(nodes)
+    }
 }

--- a/rust/darc-codecs/src/dict_encode.rs
+++ b/rust/darc-codecs/src/dict_encode.rs
@@ -856,3 +856,53 @@ impl Encoder {
         out
     }
 }
+
+/// Run all seven phases. `Err` means "this block is not worth dict-encoding",
+/// which the caller turns into a stored block, exactly as the C does when
+/// DictEncode returns non-zero.
+#[allow(clippy::too_many_arguments)]
+pub fn encode_block(buf: &[u8], min_weak_chars: i32, min_large: i32, min_medium: i32,
+                    min_small: i32, min_ratio: i32) -> Result<Vec<u8>, c_int> {
+    let mut e = Encoder::new();
+    e.phase1(buf);
+    e.phase2(min_large, min_medium, min_small, min_ratio)?;
+    let nodes = e.phase3(min_weak_chars)?;
+    e.phase4(nodes)?;
+    let mut out = e.phase5()?;
+    e.phase6()?;
+    out.extend_from_slice(&e.phase7());
+    Ok(out)
+}
+
+/// Port of `dict_compress`: block framing around `encode_block`.
+#[allow(clippy::too_many_arguments)]
+pub fn compress(io: &crate::ffi::Io, block_size: u32, min_compression: c_int, min_weak_chars: c_int,
+                min_large: c_int, min_medium: c_int, min_small: c_int, min_ratio: c_int) -> c_int {
+    use crate::ffi::{FREEARC_ERRCODE_IO, OK};
+    let block_size = block_size.max(1) as usize;
+    let mut inbuf = vec![0u8; block_size];
+    loop {
+        let got = io.read(&mut inbuf);
+        if got < 0 { return got; }
+        if got == 0 { return OK; }
+        let in_size = got as usize;
+
+        let encoded = encode_block(&inbuf[..in_size], min_weak_chars, min_large, min_medium, min_small, min_ratio);
+        // The store test is integer arithmetic in the C and is reproduced as
+        // written: OutSize/MinCompression >= InSize/100, truncation included.
+        let store = match &encoded {
+            Err(_) => true,
+            Ok(out) => min_compression > 0 && out.len() / min_compression as usize >= in_size / 100,
+        };
+        if store {
+            if io.write(&(-(in_size as i32)).to_le_bytes()) < 0 || io.write(&inbuf[..in_size]) < 0 {
+                return FREEARC_ERRCODE_IO;
+            }
+        } else {
+            let out = encoded.unwrap();
+            if io.write(&(out.len() as u32).to_le_bytes()) < 0 || io.write(&out) < 0 {
+                return FREEARC_ERRCODE_IO;
+            }
+        }
+    }
+}

--- a/rust/darc-codecs/src/dict_encode.rs
+++ b/rust/darc-codecs/src/dict_encode.rs
@@ -145,7 +145,7 @@ fn search_in_hash(scan: &[Stats], mask: u32, mut hash: u32, phash: u32, c: u8) -
 
 impl Encoder {
     pub fn new() -> Self {
-        Encoder { words: Vec::new(), scan: Vec::new(), mask: 0, max_words: 0,
+        Encoder { text: Vec::new(), hashmask: 0, hashbits: Vec::new(), codewords: Vec::new(), words: Vec::new(), scan: Vec::new(), mask: 0, max_words: 0,
                   char_counts: [0; 256], prefix_for_weak_chars: 0 }
     }
     pub fn prefix(&self) -> u8 { self.prefix_for_weak_chars }
@@ -156,6 +156,16 @@ impl Encoder {
         out.push_str(&format!("words {}\n", self.words.len()));
         for w in &self.words {
             out.push_str(&format!("W {} {} {}\n", w.at, w.len, w.count));
+        }
+        out
+    }
+
+    /// Words after phase4, matching "W <at> <len> <count> <chr> <chr2>".
+    pub fn dump_coded_words(&self) -> String {
+        let mut out = String::new();
+        out.push_str(&format!("words {}\n", self.words.len()));
+        for w in &self.words {
+            out.push_str(&format!("W {} {} {} {} {}\n", w.at, w.len, w.count, w.chr, w.chr2));
         }
         out
     }
@@ -188,6 +198,11 @@ impl Default for Encoder {
 }
 
 pub struct Encoder {
+    /// Copy of the block being encoded; words are (offset, len) into it.
+    text: Vec<u8>,
+    hashmask: u32,
+    hashbits: Vec<u16>,
+    codewords: Vec<CodeWord>,
     words: Vec<Word>,
     scan: Vec<Stats>,
     mask: u32,
@@ -212,6 +227,7 @@ impl Encoder {
 
     /// phase1: build the word list and count byte frequencies.
     pub fn phase1(&mut self, buf: &[u8]) {
+        self.text = buf.to_vec();
         let bufsize = buf.len();
         let max_words = roundup_to_power_of_2(core::cmp::max(bufsize as u32 / 32, 32768)) as usize;
         self.max_words = max_words;
@@ -506,5 +522,337 @@ impl Encoder {
             core::cmp::max(avail as i64 - ((word_count + 259) / 256) as i64, 0) as usize
         };
         Ok(nodes)
+    }
+}
+
+impl Encoder {
+    /// phase4: hand out one- and two-byte codes.
+    pub fn phase4(&mut self, nodes: usize) -> Result<(), c_int> {
+        // One-byte and two-byte groups are sorted lexicographically separately,
+        // which compresses the dictionary itself better.
+        let n = self.words.len();
+        let split = core::cmp::min(nodes, n);
+        let key = |w: &Word, buf: &[u8]| (buf[w.at..w.at + w.len as usize].to_vec(), w.len, w.at);
+        let buf = self.text.clone();
+        self.words[..split].sort_by_key(|w| key(w, &buf));
+        self.words[split..].sort_by_key(|w| key(w, &buf));
+
+        let mut p = 0usize;              // next word awaiting a code
+        let two_byte_start = split;
+
+        // One-byte codes for the most useful words.
+        let mut c = 0usize;
+        while c <= UCHAR_MAX && p < two_byte_start {
+            if self.char_counts[c] == 0 && c as u8 != RESERVED_CHAR {
+                self.words[p].chr = c as u8;
+                self.words[p].chr2 = RESERVED_CHAR;
+                p += 1;
+            }
+            c += 1;
+        }
+
+        // Two-byte codes for the rest.
+        while c <= UCHAR_MAX && p < self.words.len() {
+            if self.char_counts[c] != 0 || c as u8 == RESERVED_CHAR {
+                c += 1;
+                continue;
+            }
+            let mut c2 = 0usize;
+            while c2 <= UCHAR_MAX && p < self.words.len() {
+                if c2 as u8 == RESERVED_CHAR {
+                    c2 += 1;
+                    continue;
+                }
+                // GOOD_2BYTE_WORD(len,cnt) is (len>=4): shorter words are not
+                // worth two bytes, so they are dropped by zeroing their count.
+                while p < self.words.len() && self.words[p].len < 4 {
+                    self.words[p].count = 0;
+                    p += 1;
+                }
+                if p < self.words.len() {
+                    self.words[p].chr = c as u8;
+                    self.words[p].chr2 = c2 as u8;
+                    p += 1;
+                }
+                c2 += 1;
+            }
+            c += 1;
+        }
+        self.words.truncate(p);
+
+        // Any remaining free characters go to words that turned down a two-byte
+        // code above.
+        let mut q = two_byte_start;
+        while c <= UCHAR_MAX && q < self.words.len() {
+            if self.char_counts[c] == 0 && c as u8 != RESERVED_CHAR {
+                self.words[q].chr = c as u8;
+                self.words[q].chr2 = RESERVED_CHAR;
+                q += 1;
+            }
+            c += 1;
+        }
+
+        // Drop the words that never got a code: sort by descending count and
+        // cut at the first zero.
+        self.words.sort_by(|a, b| b.count.cmp(&a.count).then(a.at.cmp(&b.at)));
+        let keep = self.words.iter().position(|w| w.count == 0).unwrap_or(self.words.len());
+        self.words.truncate(keep);
+        Ok(())
+    }
+}
+
+impl Encoder {
+    /// phase5: serialise the dictionary. This is the exact format `dict::decode`
+    /// reads, which is a useful cross-check: the decoder was ported first and
+    /// independently.
+    pub fn phase5(&mut self) -> Result<Vec<u8>, c_int> {
+        const N: usize = UCHAR_MAX + 1;
+        // dict[i]: Some(word index) for a one-byte code, None for unused.
+        let mut dict: Vec<Option<usize>> = vec![None; N];
+        let mut dict_is_two: Vec<bool> = vec![false; N];
+        let mut dict2: Vec<Option<usize>> = vec![None; N * N];
+        let mut char_in_use = [false; N];
+
+        for (i, w) in self.words.iter().enumerate() {
+            if w.chr2 == RESERVED_CHAR {
+                dict[w.chr as usize] = Some(i);
+            } else {
+                dict2[w.chr as usize * N + w.chr2 as usize] = Some(i);
+                dict_is_two[w.chr as usize] = true;
+                for k in 0..w.len as usize {
+                    char_in_use[self.text[w.at + k] as usize] = true;
+                }
+            }
+        }
+
+        // Separator: the highest character that appears in no two-byte word.
+        let mut word_sep = None;
+        for c in (0..N).rev() {
+            if !char_in_use[c] {
+                word_sep = Some(c as u8);
+                break;
+            }
+        }
+        // Every character consumed by words leaves no separator available, and
+        // the dictionary cannot be expressed.
+        let word_sep = word_sep.ok_or(FREEARC_ERRCODE_GENERAL)?;
+
+        let mut out: Vec<u8> = Vec::new();
+        let len_of = |i: usize, dict: &Vec<Option<usize>>, two: &Vec<bool>, me: &Encoder| -> u8 {
+            if two[i] { USE_DICT2 as u8 } else { dict[i].map(|k| me.words[k].len as u8).unwrap_or(0) }
+        };
+
+        // 1. lengths of the one-byte-coded words
+        for i in 0..N {
+            out.push(len_of(i, &dict, &dict_is_two, self));
+        }
+        // 2. common-prefix lengths of the two-byte-coded words
+        let mut prev: Option<usize> = None;
+        for i in 0..N {
+            if dict_is_two[i] {
+                for j in 0..N {
+                    let cur = dict2[i * N + j];
+                    let n = match (cur, prev) {
+                        (Some(a), Some(b)) => self.common_prefix_length(a, b),
+                        _ => 0,
+                    };
+                    out.push(n as u8);
+                    prev = cur;
+                }
+            }
+        }
+        // 3. text of the one-byte words
+        for i in 0..N {
+            if dict_is_two[i] {
+                continue;
+            }
+            if let Some(k) = dict[i] {
+                let w = self.words[k];
+                out.extend_from_slice(&self.text[w.at..w.at + w.len as usize]);
+            }
+        }
+        // 4. separator, then the two-byte words minus their shared prefix
+        prev = None;
+        out.push(word_sep);
+        for i in 0..N {
+            if dict_is_two[i] {
+                for j in 0..N {
+                    let cur = dict2[i * N + j];
+                    let n = match (cur, prev) {
+                        (Some(a), Some(b)) => self.common_prefix_length(a, b),
+                        _ => 0,
+                    };
+                    if let Some(k) = cur {
+                        let w = self.words[k];
+                        out.extend_from_slice(&self.text[w.at + n..w.at + w.len as usize]);
+                    }
+                    out.push(word_sep);
+                    prev = cur;
+                }
+            }
+        }
+        // 5. the prefix used for characters that gave their code to a word
+        out.push(self.prefix_for_weak_chars);
+        Ok(out)
+    }
+
+    fn common_prefix_length(&self, a: usize, b: usize) -> usize {
+        let wa = self.words[a];
+        let wb = self.words[b];
+        let n = core::cmp::min(wa.len, wb.len) as usize;
+        let mut i = 0;
+        while i < n && self.text[wa.at + i] == self.text[wb.at + i] {
+            i += 1;
+        }
+        i
+    }
+}
+
+/// One entry of the encoding hash built by phase6.
+#[derive(Clone, Default)]
+struct CodeWord {
+    text: Vec<u8>,
+    len: u8,
+    chr: u8,
+    chr2: u8,
+}
+
+impl Encoder {
+    /// phase6: build the hash used to find the longest dictionary word at a
+    /// position. FindWord in phase7 must reproduce this hashing exactly or words
+    /// simply stop being found -- the C says as much in a comment.
+    pub fn phase6(&mut self) -> Result<(), c_int> {
+        let buf = self.text.clone();
+        let key = |w: &Word| (buf[w.at..w.at + w.len as usize].to_vec(), w.len, w.at);
+        self.words.sort_by_key(key);
+
+        // Hash size is driven by the number of distinct bytes across the words.
+        let mut unique_bytes: u32 = 0;
+        for i in 0..self.words.len() {
+            let cp = if i == 0 { 0 } else { self.common_prefix_length(i, i - 1) };
+            unique_bytes += self.words[i].len - cp as u32;
+        }
+        let hashsize = roundup_to_power_of_2(unique_bytes.saturating_mul(4)).max(1) as usize;
+        self.hashmask = (hashsize - 1) as u32;
+        self.hashbits = vec![0u16; hashsize];
+        self.codewords = vec![CodeWord::default(); hashsize];
+
+        for wi in 0..self.words.len() {
+            let w = self.words[wi];
+            let mut hash = hashsize as u32 + self.text[w.at] as u32;
+            let mut longest: Option<CodeWord> = None;
+            let mut abandoned = false;
+            for i in 1..w.len as usize {
+                let c = self.text[w.at + i];
+                let hash0 = hash;
+                hash = update_hash(hash, c);
+                let mut n = 13;
+                while self.hashbits[(hash & self.hashmask) as usize] != 0
+                    && self.hashbits[(hash & self.hashmask) as usize] != hash0 as u16
+                {
+                    n -= 1;
+                    if n == 0 {
+                        abandoned = true;
+                        break;
+                    }
+                    hash = rehash(hash, c);
+                }
+                if abandoned {
+                    break;
+                }
+                self.hashbits[(hash & self.hashmask) as usize] = hash0 as u16;
+
+                // Carry the longest prefix word along the chain, so a lookup that
+                // stops here still yields the best encodable word.
+                let idx = (hash & self.hashmask) as usize;
+                if self.codewords[idx].len != 0 {
+                    longest = Some(self.codewords[idx].clone());
+                } else if let Some(l) = &longest {
+                    self.codewords[idx] = l.clone();
+                }
+            }
+            if abandoned {
+                continue;
+            }
+            let idx = (hash & self.hashmask) as usize;
+            self.codewords[idx] = CodeWord {
+                text: self.text[w.at..w.at + w.len as usize].to_vec(),
+                len: w.len as u8,
+                chr: w.chr,
+                chr2: w.chr2,
+            };
+        }
+        Ok(())
+    }
+
+    /// Port of `FindWord`: longest dictionary word starting at `p0`.
+    fn find_word(&self, p0: usize, endbuf: usize) -> Option<&CodeWord> {
+        if p0 >= endbuf {
+            return None;
+        }
+        let mut p = p0;
+        let mut hash0 = self.hashbits.len() as u32 + self.text[p] as u32;
+        p += 1;
+        while p < endbuf {
+            let c = self.text[p];
+            p += 1;
+            let mut hash = update_hash(hash0, c);
+            let mut n = 13;
+            let mut found = false;
+            loop {
+                let h = self.hashbits[(hash & self.hashmask) as usize];
+                if h == 0 {
+                    break;
+                }
+                if h == hash0 as u16 {
+                    found = true;
+                    break;
+                }
+                hash = rehash(hash, c);
+                n -= 1;
+                if n == 0 {
+                    break;
+                }
+            }
+            if !found {
+                break;
+            }
+            hash0 = hash;
+        }
+        p -= 1;
+        let word = &self.codewords[(hash0 & self.hashmask) as usize];
+        let len = word.len as usize;
+        if len == 0 || len > endbuf - p {
+            return None;
+        }
+        if self.text[p0..p0 + len] != word.text[..len] {
+            return None;
+        }
+        Some(word)
+    }
+
+    /// phase7: encode the text with the dictionary.
+    pub fn phase7(&self) -> Vec<u8> {
+        let endbuf = self.text.len();
+        let mut out: Vec<u8> = Vec::new();
+        let mut p = 0usize;
+        while p < endbuf {
+            if let Some(w) = self.find_word(p, endbuf) {
+                out.push(w.chr);
+                if w.chr2 != RESERVED_CHAR {
+                    out.push(w.chr2);
+                }
+                p += w.len as usize;
+            } else {
+                let c = self.text[p];
+                p += 1;
+                // A character whose code was given away must be escaped.
+                if self.char_counts[c as usize] == 0 || c == self.prefix_for_weak_chars {
+                    out.push(self.prefix_for_weak_chars);
+                }
+                out.push(c);
+            }
+        }
+        out
     }
 }

--- a/rust/darc-codecs/src/exports.rs
+++ b/rust/darc-codecs/src/exports.rs
@@ -1,0 +1,31 @@
+//! C entry points.
+//!
+//! These carry the same names and signatures as the C originals so a codec can
+//! be swapped in at link time. Note the C declarations in Delta.cpp have C++
+//! linkage -- there is no `extern "C"` anywhere in that file -- so C_Delta.cpp
+//! currently links against a mangled symbol and will NOT pick these up. Adding
+//! `extern "C"` to the declarations in C_Delta.h (a linkage-only change) is
+//! what wires them together; until then these are exercised by the differential
+//! harness rather than by the archiver.
+
+use crate::delta;
+use crate::ffi::{Io, CALLBACK_FUNC, FREEARC_ERRCODE_GENERAL};
+use core::ffi::{c_int, c_void};
+
+/// # Safety
+/// `callback` and `auxdata` must be what the C caller supplied.
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_delta_decompress(
+    block_size: u32,
+    extended_tables: c_int,
+    callback: CALLBACK_FUNC,
+    auxdata: *mut c_void,
+) -> c_int {
+    // A null callback is representable in the ABI; calling through it would be
+    // undefined behaviour. bindgen types this as Option<fn> precisely so the
+    // case has to be handled.
+    match Io::new(callback, auxdata) {
+        Some(io) => delta::decompress(&io, block_size, extended_tables),
+        None => FREEARC_ERRCODE_GENERAL,
+    }
+}

--- a/rust/darc-codecs/src/exports.rs
+++ b/rust/darc-codecs/src/exports.rs
@@ -8,7 +8,7 @@
 //! what wires them together; until then these are exercised by the differential
 //! harness rather than by the archiver.
 
-use crate::{delta, dict, lzp};
+use crate::{delta, dict, dict_encode, lzp};
 use crate::ffi::{Io, CALLBACK_FUNC, FREEARC_ERRCODE_GENERAL};
 use core::ffi::{c_int, c_void};
 
@@ -185,4 +185,32 @@ pub unsafe extern "C" fn lzp_decompress(
     callback: CALLBACK_FUNC, auxdata: *mut c_void,
 ) -> c_int {
     darc_rs_lzp_decompress(block_size, a, b, c, d, e, callback, auxdata)
+}
+
+/// # Safety
+/// `callback` and `auxdata` must be what the C caller supplied.
+#[no_mangle]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn darc_rs_dict_compress(
+    block_size: u32, min_compression: c_int, min_weak_chars: c_int, min_large: c_int,
+    min_medium: c_int, min_small: c_int, min_ratio: c_int,
+    callback: CALLBACK_FUNC, auxdata: *mut c_void,
+) -> c_int {
+    match Io::new(callback, auxdata) {
+        Some(io) => dict_encode::compress(&io, block_size, min_compression, min_weak_chars,
+                                          min_large, min_medium, min_small, min_ratio),
+        None => FREEARC_ERRCODE_GENERAL,
+    }
+}
+
+/// # Safety
+/// `callback` and `auxdata` must be what the C caller supplied.
+#[cfg(feature = "dropin")]
+#[no_mangle]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn dict_compress(
+    block_size: u32, a: c_int, b: c_int, c: c_int, d: c_int, e: c_int, f: c_int,
+    callback: CALLBACK_FUNC, auxdata: *mut c_void,
+) -> c_int {
+    darc_rs_dict_compress(block_size, a, b, c, d, e, f, callback, auxdata)
 }

--- a/rust/darc-codecs/src/exports.rs
+++ b/rust/darc-codecs/src/exports.rs
@@ -159,3 +159,30 @@ pub unsafe extern "C" fn darc_rs_lzp_compress(
         None => FREEARC_ERRCODE_GENERAL,
     }
 }
+
+/// Drop-in under the archiver's own symbol names; see the note above on why the
+/// switch is an exclusion in C_LZP.cpp rather than a redeclaration.
+///
+/// # Safety
+/// `callback` and `auxdata` must be what the C caller supplied.
+#[cfg(feature = "dropin")]
+#[no_mangle]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn lzp_compress(
+    block_size: u32, a: c_int, b: c_int, c: c_int, d: c_int, e: c_int,
+    callback: CALLBACK_FUNC, auxdata: *mut c_void,
+) -> c_int {
+    darc_rs_lzp_compress(block_size, a, b, c, d, e, callback, auxdata)
+}
+
+/// # Safety
+/// `callback` and `auxdata` must be what the C caller supplied.
+#[cfg(feature = "dropin")]
+#[no_mangle]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn lzp_decompress(
+    block_size: u32, a: c_int, b: c_int, c: c_int, d: c_int, e: c_int,
+    callback: CALLBACK_FUNC, auxdata: *mut c_void,
+) -> c_int {
+    darc_rs_lzp_decompress(block_size, a, b, c, d, e, callback, auxdata)
+}

--- a/rust/darc-codecs/src/exports.rs
+++ b/rust/darc-codecs/src/exports.rs
@@ -139,3 +139,23 @@ pub unsafe extern "C" fn darc_rs_lzp_decompress(
         None => FREEARC_ERRCODE_GENERAL,
     }
 }
+
+/// # Safety
+/// `callback` and `auxdata` must be what the C caller supplied.
+#[no_mangle]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn darc_rs_lzp_compress(
+    block_size: u32,
+    min_compression: c_int,
+    min_match_len: c_int,
+    hash_size_log: c_int,
+    barrier: c_int,
+    smallest_len: c_int,
+    callback: CALLBACK_FUNC,
+    auxdata: *mut c_void,
+) -> c_int {
+    match Io::new(callback, auxdata) {
+        Some(io) => lzp::compress(&io, block_size, min_compression, min_match_len, hash_size_log, barrier, smallest_len),
+        None => FREEARC_ERRCODE_GENERAL,
+    }
+}

--- a/rust/darc-codecs/src/exports.rs
+++ b/rust/darc-codecs/src/exports.rs
@@ -44,3 +44,38 @@ pub unsafe extern "C" fn darc_rs_delta_decompress(
         None => FREEARC_ERRCODE_GENERAL,
     }
 }
+
+// ---------------------------------------------------------------------------
+// Drop-in replacements under the archiver's own symbol names.
+//
+// Delta.cpp defines delta_compress/delta_decompress with C++ linkage, so these
+// C-linkage symbols do not collide with it: they are distinct names as far as
+// the linker is concerned. Which one the archiver calls is decided entirely by
+// how C_Delta.h declares them -- `extern "C"` picks these, the default picks
+// the C++ originals. That is what makes the swap reversible with a build flag
+// rather than a source deletion.
+// ---------------------------------------------------------------------------
+
+/// # Safety
+/// `callback` and `auxdata` must be what the C caller supplied.
+#[no_mangle]
+pub unsafe extern "C" fn delta_compress(
+    block_size: u32,
+    extended_tables: c_int,
+    callback: CALLBACK_FUNC,
+    auxdata: *mut c_void,
+) -> c_int {
+    darc_rs_delta_compress(block_size, extended_tables, callback, auxdata)
+}
+
+/// # Safety
+/// `callback` and `auxdata` must be what the C caller supplied.
+#[no_mangle]
+pub unsafe extern "C" fn delta_decompress(
+    block_size: u32,
+    extended_tables: c_int,
+    callback: CALLBACK_FUNC,
+    auxdata: *mut c_void,
+) -> c_int {
+    darc_rs_delta_decompress(block_size, extended_tables, callback, auxdata)
+}

--- a/rust/darc-codecs/src/exports.rs
+++ b/rust/darc-codecs/src/exports.rs
@@ -15,6 +15,21 @@ use core::ffi::{c_int, c_void};
 /// # Safety
 /// `callback` and `auxdata` must be what the C caller supplied.
 #[no_mangle]
+pub unsafe extern "C" fn darc_rs_delta_compress(
+    block_size: u32,
+    extended_tables: c_int,
+    callback: CALLBACK_FUNC,
+    auxdata: *mut c_void,
+) -> c_int {
+    match Io::new(callback, auxdata) {
+        Some(io) => delta::compress(&io, block_size, extended_tables),
+        None => FREEARC_ERRCODE_GENERAL,
+    }
+}
+
+/// # Safety
+/// `callback` and `auxdata` must be what the C caller supplied.
+#[no_mangle]
 pub unsafe extern "C" fn darc_rs_delta_decompress(
     block_size: u32,
     extended_tables: c_int,

--- a/rust/darc-codecs/src/exports.rs
+++ b/rust/darc-codecs/src/exports.rs
@@ -8,7 +8,7 @@
 //! what wires them together; until then these are exercised by the differential
 //! harness rather than by the archiver.
 
-use crate::delta;
+use crate::{delta, dict};
 use crate::ffi::{Io, CALLBACK_FUNC, FREEARC_ERRCODE_GENERAL};
 use core::ffi::{c_int, c_void};
 
@@ -58,6 +58,7 @@ pub unsafe extern "C" fn darc_rs_delta_decompress(
 
 /// # Safety
 /// `callback` and `auxdata` must be what the C caller supplied.
+#[cfg(feature = "dropin")]
 #[no_mangle]
 pub unsafe extern "C" fn delta_compress(
     block_size: u32,
@@ -70,6 +71,7 @@ pub unsafe extern "C" fn delta_compress(
 
 /// # Safety
 /// `callback` and `auxdata` must be what the C caller supplied.
+#[cfg(feature = "dropin")]
 #[no_mangle]
 pub unsafe extern "C" fn delta_decompress(
     block_size: u32,
@@ -78,4 +80,42 @@ pub unsafe extern "C" fn delta_decompress(
     auxdata: *mut c_void,
 ) -> c_int {
     darc_rs_delta_decompress(block_size, extended_tables, callback, auxdata)
+}
+
+/// # Safety
+/// `callback` and `auxdata` must be what the C caller supplied.
+#[no_mangle]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn darc_rs_dict_decompress(
+    block_size: u32,
+    _min_compression: c_int,
+    _min_weak_chars: c_int,
+    _min_large_cnt: c_int,
+    _min_medium_cnt: c_int,
+    _min_small_cnt: c_int,
+    _min_ratio: c_int,
+    callback: CALLBACK_FUNC,
+    auxdata: *mut c_void,
+) -> c_int {
+    match Io::new(callback, auxdata) {
+        Some(io) => dict::decompress(&io, block_size),
+        None => FREEARC_ERRCODE_GENERAL,
+    }
+}
+
+/// Drop-in under the archiver's own symbol name; see the note above on why the
+/// switch is an exclusion in C_Dict.cpp rather than a redeclaration.
+///
+/// # Safety
+/// `callback` and `auxdata` must be what the C caller supplied.
+#[cfg(feature = "dropin")]
+#[no_mangle]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn dict_decompress(
+    block_size: u32,
+    a: c_int, b: c_int, c: c_int, d: c_int, e: c_int, f: c_int,
+    callback: CALLBACK_FUNC,
+    auxdata: *mut c_void,
+) -> c_int {
+    darc_rs_dict_decompress(block_size, a, b, c, d, e, f, callback, auxdata)
 }

--- a/rust/darc-codecs/src/exports.rs
+++ b/rust/darc-codecs/src/exports.rs
@@ -8,7 +8,7 @@
 //! what wires them together; until then these are exercised by the differential
 //! harness rather than by the archiver.
 
-use crate::{delta, dict};
+use crate::{delta, dict, lzp};
 use crate::ffi::{Io, CALLBACK_FUNC, FREEARC_ERRCODE_GENERAL};
 use core::ffi::{c_int, c_void};
 
@@ -118,4 +118,24 @@ pub unsafe extern "C" fn dict_decompress(
     auxdata: *mut c_void,
 ) -> c_int {
     darc_rs_dict_decompress(block_size, a, b, c, d, e, f, callback, auxdata)
+}
+
+/// # Safety
+/// `callback` and `auxdata` must be what the C caller supplied.
+#[no_mangle]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn darc_rs_lzp_decompress(
+    block_size: u32,
+    _min_compression: c_int,
+    min_match_len: c_int,
+    hash_size_log: c_int,
+    barrier: c_int,
+    smallest_len: c_int,
+    callback: CALLBACK_FUNC,
+    auxdata: *mut c_void,
+) -> c_int {
+    match Io::new(callback, auxdata) {
+        Some(io) => lzp::decompress(&io, block_size, min_match_len, hash_size_log, barrier, smallest_len),
+        None => FREEARC_ERRCODE_GENERAL,
+    }
 }

--- a/rust/darc-codecs/src/ffi.rs
+++ b/rust/darc-codecs/src/ffi.rs
@@ -1,54 +1,55 @@
-//! The C ABI boundary.
+//! The C ABI boundary, generated from DArc's own headers.
 //!
-//! This is the one part of a Rust port that the compiler does NOT make safe.
-//! Rust checks these declarations against nothing: if the signature here
-//! disagrees with the C caller, it miscompiles exactly as C would. DArc has
-//! already been bitten by this twice on the C side -- 41 helpers with no
-//! `extern "C"` declaration, 8 of which returned `long` and were truncated to
-//! `int` at every call site.
+//! This is the one part of a Rust port the compiler does NOT make safe on its
+//! own: an `extern "C"` declaration is checked against nothing, so a wrong
+//! signature miscompiles exactly as it would in C. This codebase has already
+//! been bitten by that -- 41 helpers whose declarations were missing entirely,
+//! 8 of them truncating a `long` return to `int` at every call site.
 //!
-//! So the types below are transcribed deliberately, not guessed:
+//! So the declarations are not written here at all. build.rs runs bindgen over
+//! Compression/Common.h and Compression/Compression.h -- the same headers the C
+//! side compiles against -- and the result is included below. Hand-transcribing
+//! worked, but only until a header changes and nobody re-transcribes.
 //!
-//!   Compression/Common.h:93       typedef unsigned MemSize;
-//!   Compression/Compression.h:62  typedef int CALLBACK_FUNC
-//!                                     (const char *what, void *data,
-//!                                      int size, void *auxdata);
-//!
-//! `overflow-checks = true` is set even for release builds in Cargo.toml.
-//! Release Rust wraps on overflow by default, which would silently reproduce
-//! the class of bug found in `filenameHash` and in GRZip's hash table rather
-//! than trapping on it. Codec work is not hot enough for the check to matter.
+//! Generating them paid for itself immediately: the hand-written version
+//! declared the callback as a plain `fn` pointer, while bindgen types it as
+//! `Option<fn>`, because C permits a null function pointer there -- and
+//! C_Delta.cpp does check for one. That null case is handled in `Io::new`
+//! rather than being undefined behaviour.
 
-use core::ffi::{c_char, c_int, c_uint, c_void};
+#![allow(non_camel_case_types, non_upper_case_globals, dead_code)]
 
-/// Matches `CALLBACK_FUNC` exactly.
-pub type CallbackFunc =
-    unsafe extern "C" fn(*const c_char, *mut c_void, c_int, *mut c_void) -> c_int;
+use core::ffi::{c_char, c_int, c_void};
 
-/// Matches `MemSize`.
-pub type MemSize = c_uint;
+include!(concat!(env!("OUT_DIR"), "/darc_abi.rs"));
 
-/// Error codes from Compression/Compression.h.
-pub const FREEARC_OK: c_int = 0;
-pub const FREEARC_ERRCODE_GENERAL: c_int = -1;
-pub const FREEARC_ERRCODE_IO: c_int = -6;
+/// `FREEARC_OK` arrives from bindgen as `u32` while every error code is `i32`,
+/// a consequence of how the macros are written C-side. Codec entry points
+/// return `c_int`, so expose it at the type actually used instead of casting at
+/// every comparison.
+pub const OK: c_int = FREEARC_OK as c_int;
 
-/// Safe-ish wrapper over the read/write callback protocol.
+/// Safe wrapper over the read/write callback protocol.
 ///
-/// The C side drives compression by calling back for input and output:
+/// The C side drives a codec by calling back for input and output:
 ///   callback("read",  buf, len, aux) -> bytes actually read
 ///   callback("write", buf, len, aux) -> bytes actually written
+/// See the `checked_read` / `checked_write` macros at Compression.h:65-66.
 pub struct Io {
-    callback: CallbackFunc,
+    callback: unsafe extern "C" fn(*const c_char, *mut c_void, c_int, *mut c_void) -> c_int,
     auxdata: *mut c_void,
 }
 
 impl Io {
+    /// Returns `None` when the C caller passed a null callback, which the ABI
+    /// permits. Calling through it would be undefined behaviour, so codec entry
+    /// points turn this into `FREEARC_ERRCODE_GENERAL` instead.
+    ///
     /// # Safety
-    /// `callback` and `auxdata` must be exactly what the C caller passed in,
-    /// and must stay valid for the lifetime of this `Io`.
-    pub unsafe fn new(callback: CallbackFunc, auxdata: *mut c_void) -> Self {
-        Io { callback, auxdata }
+    /// `callback` and `auxdata` must be exactly what the C caller supplied, and
+    /// must remain valid for the lifetime of this `Io`.
+    pub unsafe fn new(callback: CALLBACK_FUNC, auxdata: *mut c_void) -> Option<Self> {
+        callback.map(|callback| Io { callback, auxdata })
     }
 
     fn call(&self, what: &[u8], buf: *mut c_void, size: c_int) -> c_int {
@@ -70,29 +71,26 @@ impl Io {
             return 0;
         }
         // The callback takes a non-const pointer even for "write"; the C code
-        // does the same cast.
+        // casts the same way.
         self.call(b"write\0", buf.as_ptr() as *mut c_void, clamp_len(buf.len()))
     }
 
-    /// Write the whole buffer, mapping a short write to an IO error the way
-    /// `checked_write` does in Compression/Compression.h.
+    /// Write the whole buffer, mapping a short write to an IO error exactly as
+    /// `checked_write` does in Compression.h.
     pub fn write_all(&self, buf: &[u8]) -> Result<(), c_int> {
         let want = clamp_len(buf.len());
-        let got = self.write(buf);
-        if got == want {
-            Ok(())
-        } else if got >= 0 {
-            Err(FREEARC_ERRCODE_IO)
-        } else {
-            Err(got)
+        match self.write(buf) {
+            got if got == want => Ok(()),
+            got if got >= 0 => Err(FREEARC_ERRCODE_IO),
+            got => Err(got),
         }
     }
 }
 
-/// The callback takes an `int` length. Anything above `c_int::MAX` cannot be
-/// expressed, and silently truncating is how a 16 GB value became 0 in
-/// `GetPhysicalMemory`. Callers never pass buffers that large, so clamp
-/// explicitly and make the boundary visible rather than casting with `as`.
+/// The callback takes an `int` length; anything past `c_int::MAX` cannot be
+/// expressed. Rust's `as` truncates every bit as silently as C's implicit
+/// conversion -- that is how 16 GB became 0 in GetPhysicalMemory -- so the one
+/// place a length crosses into an `int` is explicit and asserts in debug.
 fn clamp_len(n: usize) -> c_int {
     debug_assert!(n <= c_int::MAX as usize, "buffer longer than c_int can express");
     core::cmp::min(n, c_int::MAX as usize) as c_int

--- a/rust/darc-codecs/src/lib.rs
+++ b/rust/darc-codecs/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod delta;
 pub mod dict;
+pub mod lzp;
 pub mod ffi;
 
 mod exports;

--- a/rust/darc-codecs/src/lib.rs
+++ b/rust/darc-codecs/src/lib.rs
@@ -8,6 +8,7 @@
 //! which is the highest-risk failure mode in this repository.
 
 pub mod delta;
+pub mod dict;
 pub mod ffi;
 
 mod exports;

--- a/rust/darc-codecs/src/lib.rs
+++ b/rust/darc-codecs/src/lib.rs
@@ -7,4 +7,7 @@
 //! "correctly" but differently produces archives older builds cannot read,
 //! which is the highest-risk failure mode in this repository.
 
+pub mod delta;
 pub mod ffi;
+
+mod exports;

--- a/rust/darc-codecs/src/lib.rs
+++ b/rust/darc-codecs/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod delta;
 pub mod dict;
+pub mod dict_encode;
 pub mod lzp;
 pub mod ffi;
 

--- a/rust/darc-codecs/src/lzp.rs
+++ b/rust/darc-codecs/src/lzp.rs
@@ -75,9 +75,22 @@ pub fn encode(input: &[u8], out: &mut [u8], min_len: i32, hash_size: usize, barr
             n = n1;
         }
 
+        // Two distinct literal paths, and the difference is load-bearing.
+        //
+        // When the context hash does not match (`hash_miss`), the byte is
+        // emitted raw even if it happens to equal LZP_MATCH_FLAG: the decoder
+        // reaches the same state, sees i != lzpC(p), and short-circuits before
+        // touching the backward stream, so no escape is needed.
+        //
+        // When the hash matched but no usable match was found, an emitted
+        // 0xB5 is ambiguous and must be escaped with a 255 in the backward
+        // stream. Merging the two paths and escaping in both writes one
+        // spurious backward byte -- which is exactly what this port did, and
+        // it showed up only as a one-byte difference on one input.
+        let mut hash_miss = false;
         let mut literal = false;
         if i != lzp_c(input, p) {
-            literal = true;
+            hash_miss = true;
         } else {
             let ml = if (inp - p) as i32 > barrier { smallest_len } else { min_len } as usize;
             if inp + ml <= size && lzp_c(input, p + ml) == lzp_c(input, inp + ml) {
@@ -136,7 +149,7 @@ pub fn encode(input: &[u8], out: &mut [u8], min_len: i32, hash_size: usize, barr
             }
         }
 
-        if literal {
+        if hash_miss || literal {
             if outp >= out_end {
                 return 0;
             }
@@ -144,7 +157,8 @@ pub fn encode(input: &[u8], out: &mut [u8], min_len: i32, hash_size: usize, barr
             out[outp] = c;
             outp += 1;
             inp += 1;
-            if c == LZP_MATCH_FLAG {
+            // Escape only on the MATCH_NOT_FOUND path; see above.
+            if literal && c == LZP_MATCH_FLAG {
                 if out_end == 0 {
                     return 0;
                 }
@@ -278,6 +292,42 @@ pub fn decompress(io: &Io, block_size: u32, min_len: c_int, hash_size_log: c_int
                 }
             }
             Err(e) => return e,
+        }
+    }
+}
+
+/// Port of `lzp_compress`: block framing around `encode`.
+///
+/// A block that does not compress well enough is stored instead, flagged by a
+/// negative length. The threshold test is `OutSize/MinCompression >= InSize/100`
+/// in integer arithmetic, and it is reproduced exactly rather than rewritten as
+/// a percentage -- the truncation is part of which blocks get stored.
+#[allow(clippy::too_many_arguments)]
+pub fn compress(io: &Io, block_size: u32, min_compression: c_int, min_len: c_int,
+                hash_size_log: c_int, barrier: c_int, smallest_len: c_int) -> c_int {
+    let block_size = block_size.max(1) as usize;
+    let hash_size = 1usize << hash_size_log.max(1);
+    let mut inbuf = vec![0u8; block_size];
+    loop {
+        let got = io.read(&mut inbuf);
+        if got < 0 {
+            return got;
+        }
+        if got == 0 {
+            return OK;
+        }
+        let in_size = got as usize;
+        let mut out = vec![0u8; in_size + 2];
+        let out_size = encode(&inbuf[..in_size], &mut out, min_len, hash_size, barrier, smallest_len);
+
+        let store = out_size == 0
+            || (min_compression > 0 && out_size / min_compression as usize >= in_size / 100);
+        if store {
+            if io.write(&(-(in_size as i32)).to_le_bytes()) < 0 || io.write(&inbuf[..in_size]) < 0 {
+                return FREEARC_ERRCODE_IO;
+            }
+        } else if io.write(&(out_size as u32).to_le_bytes()) < 0 || io.write(&out[..out_size]) < 0 {
+            return FREEARC_ERRCODE_IO;
         }
     }
 }

--- a/rust/darc-codecs/src/lzp.rs
+++ b/rust/darc-codecs/src/lzp.rs
@@ -1,0 +1,283 @@
+//! LZP: match-flag preprocessor, ported from Compression/LZP/C_LZP.cpp.
+//!
+//! LZP predicts the next bytes from a hash of recent context. When the
+//! prediction is right it emits a flag byte and a length instead of the bytes
+//! themselves. Its output feeds a later codec in the chain.
+//!
+//! Two things about the original shape this port has to preserve exactly:
+//!
+//!   * `lzpC(p)` reads the four bytes *before* p (`*(UINT*)(p-4)`), and the
+//!     hash reads four bytes before that again. Every index below is offset
+//!     accordingly rather than "fixed" to read forwards.
+//!   * The encoder writes **two streams into one buffer**: literals forward
+//!     from the start, match lengths backward from the end, meeting in the
+//!     middle. Compression fails (returns 0) exactly when they meet.
+//!
+//! The hash table holds positions into the input (encoding) or the output
+//! (decoding); the C version stores raw pointers, which is the same thing.
+
+use crate::ffi::{Io, FREEARC_ERRCODE_IO, OK};
+use core::ffi::c_int;
+
+const LZP_MATCH_FLAG: u8 = 0xB5;
+
+/// Rotate right, matching the portable `ROR` macro in the original.
+#[inline]
+fn ror(x: u32, y: i32) -> u32 {
+    x.rotate_right((y & 31) as u32)
+}
+
+/// `lzpC(p)` -- the 32-bit word ending at `at`, i.e. bytes [at-4, at).
+#[inline]
+fn lzp_c(b: &[u8], at: usize) -> u32 {
+    debug_assert!(at >= 4 && at <= b.len(), "lzpC out of range");
+    if at < 4 || at > b.len() {
+        return 0;
+    }
+    u32::from_le_bytes([b[at - 4], b[at - 3], b[at - 2], b[at - 1]])
+}
+
+/// `lzpH(c, p, HashMask)` -- context hash. Note the `lzpC(p-1)` term reads the
+/// word ending one byte earlier.
+#[inline]
+fn lzp_h(c: u32, b: &[u8], at: usize, mask: u32) -> u32 {
+    (c.wrapping_add(5u32.wrapping_mul(ror(c, 17)))
+        .wrapping_add(3u32.wrapping_mul(lzp_c(b, at.wrapping_sub(1))))) & mask
+}
+
+/// Port of `LZPEncode`. Returns the packed length, or 0 when the data did not
+/// compress -- the caller then stores the block instead.
+pub fn encode(input: &[u8], out: &mut [u8], min_len: i32, hash_size: usize, barrier: i32, smallest_len: i32) -> usize {
+    let size = input.len();
+    if size < 32 {
+        return 0;
+    }
+    let mask = (hash_size - 1) as u32;
+    // The C version seeds every slot with `In+5`.
+    let mut htable = vec![5usize; hash_size];
+
+    // Header: the first 12 bytes pass through unchanged.
+    out[..12].copy_from_slice(&input[..12]);
+    let mut inp = 12usize;
+    let mut outp = 12usize;
+    let mut out_end = size; // grows downward
+    let mut n1: u32 = 1;
+    let mut n: u32 = 1;
+
+    let mut i = lzp_c(input, inp);
+    let mut k = lzp_h(i, input, inp, mask) as usize;
+
+    loop {
+        let p = htable[k];
+        n -= 1;
+        if n == 0 {
+            htable[k] = inp;
+            n = n1;
+        }
+
+        let mut literal = false;
+        if i != lzp_c(input, p) {
+            literal = true;
+        } else {
+            let ml = if (inp - p) as i32 > barrier { smallest_len } else { min_len } as usize;
+            if inp + ml <= size && lzp_c(input, p + ml) == lzp_c(input, inp + ml) {
+                // Extend the match four bytes at a time, then one at a time.
+                let mut m = 4usize;
+                while inp + m <= size && lzp_c(input, p + m) == lzp_c(input, inp + m) {
+                    m += 4;
+                }
+                m -= 4;
+                while inp + m < size && input[inp + m] == input[p + m] {
+                    m += 1;
+                }
+                if m < ml {
+                    literal = true;
+                } else {
+                    htable[k] = inp;
+                    if (inp - p) as u32 > (n1 + 1) * hash_size as u32 && n1 < 7 {
+                        n1 += 1;
+                    }
+                    if outp >= out_end {
+                        return 0;
+                    }
+                    out[outp] = LZP_MATCH_FLAG;
+                    outp += 1;
+                    k = m;
+                    inp += m;
+                    // Length goes into the backward stream, 254 at a time.
+                    let mut rem = m - ml;
+                    while rem >= 254 && outp < out_end {
+                        out_end -= 1;
+                        out[out_end] = 0;
+                        rem -= 254;
+                    }
+                    if out_end == 0 {
+                        return 0;
+                    }
+                    out_end -= 1;
+                    out[out_end] = (rem + 1) as u8;
+                    // Re-index the positions skipped over by the match.
+                    loop {
+                        let step = 2 * n1 as usize + 1;
+                        if k < step {
+                            break;
+                        }
+                        k -= step;
+                        if k == 0 {
+                            break;
+                        }
+                        let at = inp - k;
+                        let h = lzp_h(lzp_c(input, at), input, at, mask) as usize;
+                        htable[h] = at;
+                    }
+                }
+            } else {
+                literal = true;
+            }
+        }
+
+        if literal {
+            if outp >= out_end {
+                return 0;
+            }
+            let c = input[inp];
+            out[outp] = c;
+            outp += 1;
+            inp += 1;
+            if c == LZP_MATCH_FLAG {
+                if out_end == 0 {
+                    return 0;
+                }
+                out_end -= 1;
+                out[out_end] = 255;
+            }
+        }
+
+        if inp >= size || outp >= out_end {
+            break;
+        }
+        i = lzp_c(input, inp);
+        k = lzp_h(i, input, inp, mask) as usize;
+    }
+
+    if outp >= out_end {
+        return 0;
+    }
+    // Close the gap between the two streams.
+    out.copy_within(out_end..size, outp);
+    size - (out_end - outp)
+}
+
+/// Port of `LZPDecode`.
+pub fn decode(input: &[u8], out: &mut Vec<u8>, min_len: i32, hash_size: usize, barrier: i32, smallest_len: i32) -> Result<usize, c_int> {
+    let size = input.len();
+    if size < 12 {
+        return Err(crate::ffi::FREEARC_ERRCODE_BAD_COMPRESSED_DATA);
+    }
+    let mask = (hash_size - 1) as u32;
+    let mut htable = vec![5usize; hash_size];
+
+    out.clear();
+    out.extend_from_slice(&input[..12]);
+    let mut inp = 12usize;
+    let mut in_end = size; // consumed downward
+    let mut n1: u32 = 1;
+    let mut n: u32 = 1;
+
+    let bad = crate::ffi::FREEARC_ERRCODE_BAD_COMPRESSED_DATA;
+    let mut i = lzp_c(out, out.len());
+    let mut k = lzp_h(i, out, out.len(), mask) as usize;
+
+    while inp < in_end {
+        let p = htable[k];
+        n -= 1;
+        if n == 0 {
+            htable[k] = out.len();
+            n = n1;
+        }
+        let c = *input.get(inp).ok_or(bad)?;
+        inp += 1;
+
+        let is_match = c == LZP_MATCH_FLAG && i == lzp_c(out, p) && {
+            // The C code consumes a byte from the backward stream as part of
+            // this test; a 255 there means "this was a literal 0xB5".
+            in_end = in_end.checked_sub(1).ok_or(bad)?;
+            *input.get(in_end).ok_or(bad)? != 255
+        };
+
+        if !is_match {
+            out.push(c);
+        } else {
+            htable[k] = out.len();
+            if (out.len() - p) as u32 > (n1 + 1) * hash_size as u32 && n1 < 7 {
+                n1 += 1;
+            }
+            let mut len = (if (out.len() - p) as i32 > barrier { smallest_len } else { min_len }) as usize - 1;
+            while *input.get(in_end).ok_or(bad)? == 0 {
+                len += 254;
+                in_end = in_end.checked_sub(1).ok_or(bad)?;
+            }
+            len += *input.get(in_end).ok_or(bad)? as usize;
+            let mut kk = 2 * n1 as usize + 2;
+            let mut src = p;
+            for _ in 0..len {
+                kk -= 1;
+                if kk == 0 {
+                    kk = 2 * n1 as usize + 1;
+                    let at = out.len();
+                    let h = lzp_h(lzp_c(out, at), out, at, mask) as usize;
+                    htable[h] = at;
+                }
+                let b = *out.get(src).ok_or(bad)?;
+                out.push(b);
+                src += 1;
+            }
+        }
+        let at = out.len();
+        i = lzp_c(out, at);
+        k = lzp_h(i, out, at, mask) as usize;
+    }
+    Ok(out.len())
+}
+
+/// Port of `lzp_decompress`: block framing around `decode`.
+#[allow(clippy::too_many_arguments)]
+pub fn decompress(io: &Io, block_size: u32, min_len: c_int, hash_size_log: c_int, barrier: c_int, smallest_len: c_int) -> c_int {
+    let hash_size = 1usize << hash_size_log.max(1);
+    let mut out: Vec<u8> = Vec::new();
+    loop {
+        let mut hdr = [0u8; 4];
+        match io.read(&mut hdr) {
+            0 => return OK,
+            4 => {}
+            n if n < 0 => return n,
+            _ => return FREEARC_ERRCODE_IO,
+        }
+        let in_size = i32::from_le_bytes(hdr);
+        if in_size < 0 {
+            let n = (-(in_size as i64)) as usize;
+            let mut raw = vec![0u8; n];
+            if io.read(&mut raw) as usize != n {
+                return FREEARC_ERRCODE_IO;
+            }
+            if io.write(&raw) < 0 {
+                return FREEARC_ERRCODE_IO;
+            }
+            continue;
+        }
+        let n = in_size as usize;
+        let mut packed = vec![0u8; n];
+        if n != 0 && io.read(&mut packed) as usize != n {
+            return FREEARC_ERRCODE_IO;
+        }
+        let _ = block_size;
+        match decode(&packed, &mut out, min_len, hash_size, barrier, smallest_len) {
+            Ok(_) => {
+                if !out.is_empty() && io.write(&out) < 0 {
+                    return FREEARC_ERRCODE_IO;
+                }
+            }
+            Err(e) => return e,
+        }
+    }
+}

--- a/rust/darc-codecs/wrapper.h
+++ b/rust/darc-codecs/wrapper.h
@@ -1,0 +1,9 @@
+/* Translation unit bindgen parses to produce the C ABI declarations.
+ *
+ * Deliberately narrow: it pulls in Compression.h (CALLBACK_FUNC, the
+ * FREEARC_ERRCODE_* constants) and Common.h (MemSize) and nothing else, so the
+ * generated bindings stay small and reviewable rather than covering the whole
+ * C++ surface of the codebase.
+ */
+#include "Common.h"
+#include "Compression.h"

--- a/rust/difftest/delta_ref.cpp
+++ b/rust/difftest/delta_ref.cpp
@@ -33,6 +33,14 @@
 int delta_compress   (MemSize BlockSize, int ExtendedTables, CALLBACK_FUNC *callback, void *auxdata);
 int delta_decompress (MemSize BlockSize, int ExtendedTables, CALLBACK_FUNC *callback, void *auxdata);
 
+/* Built a second time with -DUSE_RUST to produce the same driver over the Rust
+ * port, so the two can be diffed on identical input. The Rust symbol IS
+ * extern "C" -- it is the C original that is not. */
+#ifdef USE_RUST
+extern "C" int darc_rs_delta_decompress (MemSize BlockSize, int ExtendedTables,
+                                         CALLBACK_FUNC *callback, void *auxdata);
+#endif
+
 // Buffers the codec reads from and writes to.
 struct Buffers {
   const unsigned char *in;
@@ -101,9 +109,17 @@ int main (int argc, char **argv)
   b.in = in;  b.in_len = len;  b.in_pos = 0;
   b.out = NULL;  b.out_len = 0;  b.out_cap = 0;
 
+#ifdef USE_RUST
+  // Only decompression is ported so far; compression still routes to the C
+  // original so the harness can produce input for it.
+  int rc = argv[1][0] == 'c'
+         ? delta_compress            (blocksize, extended, io_callback, &b)
+         : darc_rs_delta_decompress  (blocksize, extended, io_callback, &b);
+#else
   int rc = argv[1][0] == 'c'
          ? delta_compress   (blocksize, extended, io_callback, &b)
          : delta_decompress (blocksize, extended, io_callback, &b);
+#endif
 
   if (rc < 0) {
     fprintf (stderr, "codec returned %d\n", rc);

--- a/rust/difftest/delta_ref.cpp
+++ b/rust/difftest/delta_ref.cpp
@@ -37,6 +37,8 @@ int delta_decompress (MemSize BlockSize, int ExtendedTables, CALLBACK_FUNC *call
  * port, so the two can be diffed on identical input. The Rust symbol IS
  * extern "C" -- it is the C original that is not. */
 #ifdef USE_RUST
+extern "C" int darc_rs_delta_compress   (MemSize BlockSize, int ExtendedTables,
+                                         CALLBACK_FUNC *callback, void *auxdata);
 extern "C" int darc_rs_delta_decompress (MemSize BlockSize, int ExtendedTables,
                                          CALLBACK_FUNC *callback, void *auxdata);
 #endif
@@ -110,10 +112,8 @@ int main (int argc, char **argv)
   b.out = NULL;  b.out_len = 0;  b.out_cap = 0;
 
 #ifdef USE_RUST
-  // Only decompression is ported so far; compression still routes to the C
-  // original so the harness can produce input for it.
   int rc = argv[1][0] == 'c'
-         ? delta_compress            (blocksize, extended, io_callback, &b)
+         ? darc_rs_delta_compress    (blocksize, extended, io_callback, &b)
          : darc_rs_delta_decompress  (blocksize, extended, io_callback, &b);
 #else
   int rc = argv[1][0] == 'c'

--- a/rust/difftest/delta_ref.cpp
+++ b/rust/difftest/delta_ref.cpp
@@ -1,0 +1,120 @@
+/* Reference driver for differential-testing the Delta codec port.
+ *
+ * Links the original C Delta.cpp and drives it over an in-memory buffer using
+ * the same callback protocol the archiver uses, so a ported implementation can
+ * be compared against it byte for byte:
+ *
+ *     delta_ref  c   <in >out      compress with the C original
+ *     delta_ref  d   <in >out      decompress with the C original
+ *
+ * Why this exists: these codecs define the archive format. A port that
+ * compresses "correctly" but differently produces archives older builds cannot
+ * read, which is the highest-risk failure mode in this repository. Comparing
+ * whole archives catches that, but only one bit at a time and only for inputs
+ * the corpus happens to contain. Driving the codec directly makes it cheap to
+ * throw thousands of inputs at both implementations and diff the results.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../Compression/Compression.h"
+
+// Declared with C++ linkage, deliberately: Delta.cpp defines these without
+// extern "C", so C_Delta.cpp links against the mangled names. Declaring them
+// extern "C" here compiles fine and then fails at link time with "undefined
+// symbol _delta_compress".
+//
+// That matters beyond this driver. A Rust replacement exporting
+// #[no_mangle] extern "C" fn delta_compress would not link either, for exactly
+// the same reason -- so swapping a codec needs extern "C" added to the C
+// declarations (a linkage-only change) or a small C++ shim forwarding to the
+// Rust symbol.
+int delta_compress   (MemSize BlockSize, int ExtendedTables, CALLBACK_FUNC *callback, void *auxdata);
+int delta_decompress (MemSize BlockSize, int ExtendedTables, CALLBACK_FUNC *callback, void *auxdata);
+
+// Buffers the codec reads from and writes to.
+struct Buffers {
+  const unsigned char *in;
+  size_t in_len, in_pos;
+  unsigned char *out;
+  size_t out_len, out_cap;
+};
+
+static int io_callback (const char *what, void *data, int size, void *auxdata)
+{
+  Buffers *b = (Buffers*) auxdata;
+  if (size < 0)  return FREEARC_ERRCODE_GENERAL;
+
+  if (strcmp(what, "read") == 0) {
+    size_t avail = b->in_len - b->in_pos;
+    size_t n = (size_t)size < avail ? (size_t)size : avail;
+    memcpy (data, b->in + b->in_pos, n);
+    b->in_pos += n;
+    return (int) n;
+  }
+
+  if (strcmp(what, "write") == 0) {
+    if (b->out_len + (size_t)size > b->out_cap) {
+      size_t cap = (b->out_cap ? b->out_cap : 65536);
+      while (cap < b->out_len + (size_t)size)  cap *= 2;
+      unsigned char *grown = (unsigned char*) realloc (b->out, cap);
+      if (!grown)  return FREEARC_ERRCODE_NOT_ENOUGH_MEMORY;
+      b->out = grown;                 // realloc may move the block; see the
+      b->out_cap = cap;               // dict.cpp phase2 bug for why this is
+    }                                 // assigned rather than assumed stable
+    memcpy (b->out + b->out_len, data, (size_t)size);
+    b->out_len += (size_t)size;
+    return size;
+  }
+
+  // Anything else the codec might ask about is not supported here.
+  return FREEARC_ERRCODE_NOT_IMPLEMENTED;
+}
+
+int main (int argc, char **argv)
+{
+  if (argc < 2 || (argv[1][0] != 'c' && argv[1][0] != 'd')) {
+    fprintf (stderr, "usage: %s c|d [blocksize] [extended] <in >out\n", argv[0]);
+    return 2;
+  }
+  MemSize blocksize = argc > 2 ? (MemSize) strtoul (argv[2], NULL, 0) : 8*1024*1024;
+  int extended      = argc > 3 ? atoi (argv[3]) : 0;
+
+  // Slurp stdin.
+  size_t cap = 1<<20, len = 0;
+  unsigned char *in = (unsigned char*) malloc (cap);
+  if (!in)  { fprintf (stderr, "oom\n"); return 3; }
+  for (;;) {
+    if (len == cap) {
+      cap *= 2;
+      unsigned char *grown = (unsigned char*) realloc (in, cap);
+      if (!grown)  { free(in); fprintf (stderr, "oom\n"); return 3; }
+      in = grown;
+    }
+    size_t n = fread (in + len, 1, cap - len, stdin);
+    if (n == 0)  break;
+    len += n;
+  }
+
+  Buffers b;
+  b.in = in;  b.in_len = len;  b.in_pos = 0;
+  b.out = NULL;  b.out_len = 0;  b.out_cap = 0;
+
+  int rc = argv[1][0] == 'c'
+         ? delta_compress   (blocksize, extended, io_callback, &b)
+         : delta_decompress (blocksize, extended, io_callback, &b);
+
+  if (rc < 0) {
+    fprintf (stderr, "codec returned %d\n", rc);
+    free (in);  free (b.out);
+    return 4;
+  }
+  if (b.out_len && fwrite (b.out, 1, b.out_len, stdout) != b.out_len) {
+    fprintf (stderr, "short write\n");
+    free (in);  free (b.out);
+    return 5;
+  }
+  free (in);  free (b.out);
+  return 0;
+}

--- a/rust/difftest/dict_phase1_ref.cpp
+++ b/rust/difftest/dict_phase1_ref.cpp
@@ -30,11 +30,37 @@ int main (void)
     len += n;
   }
 
-  if (phase1 (in, (unsigned) len) != 0) { fprintf (stderr, "phase1 failed\n"); return 4; }
+  // Which phase to stop after; default 1.
+  int upto = 1;
+  if (getenv("DICT_PHASE")) upto = atoi(getenv("DICT_PHASE"));
 
-  printf ("words %ld\n", (long)(NextWord - FirstWord));
-  for (Word *p = FirstWord; p < NextWord; p++)
-    printf ("W %ld %u %u %u\n", (long)(p->ptr - in), p->len, p->hash, p->hash0);
+  if (phase1 (in, (unsigned) len) != 0) { fprintf (stderr, "phase1 failed\n"); return 4; }
+  if (upto == 1) {
+    printf ("words %ld\n", (long)(NextWord - FirstWord));
+    for (Word *p = FirstWord; p < NextWord; p++)
+      printf ("W %ld %u %u %u\n", (long)(p->ptr - in), p->len, p->hash, p->hash0);
+    for (int c = 0; c <= UCHAR_MAX; c++)
+      if (char_counts[c]) printf ("C %d %d\n", c, char_counts[c]);
+    return 0;
+  }
+
+  LastWord = NextWord;
+  int rc2 = phase2 ((unsigned) len, 200, 200, 200, 0);
+  if (rc2) { printf ("phase2 rejected\n"); return 0; }
+  if (upto == 2) {
+    printf ("words %ld\n", (long)(LastWord - FirstWord));
+    for (Word *p = FirstWord; p < LastWord; p++)
+      printf ("W %ld %u %d\n", (long)(p->ptr - in), p->len, p->count);
+    return 0;
+  }
+
+  int nodes = 0;
+  int rc3 = phase3 (0, &nodes);
+  if (rc3) { printf ("phase3 rejected\n"); return 0; }
+  printf ("nodes %d prefix %d\n", nodes, PREFIX_FOR_WEAK_CHARS);
+  printf ("words %ld\n", (long)(LastWord - FirstWord));
+  for (Word *p = FirstWord; p < LastWord; p++)
+    printf ("W %ld %u %d\n", (long)(p->ptr - in), p->len, p->count);
   for (int c = 0; c <= UCHAR_MAX; c++)
     if (char_counts[c]) printf ("C %d %d\n", c, char_counts[c]);
   return 0;

--- a/rust/difftest/dict_phase1_ref.cpp
+++ b/rust/difftest/dict_phase1_ref.cpp
@@ -57,11 +57,34 @@ int main (void)
   int nodes = 0;
   int rc3 = phase3 (0, &nodes);
   if (rc3) { printf ("phase3 rejected\n"); return 0; }
-  printf ("nodes %d prefix %d\n", nodes, PREFIX_FOR_WEAK_CHARS);
-  printf ("words %ld\n", (long)(LastWord - FirstWord));
-  for (Word *p = FirstWord; p < LastWord; p++)
-    printf ("W %ld %u %d\n", (long)(p->ptr - in), p->len, p->count);
-  for (int c = 0; c <= UCHAR_MAX; c++)
-    if (char_counts[c]) printf ("C %d %d\n", c, char_counts[c]);
+  if (upto == 3) {
+    printf ("nodes %d prefix %d\n", nodes, PREFIX_FOR_WEAK_CHARS);
+    printf ("words %ld\n", (long)(LastWord - FirstWord));
+    for (Word *p = FirstWord; p < LastWord; p++)
+      printf ("W %ld %u %d\n", (long)(p->ptr - in), p->len, p->count);
+    for (int c = 0; c <= UCHAR_MAX; c++)
+      if (char_counts[c]) printf ("C %d %d\n", c, char_counts[c]);
+    return 0;
+  }
+
+  int rc4 = phase4 (nodes);
+  if (rc4) { printf ("phase4 rejected\n"); return 0; }
+  if (upto == 4) {
+    printf ("words %ld\n", (long)(LastWord - FirstWord));
+    for (Word *p = FirstWord; p < LastWord; p++)
+      printf ("W %ld %u %d %d %d\n", (long)(p->ptr - in), p->len, p->count, p->chr, p->chr2);
+    return 0;
+  }
+
+  byte *outbuf = NULL; unsigned dictlen = 0;
+  int rc5 = phase5 (&outbuf, &dictlen, (unsigned) len);
+  if (rc5) { printf ("phase5 rejected\n"); return 0; }
+  if (upto == 5) { fwrite (outbuf, 1, dictlen, stdout); return 0; }
+
+  if (phase6()) { printf ("phase6 rejected\n"); return 0; }
+  unsigned datalen = 0;
+  if (phase7 (in, (unsigned) len, outbuf + dictlen, &datalen)) { printf ("phase7 rejected\n"); return 0; }
+  // Dictionary followed by the encoded text -- what DictEncode returns.
+  fwrite (outbuf, 1, dictlen + datalen, stdout);
   return 0;
 }

--- a/rust/difftest/dict_phase1_ref.cpp
+++ b/rust/difftest/dict_phase1_ref.cpp
@@ -1,0 +1,41 @@
+/* Dump phase1's output from the C Dict encoder so a ported phase1 can be
+ * compared on its own.
+ *
+ * DictEncode runs all seven phases, so a port of it has no validation until
+ * every phase exists -- ~600 lines written blind and debugged at once. phase1's
+ * result is just the word list and the byte-frequency table, and both can be
+ * dumped and diffed, so each phase can be landed against evidence instead.
+ *
+ *   dict_phase1_ref <in     "W <at> <len> <hash> <hash0>" per word, then
+ *                           "C <byte> <count>" for non-zero counts
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Pull in the codec source itself: Word, phase1 and the globals are file-scope
+// there, and this is the only way to see the struct layout.
+#define DICT_LIBRARY
+#include "../../Compression/Dict/C_Dict.cpp"
+
+int main (void)
+{
+  size_t cap = 1<<20, len = 0;
+  unsigned char *in = (unsigned char*) malloc (cap);
+  if (!in) return 3;
+  for (;;) {
+    if (len == cap) { cap *= 2; unsigned char *g = (unsigned char*) realloc (in, cap); if (!g) return 3; in = g; }
+    size_t n = fread (in + len, 1, cap - len, stdin);
+    if (n == 0) break;
+    len += n;
+  }
+
+  if (phase1 (in, (unsigned) len) != 0) { fprintf (stderr, "phase1 failed\n"); return 4; }
+
+  printf ("words %ld\n", (long)(NextWord - FirstWord));
+  for (Word *p = FirstWord; p < NextWord; p++)
+    printf ("W %ld %u %u %u\n", (long)(p->ptr - in), p->len, p->hash, p->hash0);
+  for (int c = 0; c <= UCHAR_MAX; c++)
+    if (char_counts[c]) printf ("C %d %d\n", c, char_counts[c]);
+  return 0;
+}

--- a/rust/difftest/dict_ref.cpp
+++ b/rust/difftest/dict_ref.cpp
@@ -28,6 +28,8 @@ int dict_decompress (MemSize BlockSize, int MinCompression, int MinWeakChars, in
 }
 
 #ifdef USE_RUST
+extern "C" int darc_rs_dict_compress   (MemSize BlockSize, int, int, int, int, int, int,
+                                        CALLBACK_FUNC *callback, void *auxdata);
 extern "C" int darc_rs_dict_decompress (MemSize BlockSize, int, int, int, int, int, int,
                                         CALLBACK_FUNC *callback, void *auxdata);
 #endif
@@ -40,6 +42,7 @@ extern "C" int darc_rs_dict_decompress (MemSize BlockSize, int, int, int, int, i
 struct Buffers {
   const unsigned char *in; size_t in_len, in_pos;
   unsigned char *out; size_t out_len, out_cap;
+  size_t chunk;   // max bytes one "read" may return; 0 = no limit
 };
 
 static int io_callback (const char *what, void *data, int size, void *auxdata)
@@ -49,6 +52,13 @@ static int io_callback (const char *what, void *data, int size, void *auxdata)
   if (strcmp(what, "read") == 0) {
     size_t avail = b->in_len - b->in_pos;
     size_t n = (size_t)size < avail ? (size_t)size : avail;
+    // A short read is not an error here, and getting this wrong hid a real
+    // divergence for a long time. dict_compress loops on "read", so in the
+    // archiver the codec sees a *sequence* of pipeline-sized buffers, and the
+    // block boundaries decide which words each DictEncode call ever sees.
+    // Returning the whole input in one read -- what this driver used to do --
+    // exercises exactly one block and can never reproduce that.
+    if (b->chunk && n > b->chunk)  n = b->chunk;
     memcpy (data, b->in + b->in_pos, n);  b->in_pos += n;  return (int) n;
   }
   if (strcmp(what, "write") == 0) {
@@ -67,10 +77,40 @@ static int io_callback (const char *what, void *data, int size, void *auxdata)
   return FREEARC_ERRCODE_NOT_IMPLEMENTED;
 }
 
+/* Mode 'v': mimic dict_compress's read loop but call DictEncode directly and
+ * report what each block decided. dict_compress only reports a total, so a
+ * per-block disagreement between implementations is invisible in it -- which
+ * is how a block that compresses standalone but declines mid-stream went
+ * unexplained. C++ linkage, matching dict.cpp (see the note at the top). */
+#ifndef DARC_RUST
+int DictEncode (byte *buf, unsigned bufsize, byte **outbuf, unsigned *outsize,
+                int MinWeakChars, int MinLargeCnt, int MinMediumCnt, int MinSmallCnt, int MinRatio);
+
+static void verbose_stream (const unsigned char *in, size_t len, size_t chunk,
+                            int MinCompression, int MinWeakChars, int MinLargeCnt,
+                            int MinMediumCnt, int MinSmallCnt, int MinRatio)
+{
+  size_t pos = 0;  int blk = 0;
+  while (pos < len) {
+    unsigned InSize = (unsigned) ((len - pos < chunk) ? len - pos : chunk);
+    byte *In = (byte*) malloc (InSize);
+    memcpy (In, in + pos, InSize);
+    byte *Out = NULL;  unsigned OutSize = 0;
+    int x = DictEncode (In, InSize, &Out, &OutSize, MinWeakChars, MinLargeCnt,
+                        MinMediumCnt, MinSmallCnt, MinRatio);
+    int declined = (x || OutSize/MinCompression >= InSize/100);
+    fprintf (stderr, "block %2d  in=%-7u rc=%-3d out=%-7u %s\n",
+             blk++, InSize, x, OutSize, declined ? "DECLINED" : "engaged");
+    FreeAndNil (Out);  FreeAndNil (In);
+    pos += InSize;
+  }
+}
+#endif
+
 int main (int argc, char **argv)
 {
-  if (argc < 2 || (argv[1][0] != 'c' && argv[1][0] != 'd')) {
-    fprintf (stderr, "usage: %s c|d [blocksize] <in >out\n", argv[0]);  return 2;
+  if (argc < 2 || (argv[1][0] != 'c' && argv[1][0] != 'd' && argv[1][0] != 'v')) {
+    fprintf (stderr, "usage: %s c|d|v [blocksize] <in >out\n", argv[0]);  return 2;
   }
   MemSize blocksize = argc > 2 ? (MemSize) strtoul (argv[2], NULL, 0) : 8*1024*1024;
 
@@ -85,13 +125,42 @@ int main (int argc, char **argv)
   }
 
   Buffers b; b.in = in; b.in_len = len; b.in_pos = 0; b.out = NULL; b.out_len = 0; b.out_cap = 0;
+  const char *chunk_env = getenv ("DICT_CHUNK");
+  b.chunk = chunk_env ? (size_t) strtoul (chunk_env, NULL, 0) : 0;
 
-  // Defaults taken from C_Dict.cpp's parse_DICT.
-  const int MinCompression = 100, MinWeakChars = 0, MinLargeCnt = 200, MinMediumCnt = 200,
-            MinSmallCnt = 200, MinRatio = 0;
+  // These MUST match DICT_METHOD's constructor (C_Dict.cpp:111-116), which is
+  // what the archiver actually runs. An earlier version of this driver used
+  // MinWeakChars=0, MinLargeCnt=200, MinMediumCnt=200, MinSmallCnt=200,
+  // MinRatio=0 under a comment claiming they came from parse_DICT. They did
+  // not: five of the six were wrong. The port was declared byte-identical on a
+  // parameter set the archiver never uses, and the first whole-archive
+  // comparison found a 9200-byte divergence the phase harness could not see.
+  // If these drift from C_Dict.cpp again the suite goes quietly green on
+  // nothing, so they are overridable below only to *widen* coverage.
+  int MinCompression = 100, MinWeakChars = 20, MinLargeCnt = 2048, MinMediumCnt = 100,
+      MinSmallCnt = 50, MinRatio = 4;
+  if (argc > 3)  MinCompression = atoi (argv[3]);
+  if (argc > 4)  MinWeakChars   = atoi (argv[4]);
+  if (argc > 5)  MinLargeCnt    = atoi (argv[5]);
+  if (argc > 6)  MinMediumCnt   = atoi (argv[6]);
+  if (argc > 7)  MinSmallCnt    = atoi (argv[7]);
+  if (argc > 8)  MinRatio       = atoi (argv[8]);
+
+#ifndef DARC_RUST
+  if (argv[1][0] == 'v') {
+    verbose_stream (in, len, b.chunk ? b.chunk : len, MinCompression, MinWeakChars,
+                    MinLargeCnt, MinMediumCnt, MinSmallCnt, MinRatio);
+    free (in);  return 0;
+  }
+#endif
+
   int rc;
   if (argv[1][0] == 'c')
+#ifdef USE_RUST
+    rc = darc_rs_dict_compress (blocksize, MinCompression, MinWeakChars, MinLargeCnt, MinMediumCnt, MinSmallCnt, MinRatio, io_callback, &b);
+#else
     rc = dict_compress (blocksize, MinCompression, MinWeakChars, MinLargeCnt, MinMediumCnt, MinSmallCnt, MinRatio, io_callback, &b);
+#endif
   else
 #ifdef USE_RUST
     rc = darc_rs_dict_decompress (blocksize, MinCompression, MinWeakChars, MinLargeCnt, MinMediumCnt, MinSmallCnt, MinRatio, io_callback, &b);

--- a/rust/difftest/dict_ref.cpp
+++ b/rust/difftest/dict_ref.cpp
@@ -1,0 +1,105 @@
+/* Reference driver for differential-testing the Dict codec port.
+ *
+ *     dict_ref c <in >out     compress with the C original
+ *     dict_ref d <in >out     decompress
+ *
+ * Built a second time with -DUSE_RUST to drive the Rust port instead, so the
+ * two can be diffed on identical input. Same rationale as delta_ref.cpp: these
+ * codecs define the archive format, so a port has to be bit-exact.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../Compression/Compression.h"
+
+// extern "C" because C_Dict.cpp wraps its whole body in extern "C" and
+// #includes dict.cpp, so these are C symbols -- the same arrangement as
+// C_Delta.cpp. That is also why swapping in the Rust port has to exclude the C
+// implementation rather than redeclare it: with both present the linker
+// resolves from the object file and never touches the Rust archive.
+extern "C" {
+int dict_compress   (MemSize BlockSize, int MinCompression, int MinWeakChars, int MinLargeCnt,
+                     int MinMediumCnt, int MinSmallCnt, int MinRatio,
+                     CALLBACK_FUNC *callback, void *auxdata);
+int dict_decompress (MemSize BlockSize, int MinCompression, int MinWeakChars, int MinLargeCnt,
+                     int MinMediumCnt, int MinSmallCnt, int MinRatio,
+                     CALLBACK_FUNC *callback, void *auxdata);
+}
+
+#ifdef USE_RUST
+extern "C" int darc_rs_dict_decompress (MemSize BlockSize, int, int, int, int, int, int,
+                                        CALLBACK_FUNC *callback, void *auxdata);
+#endif
+
+// C_Dict.cpp registers itself with the compression-method table and inherits
+// from COMPRESSION_METHOD, so CompressionLibrary.cpp has to be linked in --
+// stubbing AddCompressionMethod/LoadFromDLL is not enough, the base class
+// vtable is needed too.
+
+struct Buffers {
+  const unsigned char *in; size_t in_len, in_pos;
+  unsigned char *out; size_t out_len, out_cap;
+};
+
+static int io_callback (const char *what, void *data, int size, void *auxdata)
+{
+  Buffers *b = (Buffers*) auxdata;
+  if (size < 0)  return FREEARC_ERRCODE_GENERAL;
+  if (strcmp(what, "read") == 0) {
+    size_t avail = b->in_len - b->in_pos;
+    size_t n = (size_t)size < avail ? (size_t)size : avail;
+    memcpy (data, b->in + b->in_pos, n);  b->in_pos += n;  return (int) n;
+  }
+  if (strcmp(what, "write") == 0) {
+    if (b->out_len + (size_t)size > b->out_cap) {
+      size_t cap = (b->out_cap ? b->out_cap : 65536);
+      while (cap < b->out_len + (size_t)size)  cap *= 2;
+      unsigned char *grown = (unsigned char*) realloc (b->out, cap);
+      if (!grown)  return FREEARC_ERRCODE_NOT_ENOUGH_MEMORY;
+      b->out = grown;  b->out_cap = cap;
+    }
+    memcpy (b->out + b->out_len, data, (size_t)size);  b->out_len += (size_t)size;  return size;
+  }
+  // "quasiwrite" and "time" are progress signals the archiver consumes; the
+  // codec does not depend on their result, so reporting them unimplemented is
+  // what the real callback chain does for unknown requests too.
+  return FREEARC_ERRCODE_NOT_IMPLEMENTED;
+}
+
+int main (int argc, char **argv)
+{
+  if (argc < 2 || (argv[1][0] != 'c' && argv[1][0] != 'd')) {
+    fprintf (stderr, "usage: %s c|d [blocksize] <in >out\n", argv[0]);  return 2;
+  }
+  MemSize blocksize = argc > 2 ? (MemSize) strtoul (argv[2], NULL, 0) : 8*1024*1024;
+
+  size_t cap = 1<<20, len = 0;
+  unsigned char *in = (unsigned char*) malloc (cap);
+  if (!in) return 3;
+  for (;;) {
+    if (len == cap) { cap *= 2; unsigned char *g = (unsigned char*) realloc (in, cap); if (!g) { free(in); return 3; } in = g; }
+    size_t n = fread (in + len, 1, cap - len, stdin);
+    if (n == 0) break;
+    len += n;
+  }
+
+  Buffers b; b.in = in; b.in_len = len; b.in_pos = 0; b.out = NULL; b.out_len = 0; b.out_cap = 0;
+
+  // Defaults taken from C_Dict.cpp's parse_DICT.
+  const int MinCompression = 100, MinWeakChars = 0, MinLargeCnt = 200, MinMediumCnt = 200,
+            MinSmallCnt = 200, MinRatio = 0;
+  int rc;
+  if (argv[1][0] == 'c')
+    rc = dict_compress (blocksize, MinCompression, MinWeakChars, MinLargeCnt, MinMediumCnt, MinSmallCnt, MinRatio, io_callback, &b);
+  else
+#ifdef USE_RUST
+    rc = darc_rs_dict_decompress (blocksize, MinCompression, MinWeakChars, MinLargeCnt, MinMediumCnt, MinSmallCnt, MinRatio, io_callback, &b);
+#else
+    rc = dict_decompress (blocksize, MinCompression, MinWeakChars, MinLargeCnt, MinMediumCnt, MinSmallCnt, MinRatio, io_callback, &b);
+#endif
+
+  if (rc < 0) { fprintf (stderr, "codec returned %d\n", rc); free(in); free(b.out); return 4; }
+  if (b.out_len && fwrite (b.out, 1, b.out_len, stdout) != b.out_len) { free(in); free(b.out); return 5; }
+  free (in); free (b.out); return 0;
+}

--- a/rust/difftest/lzp_ref.cpp
+++ b/rust/difftest/lzp_ref.cpp
@@ -26,6 +26,8 @@ int lzp_decompress (MemSize BlockSize, int MinCompression, int MinMatchLen, int 
 }
 
 #ifdef USE_RUST
+extern "C" int darc_rs_lzp_compress   (MemSize BlockSize, int, int, int, int, int,
+                                        CALLBACK_FUNC *callback, void *auxdata);
 extern "C" int darc_rs_lzp_decompress (MemSize BlockSize, int, int, int, int, int,
                                         CALLBACK_FUNC *callback, void *auxdata);
 #endif
@@ -90,7 +92,11 @@ int main (int argc, char **argv)
             SmallestLen = 32;
   int rc;
   if (argv[1][0] == 'c')
+#ifdef USE_RUST
+    rc = darc_rs_lzp_compress (blocksize, MinCompression, MinMatchLen, HashSizeLog, Barrier, SmallestLen, io_callback, &b);
+#else
     rc = lzp_compress (blocksize, MinCompression, MinMatchLen, HashSizeLog, Barrier, SmallestLen, io_callback, &b);
+#endif
   else
 #ifdef USE_RUST
     rc = darc_rs_lzp_decompress (blocksize, MinCompression, MinMatchLen, HashSizeLog, Barrier, SmallestLen, io_callback, &b);

--- a/rust/difftest/lzp_ref.cpp
+++ b/rust/difftest/lzp_ref.cpp
@@ -1,0 +1,104 @@
+/* Reference driver for differential-testing the LZP codec port.
+ *
+ *     lzp_ref c <in >out     compress with the C original
+ *     lzp_ref d <in >out     decompress
+ *
+ * Built a second time with -DUSE_RUST to drive the Rust port instead, so the
+ * two can be diffed on identical input. Same rationale as delta_ref.cpp: these
+ * codecs define the archive format, so a port has to be bit-exact.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../Compression/Compression.h"
+
+// extern "C" because C_LZP.cpp wraps its whole body in extern "C" and
+// #includes dict.cpp, so these are C symbols -- the same arrangement as
+// C_Delta.cpp. That is also why swapping in the Rust port has to exclude the C
+// implementation rather than redeclare it: with both present the linker
+// resolves from the object file and never touches the Rust archive.
+extern "C" {
+int lzp_compress   (MemSize BlockSize, int MinCompression, int MinMatchLen, int HashSizeLog,
+                     int Barrier, int SmallestLen, CALLBACK_FUNC *callback, void *auxdata);
+int lzp_decompress (MemSize BlockSize, int MinCompression, int MinMatchLen, int HashSizeLog,
+                     int Barrier, int SmallestLen, CALLBACK_FUNC *callback, void *auxdata);
+}
+
+#ifdef USE_RUST
+extern "C" int darc_rs_lzp_decompress (MemSize BlockSize, int, int, int, int, int,
+                                        CALLBACK_FUNC *callback, void *auxdata);
+#endif
+
+// C_LZP.cpp registers itself with the compression-method table and inherits
+// from COMPRESSION_METHOD, so CompressionLibrary.cpp has to be linked in --
+// stubbing AddCompressionMethod/LoadFromDLL is not enough, the base class
+// vtable is needed too.
+
+struct Buffers {
+  const unsigned char *in; size_t in_len, in_pos;
+  unsigned char *out; size_t out_len, out_cap;
+};
+
+static int io_callback (const char *what, void *data, int size, void *auxdata)
+{
+  Buffers *b = (Buffers*) auxdata;
+  if (size < 0)  return FREEARC_ERRCODE_GENERAL;
+  if (strcmp(what, "read") == 0) {
+    size_t avail = b->in_len - b->in_pos;
+    size_t n = (size_t)size < avail ? (size_t)size : avail;
+    memcpy (data, b->in + b->in_pos, n);  b->in_pos += n;  return (int) n;
+  }
+  if (strcmp(what, "write") == 0) {
+    if (b->out_len + (size_t)size > b->out_cap) {
+      size_t cap = (b->out_cap ? b->out_cap : 65536);
+      while (cap < b->out_len + (size_t)size)  cap *= 2;
+      unsigned char *grown = (unsigned char*) realloc (b->out, cap);
+      if (!grown)  return FREEARC_ERRCODE_NOT_ENOUGH_MEMORY;
+      b->out = grown;  b->out_cap = cap;
+    }
+    memcpy (b->out + b->out_len, data, (size_t)size);  b->out_len += (size_t)size;  return size;
+  }
+  // "quasiwrite" and "time" are progress signals the archiver consumes; the
+  // codec does not depend on their result, so reporting them unimplemented is
+  // what the real callback chain does for unknown requests too.
+  return FREEARC_ERRCODE_NOT_IMPLEMENTED;
+}
+
+int main (int argc, char **argv)
+{
+  if (argc < 2 || (argv[1][0] != 'c' && argv[1][0] != 'd')) {
+    fprintf (stderr, "usage: %s c|d [blocksize] <in >out\n", argv[0]);  return 2;
+  }
+  MemSize blocksize = argc > 2 ? (MemSize) strtoul (argv[2], NULL, 0) : 8*1024*1024;
+
+  size_t cap = 1<<20, len = 0;
+  unsigned char *in = (unsigned char*) malloc (cap);
+  if (!in) return 3;
+  for (;;) {
+    if (len == cap) { cap *= 2; unsigned char *g = (unsigned char*) realloc (in, cap); if (!g) { free(in); return 3; } in = g; }
+    size_t n = fread (in + len, 1, cap - len, stdin);
+    if (n == 0) break;
+    len += n;
+  }
+
+  Buffers b; b.in = in; b.in_len = len; b.in_pos = 0; b.out = NULL; b.out_len = 0; b.out_cap = 0;
+
+  // Defaults taken from C_LZP.cpp's parse_DICT.
+  // Defaults from parse_LZP in C_LZP.cpp.
+  const int MinCompression = 100, MinMatchLen = 32, HashSizeLog = 16, Barrier = 0x7fffffff,
+            SmallestLen = 32;
+  int rc;
+  if (argv[1][0] == 'c')
+    rc = lzp_compress (blocksize, MinCompression, MinMatchLen, HashSizeLog, Barrier, SmallestLen, io_callback, &b);
+  else
+#ifdef USE_RUST
+    rc = darc_rs_lzp_decompress (blocksize, MinCompression, MinMatchLen, HashSizeLog, Barrier, SmallestLen, io_callback, &b);
+#else
+    rc = lzp_decompress (blocksize, MinCompression, MinMatchLen, HashSizeLog, Barrier, SmallestLen, io_callback, &b);
+#endif
+
+  if (rc < 0) { fprintf (stderr, "codec returned %d\n", rc); free(in); free(b.out); return 4; }
+  if (b.out_len && fwrite (b.out, 1, b.out_len, stdout) != b.out_len) { free(in); free(b.out); return 5; }
+  free (in); free (b.out); return 0;
+}

--- a/rust/difftest/make_inputs.py
+++ b/rust/difftest/make_inputs.py
@@ -54,3 +54,86 @@ for i in range(10000):
     out += struct.pack("<IIII", i * 5, i * 9 + 3, 0xCAFEBABE, i)
 out += random.randbytes(30000)
 w("embedded.bin", out)
+
+
+# ---------------------------------------------------------------------------
+# Inputs aimed at the compressor's heuristics.
+#
+# The first corpus here matched C byte-for-byte on 14/14 inputs and still could
+# not detect four deliberately introduced errors, including a wrong reading of
+#     difflb < itemlb? len++,omit=0 : useless++,omit++;
+# and a changed acceptance threshold. Counting the tables actually detected
+# explained it: 14 tables across 14 inputs, all of them perfectly monotonic, so
+# search_for_table_boundary never took its direction-change branch -- which is
+# the only place `omit` and `lastpoint` are used -- and the threshold was never
+# near enough to matter.
+#
+# These are built to make those paths run: direction reversals, wrap-around,
+# many small tables at varied widths and spacings, and table sizes that sit
+# either side of the acceptance test.
+# ---------------------------------------------------------------------------
+
+def le(v, w):
+    return (v & ((1 << (8 * w)) - 1)).to_bytes(w, "little")
+
+
+# Columns that climb then fall, repeatedly: forces the direction-change branch,
+# which is where `omit`, `lastpoint` and the bad-run counter come into play.
+out = bytearray()
+for i in range(30000):
+    phase = (i // 40) % 2
+    v = i * 11 if phase == 0 else 500000 - i * 11
+    out += le(v, 4) + le(i * 3, 4)
+w("zigzag.bin", out)
+
+# Counters that wrap, producing a sign flip in the int16 view every 2^16.
+out = bytearray()
+for i in range(40000):
+    out += le(i * 2731, 4) + le(i * 65533, 4)
+w("wrapping.bin", out)
+
+# Many independent small tables of differing widths, separated by noise of
+# differing lengths, so the skip field -- and therefore skipBits in the
+# acceptance test -- takes a wide range of values.
+random.seed(99)
+out = bytearray()
+for t, width in enumerate((2, 3, 4, 5, 6, 8, 12, 16)):
+    for rep in range(6):
+        out += random.randbytes(17 + t * 29 + rep * 7)
+        rows = 40 + rep * 25
+        for i in range(rows):
+            out += le(i * (t + 2) + rep, width)
+w("many-tables.bin", out)
+
+# Tables sized either side of the acceptance test, so a shifted threshold
+# changes which of them are accepted.
+out = bytearray()
+for rows in range(8, 90, 3):
+    out += random.randbytes(23)
+    for i in range(rows):
+        out += le(i * 5 + 7, 4)
+w("threshold-edge.bin", out)
+
+# Runs that are monotonic but only briefly, so the len>=4 test and the
+# consecutive-short-run counter both matter.
+out = bytearray()
+for i in range(30000):
+    seg = i // 3
+    out += le(seg * 17 + (i % 3) * 4099, 4)
+w("short-runs.bin", out)
+
+# A fine sweep across the acceptance test. The coarser threshold-edge.bin above
+# stepped rows by 3 and never landed a candidate close enough to the boundary
+# for a 30 -> 29 change in
+#     useful*sqrt(N) > 30 + 4*skipBits
+# to alter any decision -- that sabotage went undetected by all 13 inputs. This
+# steps one row at a time at several widths and several skip distances, so some
+# candidate sits exactly on the line whichever way it is nudged.
+for width in (2, 3, 4, 6, 8):
+    out = bytearray()
+    for gap in (5, 40, 300, 2000):
+        for rows in range(6, 70):
+            out += random.randbytes(gap)
+            for i in range(rows):
+                out += le(i * 3 + 11, width)
+    w(f"threshold-sweep{width}.bin", out)

--- a/rust/difftest/make_inputs.py
+++ b/rust/difftest/make_inputs.py
@@ -1,0 +1,56 @@
+"""Table-shaped inputs for the Delta differential test.
+
+These exist because of a measurement, not a guess. An input set of random data,
+a real binary, and a few degenerate sizes matched 8/8 between C and Rust and
+looked like a thorough pass -- but when the Rust carry handling was broken on
+purpose, only 1 of those 8 noticed. For random and binary data the compressor
+finds almost no tables, so undiff_table barely runs and a wrong answer never
+shows up in the output.
+
+The inputs below are built so the transforms actually run: multi-byte
+little-endian counters whose consecutive rows differ by small amounts, which is
+what makes byte-wise subtraction borrow across the bytes of a column. With these
+added, 4 of 8 detect the same broken carry.
+"""
+import os
+import random
+import struct
+import sys
+
+d = sys.argv[1]
+
+
+def w(name, b):
+    with open(os.path.join(d, name), "wb") as f:
+        f.write(bytes(b))
+
+
+# Counters of several element widths: the carry path, at several table shapes.
+for n_bytes, rows in ((2, 20000), (3, 15000), (4, 20000), (8, 10000), (16, 6000)):
+    out = bytearray()
+    for i in range(rows):
+        v = (i * 7 + 1000) & ((1 << (8 * n_bytes)) - 1)
+        out += v.to_bytes(n_bytes, "little")
+    w(f"counter{n_bytes}.bin", out)
+
+# Monotonic and constant columns together: exercises the diff path, the column
+# reordering, and unreorder_table's early return when every column is one kind.
+out = bytearray()
+for i in range(20000):
+    out += struct.pack("<IIII", i * 3, 0xDEADBEEF, i * 65537, 0x11223344)
+w("mixed-cols.bin", out)
+
+# A column that increments past 2^24, so carries propagate the full element width.
+out = bytearray()
+for i in range(20000):
+    out += struct.pack("<QQ", 0x0100000000 + i * 13, i * 257)
+w("wide-carry.bin", out)
+
+# A table buried in noise, so table-boundary detection has to find its extent
+# rather than being handed a block that is entirely table.
+random.seed(1234)
+out = bytearray(random.randbytes(30000))
+for i in range(10000):
+    out += struct.pack("<IIII", i * 5, i * 9 + 3, 0xCAFEBABE, i)
+out += random.randbytes(30000)
+w("embedded.bin", out)

--- a/rust/difftest/run.sh
+++ b/rust/difftest/run.sh
@@ -95,15 +95,34 @@ build_rs () {
 compare_with () {
   local rs="$1" quiet="${2:-}" fail=0 n=0
   for f in "$WORK"/in/*; do
-    "$REF" c >| "$WORK/packed" < "$f" 2>/dev/null || continue
-    "$REF" d >| "$WORK/c_out"  < "$WORK/packed" 2>/dev/null || continue
+    "$REF" c >| "$WORK/c_packed" < "$f" 2>/dev/null || continue
+    "$REF" d >| "$WORK/c_out"    < "$WORK/c_packed" 2>/dev/null || continue
     n=$((n+1))
-    "$rs" d >| "$WORK/r_out" < "$WORK/packed" 2>/dev/null || true
-    if cmp -s "$WORK/c_out" "$WORK/r_out" && cmp -s "$f" "$WORK/r_out"; then
-      [ -n "$quiet" ] || printf "  %-18s %9s bytes  C==Rust, round-trips\n" \
+    local bad=0
+
+    # Compression: the ported compressor must emit the same bytes as the C one.
+    # Checking only decompression would miss every heuristic in the compressor --
+    # which it silently did at first, reporting 0/23 for eight mutations that
+    # were each detectable when compressed output was compared.
+    if ! "$rs" c >| "$WORK/r_packed" < "$f" 2>/dev/null; then bad=1
+    elif ! cmp -s "$WORK/c_packed" "$WORK/r_packed"; then bad=1
+    fi
+
+    # Decompression, both ways round: the port must read the C stream, and the C
+    # original must read the port's.
+    if [ "$bad" -eq 0 ]; then
+      "$rs" d >| "$WORK/r_out" < "$WORK/c_packed" 2>/dev/null || bad=1
+      cmp -s "$WORK/c_out" "$WORK/r_out" || bad=1
+      cmp -s "$f" "$WORK/r_out" || bad=1
+      "$REF" d >| "$WORK/x_out" < "$WORK/r_packed" 2>/dev/null || bad=1
+      cmp -s "$f" "$WORK/x_out" || bad=1
+    fi
+
+    if [ "$bad" -eq 0 ]; then
+      [ -n "$quiet" ] || printf "  %-20s %9s bytes  C==Rust both ways\n" \
         "$(basename "$f")" "$(wc -c <"$f" | tr -d ' ')" >&2
     else
-      [ -n "$quiet" ] || printf "  %-18s DIFFERS FROM C\n" "$(basename "$f")" >&2
+      [ -n "$quiet" ] || printf "  %-20s DIFFERS FROM C\n" "$(basename "$f")" >&2
       fail=$((fail+1))
     fi
   done
@@ -122,34 +141,77 @@ diff_impls () {
   echo "delta port matches the C original byte for byte"
 }
 
-# A differential test that has never been seen to fail is not evidence. Break
-# the port on purpose and confirm the comparison notices.
+# A differential test that has never been seen to fail is not evidence.
 #
-# This is not ceremony: the first input set here looked like a thorough pass at
-# 8/8 matching, but only 1 of those 8 could detect a deliberately broken carry.
-# For random and binary data the compressor finds almost no tables, so
-# undiff_table barely runs and a wrong answer is invisible. The table-shaped
-# inputs in make_inputs.py exist because of that measurement.
+# This mutates the port in ways that mirror real transcription errors and
+# reports how many inputs notice each one. It is not ceremony -- every number
+# below started out wrong:
+#
+#   * An early corpus of random data, a binary and degenerate sizes matched C on
+#     14/14 and could not detect four deliberate errors. Counting the tables it
+#     actually produced explained it: 14 tables across 14 inputs, all perfectly
+#     monotonic, so search_for_table_boundary never took its direction-change
+#     branch -- the only place `omit` and `lastpoint` are used.
+#   * One mutation reported 0/13 for a different reason entirely: the sed
+#     pattern had the wrong indentation and never applied. The zero meant
+#     "nothing was broken", not "the test is blind". Hence apply_mutation
+#     below refuses to continue if its pattern is absent.
+#
+# With inputs built for the heuristics (make_inputs.py) the corpus produces
+# ~280 tables and every mutation is caught by at least one input.
+MUT_SRC="$ROOT/rust/darc-codecs/src/delta.rs"
+
+apply_mutation () {
+  python3 - "$MUT_SRC" "$1" "$2" <<'PYEOF'
+import sys
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+s = open(path).read()
+if old not in s:
+    sys.stderr.write("mutation pattern not found: %r\n" % old)
+    sys.exit(1)
+open(path, "w").write(s.replace(old, new, 1))
+PYEOF
+}
+
 sabotage () {
   [ -x "$REF" ] || build_ref || return 1
   build_rs || return 1
   make_inputs
-  local src="$ROOT/rust/darc-codecs/src/delta.rs" bak="$WORK/delta.rs.bak"
-  cp "$src" "$bak"
-  sed -i.tmp 's|carry = sum >> 8;|carry = 0;|' "$src" && rm -f "$src.tmp"
-  local broken="$RS.broken" res n caught
-  if ( cd "$ROOT/rust/darc-codecs" && cargo build --release ) >/dev/null 2>&1; then
+  local bak="$WORK/delta.rs.bak"; cp "$MUT_SRC" "$bak"
+  local broken="$RS.broken" status=0
+
+  # name | pattern | replacement
+  local muts=(
+    "omit++ unconditional|            omit += 1;|            // mutated"
+    "lastpoint back-off|lastpoint = t - n * omit as isize;|lastpoint = t;"
+    "acceptance threshold|> 30.0 + 4.0 * skip_bits|> 29.0 + 4.0 * skip_bits"
+    "candidate count > 5|if count[i] > 5 {|if count[i] > 4 {"
+    "immutable N exclusion|&& n != 2 && n != 4 && n != 8|&& n != 4 && n != 8"
+    "itemlb > 10 adjustment|itemlb -= (itemlb > 10) as u32;|// mutated"
+    "short-run limit|if bad >= 2 {|if bad >= 3 {"
+    "constant-column ratio|neq * 4 < rows as i32|neq * 3 < rows as i32"
+  )
+  for m in "${muts[@]}"; do
+    local name="${m%%|*}" rest="${m#*|}"
+    local pat="${rest%%|*}" rep="${rest#*|}"
+    cp "$bak" "$MUT_SRC"
+    if ! apply_mutation "$pat" "$rep"; then status=1; continue; fi
+    ( cd "$ROOT/rust/darc-codecs" && cargo build --release ) >/dev/null 2>&1
     clang++ -std=c++17 -O2 -w -DUSE_RUST -DDELTA_LIBRARY -DFREEARC_UNIX \
       -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT -I Compression -I . \
       -o "$broken" "$HERE/delta_ref.cpp" Compression/Delta/Delta.cpp Compression/Common.cpp \
       "$ROOT/rust/darc-codecs/target/release/libdarc_codecs.a" 2>/dev/null
-  fi
-  res=$(compare_with "$broken" quiet); n=${res%% *}; caught=${res##* }
-  cp "$bak" "$src"
+    local res n caught
+    res=$(compare_with "$broken" quiet); n=${res%% *}; caught=${res##* }
+    printf "  %-24s %2s of %2s inputs detect it\n" "$name" "$caught" "$n"
+    [ "$caught" -gt 0 ] || { echo "    ^ NOT DETECTED by any input" >&2; status=1; }
+  done
+
+  cp "$bak" "$MUT_SRC"
   ( cd "$ROOT/rust/darc-codecs" && cargo build --release ) >/dev/null 2>&1
   rm -rf "$WORK"
-  echo "sabotage check: $caught of $n inputs detect a broken carry"
-  [ "$caught" -gt 0 ] || { echo "the differential test cannot detect a broken port" >&2; return 1; }
+  [ "$status" -eq 0 ] && echo "every mutation is caught by at least one input" \
+                      || { echo "the differential test is blind to some errors" >&2; return 1; }
 }
 
 case "${1:-selftest}" in

--- a/rust/difftest/run.sh
+++ b/rust/difftest/run.sh
@@ -4,6 +4,7 @@
 #   rust/difftest/run.sh build      build the C reference driver
 #   rust/difftest/run.sh selftest   round-trip the C original over sample inputs
 #   rust/difftest/run.sh diff       compare C vs Rust output byte for byte
+#   rust/difftest/run.sh sabotage   prove the comparison can actually fail
 #
 # The C original is the oracle. These codecs define the archive format, so a
 # port has to be bit-exact, not merely correct: output that decompresses fine
@@ -19,6 +20,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$HERE/../.." && pwd)"
 cd "$ROOT"
 REF=${REF:-/tmp/darc-delta-ref}
+RS=${RS:-/tmp/darc-delta-rs}
 WORK=${WORK:-${TMPDIR:-/tmp}/darc-difftest.$$}
 
 build_ref () {
@@ -46,22 +48,7 @@ make_inputs () {
   : > "$WORK/in/empty.bin"
   printf 'x'                             > "$WORK/in/one-byte.bin"
   head -c 7 /dev/urandom                 > "$WORK/in/tiny.bin"
-  python3 -c "
-import struct,sys
-out=bytearray()
-for i in range(5000):
-    out += struct.pack('<IIII', i*4, i*7+100, 0xAABBCCDD, i)
-sys.stdout.buffer.write(bytes(out))"    > "$WORK/in/table16.bin"
-  python3 -c "
-import struct,sys
-out=bytearray()
-for i in range(20000):
-    out += struct.pack('<IIII', i*4, i*8+1000, i*2, 0x11223344)
-sys.stdout.buffer.write(bytes(out))"    > "$WORK/in/table16-wide.bin"
-  python3 -c "
-import sys
-sys.stdout.buffer.write(bytes((i*3+7) % 251 for i in range(100000)))" \
-                                         > "$WORK/in/sawtooth.bin"
+  python3 "$HERE/make_inputs.py" "$WORK/in"
 }
 
 selftest () {
@@ -87,18 +74,88 @@ selftest () {
                     || { echo "reference self-test: $fail failed" >&2; return 1; }
 }
 
-# Placeholder until a Rust Delta exists. Deliberately fails rather than
-# reporting success on a comparison it never made -- a check that cannot fail
-# is how this branch's Windows CI went green on a binary that did not work.
+# Build the same driver against the Rust port and diff it with the C original.
+build_rs () {
+  ( cd "$ROOT/rust/darc-codecs" && cargo build --release ) >/dev/null 2>&1 \
+    || { echo "error: cargo build failed" >&2; return 1; }
+  clang++ -std=c++17 -O2 -w \
+    -DUSE_RUST -DDELTA_LIBRARY -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+    -I Compression -I . \
+    -o "$RS" "$HERE/delta_ref.cpp" Compression/Delta/Delta.cpp Compression/Common.cpp \
+    "$ROOT/rust/darc-codecs/target/release/libdarc_codecs.a" \
+    || { echo "error: failed to build the Rust driver" >&2; return 1; }
+}
+
+# Compare C and Rust decompression of the same C-produced stream. `$1` names the
+# Rust binary so the sabotage check can point this at a deliberately broken one.
+#
+# Contract: per-file detail goes to stderr, and stdout carries ONLY "<n> <fail>".
+# The caller captures stdout, so anything else printed there is parsed as a
+# count -- which silently produced an empty tally the first time round.
+compare_with () {
+  local rs="$1" quiet="${2:-}" fail=0 n=0
+  for f in "$WORK"/in/*; do
+    "$REF" c >| "$WORK/packed" < "$f" 2>/dev/null || continue
+    "$REF" d >| "$WORK/c_out"  < "$WORK/packed" 2>/dev/null || continue
+    n=$((n+1))
+    "$rs" d >| "$WORK/r_out" < "$WORK/packed" 2>/dev/null || true
+    if cmp -s "$WORK/c_out" "$WORK/r_out" && cmp -s "$f" "$WORK/r_out"; then
+      [ -n "$quiet" ] || printf "  %-18s %9s bytes  C==Rust, round-trips\n" \
+        "$(basename "$f")" "$(wc -c <"$f" | tr -d ' ')" >&2
+    else
+      [ -n "$quiet" ] || printf "  %-18s DIFFERS FROM C\n" "$(basename "$f")" >&2
+      fail=$((fail+1))
+    fi
+  done
+  echo "$n $fail"
+}
+
 diff_impls () {
-  echo "error: no Rust Delta implementation to compare against yet." >&2
-  echo "       Port it, expose it under the same ABI, then run this." >&2
-  return 1
+  [ -x "$REF" ] || build_ref || return 1
+  build_rs || return 1
+  make_inputs
+  local res n fail
+  res=$(compare_with "$RS"); n=${res%% *}; fail=${res##* }
+  echo "delta: $n inputs, $fail differing"
+  rm -rf "$WORK"
+  [ "$fail" -eq 0 ] || { echo "PORT DIFFERS FROM THE C ORIGINAL" >&2; return 1; }
+  echo "delta port matches the C original byte for byte"
+}
+
+# A differential test that has never been seen to fail is not evidence. Break
+# the port on purpose and confirm the comparison notices.
+#
+# This is not ceremony: the first input set here looked like a thorough pass at
+# 8/8 matching, but only 1 of those 8 could detect a deliberately broken carry.
+# For random and binary data the compressor finds almost no tables, so
+# undiff_table barely runs and a wrong answer is invisible. The table-shaped
+# inputs in make_inputs.py exist because of that measurement.
+sabotage () {
+  [ -x "$REF" ] || build_ref || return 1
+  build_rs || return 1
+  make_inputs
+  local src="$ROOT/rust/darc-codecs/src/delta.rs" bak="$WORK/delta.rs.bak"
+  cp "$src" "$bak"
+  sed -i.tmp 's|carry = sum >> 8;|carry = 0;|' "$src" && rm -f "$src.tmp"
+  local broken="$RS.broken" res n caught
+  if ( cd "$ROOT/rust/darc-codecs" && cargo build --release ) >/dev/null 2>&1; then
+    clang++ -std=c++17 -O2 -w -DUSE_RUST -DDELTA_LIBRARY -DFREEARC_UNIX \
+      -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT -I Compression -I . \
+      -o "$broken" "$HERE/delta_ref.cpp" Compression/Delta/Delta.cpp Compression/Common.cpp \
+      "$ROOT/rust/darc-codecs/target/release/libdarc_codecs.a" 2>/dev/null
+  fi
+  res=$(compare_with "$broken" quiet); n=${res%% *}; caught=${res##* }
+  cp "$bak" "$src"
+  ( cd "$ROOT/rust/darc-codecs" && cargo build --release ) >/dev/null 2>&1
+  rm -rf "$WORK"
+  echo "sabotage check: $caught of $n inputs detect a broken carry"
+  [ "$caught" -gt 0 ] || { echo "the differential test cannot detect a broken port" >&2; return 1; }
 }
 
 case "${1:-selftest}" in
   build)    build_ref ;;
   selftest) selftest ;;
   diff)     diff_impls ;;
-  *) echo "usage: $0 build|selftest|diff" >&2; exit 2 ;;
+  sabotage) sabotage ;;
+  *) echo "usage: $0 build|selftest|diff|sabotage" >&2; exit 2 ;;
 esac

--- a/rust/difftest/run.sh
+++ b/rust/difftest/run.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Differential-test a ported codec against the C original.
+#
+#   rust/difftest/run.sh build      build the C reference driver
+#   rust/difftest/run.sh selftest   round-trip the C original over sample inputs
+#   rust/difftest/run.sh diff       compare C vs Rust output byte for byte
+#
+# The C original is the oracle. These codecs define the archive format, so a
+# port has to be bit-exact, not merely correct: output that decompresses fine
+# but differs byte-wise produces archives older builds cannot read.
+#
+# Comparing whole archives via Tests/run-tests.sh also catches that, but only
+# one bit of signal per run and only over inputs the corpus happens to contain.
+# Driving the codec directly makes it cheap to throw thousands of inputs at both
+# implementations.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+cd "$ROOT"
+REF=${REF:-/tmp/darc-delta-ref}
+WORK=${WORK:-${TMPDIR:-/tmp}/darc-difftest.$$}
+
+build_ref () {
+  # DELTA_LIBRARY suppresses Delta.cpp's own main(); Common.cpp supplies
+  # MyAlloc/MyFree. Both are easy to omit and produce link errors that look
+  # unrelated to the driver.
+  clang++ -std=c++17 -O2 -w \
+    -DDELTA_LIBRARY -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+    -I Compression -I . \
+    -o "$REF" "$HERE/delta_ref.cpp" Compression/Delta/Delta.cpp Compression/Common.cpp \
+    || { echo "error: failed to build the reference driver" >&2; return 1; }
+  echo "built $REF"
+}
+
+# Inputs chosen to reach different parts of the table detector, not just the
+# easy path: a real binary has genuine relocation tables, the synthetic ones
+# have known column structure, and the degenerate sizes probe the boundaries
+# where this codec family has historically gone wrong (empty, 1 byte, and
+# smaller than one record).
+make_inputs () {
+  mkdir -p "$WORK/in"
+  head -c 200000 /dev/urandom            > "$WORK/in/random.bin"
+  head -c 300000 /bin/bash 2>/dev/null   > "$WORK/in/binary.bin" || \
+    head -c 300000 /bin/sh               > "$WORK/in/binary.bin"
+  : > "$WORK/in/empty.bin"
+  printf 'x'                             > "$WORK/in/one-byte.bin"
+  head -c 7 /dev/urandom                 > "$WORK/in/tiny.bin"
+  python3 -c "
+import struct,sys
+out=bytearray()
+for i in range(5000):
+    out += struct.pack('<IIII', i*4, i*7+100, 0xAABBCCDD, i)
+sys.stdout.buffer.write(bytes(out))"    > "$WORK/in/table16.bin"
+  python3 -c "
+import struct,sys
+out=bytearray()
+for i in range(20000):
+    out += struct.pack('<IIII', i*4, i*8+1000, i*2, 0x11223344)
+sys.stdout.buffer.write(bytes(out))"    > "$WORK/in/table16-wide.bin"
+  python3 -c "
+import sys
+sys.stdout.buffer.write(bytes((i*3+7) % 251 for i in range(100000)))" \
+                                         > "$WORK/in/sawtooth.bin"
+}
+
+selftest () {
+  [ -x "$REF" ] || build_ref || return 1
+  make_inputs
+  local fail=0
+  for f in "$WORK"/in/*; do
+    local n; n=$(wc -c < "$f" | tr -d ' ')
+    if ! "$REF" c >| "$WORK/packed" < "$f" 2>"$WORK/err"; then
+      echo "  $(basename "$f"): compress FAILED ($(tr -d '\n' < "$WORK/err"))"; fail=$((fail+1)); continue
+    fi
+    if ! "$REF" d >| "$WORK/back" < "$WORK/packed" 2>"$WORK/err"; then
+      echo "  $(basename "$f"): decompress FAILED ($(tr -d '\n' < "$WORK/err"))"; fail=$((fail+1)); continue
+    fi
+    if cmp -s "$f" "$WORK/back"; then
+      printf "  %-20s %8s bytes  round-trip OK\n" "$(basename "$f")" "$n"
+    else
+      printf "  %-20s %8s bytes  ROUND-TRIP MISMATCH\n" "$(basename "$f")" "$n"; fail=$((fail+1))
+    fi
+  done
+  rm -rf "$WORK"
+  [ "$fail" -eq 0 ] && echo "reference self-test: all inputs round-trip" \
+                    || { echo "reference self-test: $fail failed" >&2; return 1; }
+}
+
+# Placeholder until a Rust Delta exists. Deliberately fails rather than
+# reporting success on a comparison it never made -- a check that cannot fail
+# is how this branch's Windows CI went green on a binary that did not work.
+diff_impls () {
+  echo "error: no Rust Delta implementation to compare against yet." >&2
+  echo "       Port it, expose it under the same ABI, then run this." >&2
+  return 1
+}
+
+case "${1:-selftest}" in
+  build)    build_ref ;;
+  selftest) selftest ;;
+  diff)     diff_impls ;;
+  *) echo "usage: $0 build|selftest|diff" >&2; exit 2 ;;
+esac

--- a/unix-common.mak
+++ b/unix-common.mak
@@ -3,6 +3,9 @@ DEFINES  = -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER
 ifeq ($(shell getconf LONG_BIT 2>/dev/null),64)
 DEFINES  += -DFREEARC_64BIT
 endif
+# Extra defines threaded in from the compile script (e.g. -DDARC_RUST, which
+# selects the Rust port of a codec). make imports this from the environment.
+DEFINES += $(DARC_EXTRA_DEFINES)
 TEMPDIR  = /tmp/out/FreeArc
 GCC      = clang++ -std=c++17
 ifeq ($(shell pkg-config --exists libcurl 2>/dev/null && echo yes),yes)


### PR DESCRIPTION
Groundwork for porting DArc's codecs to Rust. **No codec is ported yet** — this is the foundation, kept separate so the porting commits stay about algorithms.

## Why Rust here

The defects on the previous branch were concentrated in the C codecs, and most are unrepresentable in safe Rust:

| Defect | Rust |
|---|---|
| GRZip pointer table sized with `sizeof(uint32)` | **caught** — size is tied to type |
| `Dict/FindWord` read one past the end | **caught** — bounds-checked indexing |
| `Dict/phase1` unsigned underflow past the buffer front | **caught** — underflow traps |
| `Dict/phase2` double free after `realloc(p,0)` | **caught** — ownership |
| `GetPhysicalMemory` truncating 16 GB to 0 | *not* caught — `as` truncates silently in Rust too |
| 41 missing `extern "C"`, `long`→`int` truncation | *not* caught — Rust FFI decls are unchecked too |

The last two are why this PR leads with the FFI boundary rather than a codec.

## What's here

**`rust/darc-codecs`** — staticlib exposing the same C ABI as the C originals, so codecs swap in one at a time at link time.

`src/ffi.rs` is the most heavily annotated file in the crate because it is the one part a Rust port does *not* make safe. The declarations aren't written by hand: `build.rs` runs **bindgen** over `Compression/Common.h` and `Compression/Compression.h`, the same headers the C side compiles against.

That caught a real bug on its first run. The hand-written binding declared the callback as a plain `fn` pointer; bindgen types `CALLBACK_FUNC` as `Option<fn>` because C permits null there — and `C_Delta.cpp` explicitly checks for it. Calling through null would have been UB on a path the C code treats as reachable.

Two settings worth review:
- `overflow-checks = true` in release — otherwise Rust wraps silently and reproduces the `filenameHash`/GRZip class rather than trapping.
- `clamp_len` instead of `as c_int` — `as` truncates exactly as C's implicit conversion did.

**`rust/difftest`** — differential harness. These codecs define the archive format, so a port must be bit-exact, not merely correct. It drives a codec directly over an in-memory buffer via the real callback protocol, so thousands of inputs can be compared between C and Rust.

Self-test passes on 8 inputs including empty, 1-byte and 7-byte blocks — every Dict defect on the previous branch was on blocks too small for the code's assumptions.

## Findings that affect the port

**`delta_compress` has C++ linkage** — no `extern "C"` in `Delta.cpp` — so `C_Delta.cpp` links against the mangled name. A Rust `#[no_mangle] extern "C"` symbol will *not* link. Swapping a codec needs `extern "C"` added to the C declarations (linkage-only) or a forwarding shim.

**A coverage check is still owed.** Two attempts to confirm the table-detection path is exercised both gave confident wrong readings — output size can't show it (Delta is a preprocessor, not a compressor) and counting differing bytes reports ~99% for random input because a header shifts everything. Neither affects the harness's actual job, but the coverage question is open.

## Next

Port Delta (673 lines, self-contained, no `qsort` tie-breaking) to prove the swap end to end, then Dict — where three of the previous branch's defects lived. Every port must produce byte-identical archives before the C version is deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)