### PR TITLE
MM: bound the rolz_run byte-refinement loop like its siblings

### DIFF
--- a/Compression/MM/mmdet.cpp
+++ b/Compression/MM/mmdet.cpp
@@ -456,7 +456,22 @@ Model& Model::rolz_run (int hashlog, int hash_row_width)
             if (i == value(p)  &&  value32(p+MinLen-4) == value32(In+MinLen-4)) {
                 len=MinLen;
                 while (In+len <= InEnd  &&  value32(p+len) == value32(In+len))  len+=4;
-                while (In[len] == p[len])  len++;
+                // The byte-refinement loop needs the same InEnd guard the
+                // 4-byte loop above has. Without it, on data where In[len]
+                // keeps matching p[len] to the end of the block (a long run of
+                // identical bytes is enough), len walks past InEnd and reads
+                // beyond buf. Every sibling scanner bounds this the same way --
+                // lzp_run "In+i<InEnd && In[i]==p[i]" (:410), lz77_run
+                // "p+len<bufend && p[len]==q[len]" (:509); rolz_run was the lone
+                // outlier that dropped the guard. p is always an earlier stored
+                // position than In, so bounding In+len bounds p+len too.
+                //
+                // rolz_run is currently dead in the archiver: its only caller
+                // sits behind "#ifndef MMD_LIBRARY" (:1064) and mm.cpp defines
+                // MMD_LIBRARY before including this file, so this fires only in
+                // the standalone mmdet analysis tool. Fixed for correctness and
+                // to keep it from becoming a live bug if it is ever wired in.
+                while (In+len < InEnd  &&  In[len] == p[len])  len++;
                 if (len>best_len)  {best_len=len; best_j=j;}
             }
         }


### PR DESCRIPTION
`Model::rolz_run` extends a match in two loops (`mmdet.cpp`): a 4-byte loop guarded by `In+len <= InEnd`, then a byte loop

```c
while (In[len] == p[len])  len++;
```

with **no bound at all**. On data where `In[len]` keeps matching `p[len]` to the end of the block — a long run of identical bytes is enough — `len` walks past `InEnd` and reads beyond `buf`.

Every sibling scanner in the same file bounds this loop:
- `lzp_run`: `In+i<InEnd && In[i]==p[i]` (`:410`)
- `lz77_run`: `p+len<bufend && p[len]==q[len]` (`:509`)

`rolz_run` was the lone outlier. `p` is always an earlier stored position than `In`, so bounding `In+len` bounds `p+len` too.

## Reachability — read this before assuming severity

`rolz_run` is **currently dead in the archiver**. Its only caller sits behind `#ifndef MMD_LIBRARY` (`mmdet.cpp:1064`), and `mm.cpp` defines `MMD_LIBRARY` before including the file, so it fires only in the standalone `mmdet` analysis tool — never through an archive operation. `mm_compress` does not call it, and there is no external caller.

So this is a **correctness/consistency fix, not a shipped-bug fix**: it makes the tool memory-safe and removes a landmine if `rolz_run` is ever wired into the detector.

## Context

Came out of a sweep for the read-before-bounds idiom fixed three times in Dict (FindWord, phase1, phase7). That exact `do/while` shape did **not** recur elsewhere — Dict was the only instance — but this missing bound is the same failure in a different form. A three-codec-group static audit otherwise found only malformed-input-only decompressor over-reads (a separate, larger hardening class), no other reachable valid-input bug.

## Verification

Because the function is uncalled, the change cannot alter archive bytes — confirmed by the suite: **17/17 round-trip, all fingerprints unchanged**. Builds clean under MicroHs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)