### PR TITLE
REP: bounds-check the decompressor against corrupt input

### DIFF
--- a/Compression/REP/rep.cpp
+++ b/Compression/REP/rep.cpp
@@ -516,6 +516,13 @@ int rep_decompress (unsigned BlockSize, int MinCompression, int MinMatchLen, int
         READ4(ComprSize);
         if (ComprSize == 0)  break;    // EOF flag (see above)
 
+        // ComprSize is read straight from the (possibly corrupt) stream. A
+        // negative value made READ below memcpy a negative -> huge size; a
+        // value too small to hold the block header let the table parsing walk
+        // off the input buffer. The smallest legal block is the num field plus
+        // datalens[0], i.e. 2*sizeof(int32). Reject anything below that.
+        if (ComprSize < (int)(2*sizeof(int32)))  ReturnErrorCode (FREEARC_ERRCODE_BAD_COMPRESSED_DATA);
+
         if (ComprSize > bufsize)
         {
             BigFree(buf0); bufsize=ComprSize; buf0 = (byte*) BigAlloc(bufsize);
@@ -526,21 +533,49 @@ int rep_decompress (unsigned BlockSize, int MinCompression, int MinMatchLen, int
         READ(buf, ComprSize);
 
         // The block header contains the size of the lens/offsets/datalens tables; then come the tables themselves and finally the uncompressed data
+        byte *buf_end  = buf0 + ComprSize;   // end of the input block
+        byte *data_end = data0 + BlockSize;  // end of the output buffer
+
         int         num = *(int32*)buf;  buf += sizeof(int32);           // Number of matches (= the number of entries in the lens/offsets/datalens tables)
+        // num is untrusted. It sizes three tables (lens, offsets: num each;
+        // datalens: num+1) plus the num field itself: sizeof(int32)*(3*num+2)
+        // bytes, which must fit inside the block. Validate it in 64-bit BEFORE
+        // deriving the table pointers, because a corrupt num otherwise overflows
+        // the pointer arithmetic and every datalens[i]/lens[i] read is wild.
+        if (num < 0  ||  (int64)sizeof(int32) * (3*(int64)num + 2) > ComprSize)
+            ReturnErrorCode (FREEARC_ERRCODE_BAD_COMPRESSED_DATA);
         int32*     lens =  (int32*)buf;  buf += num*sizeof(int32);
         int32*  offsets =  (int32*)buf;  buf += num*sizeof(int32);
         int32* datalens =  (int32*)buf;  buf += (num+1)*sizeof(int32);   // More precisely, datalens contains num+1 entries
 
         // Each iteration of this loop copies one block of uncompressed data and one match, which are interleaved in our implementation of the compression process
         for (int i=0; i<num; i++) {
-            memcpy (data, buf, datalens[i]);  buf += datalens[i];  data += datalens[i];
+            // Every copy length is untrusted. Validate the literal against both
+            // the remaining input (buf_end) and the remaining output (data_end),
+            // and the match against the output, before copying -- otherwise a
+            // corrupt datalens[i]/lens[i] overruns the data0 heap block. The
+            // decompressor is fed raw archive bytes, so this fires on ordinary
+            // corruption, not only crafted input (verified: a single flipped
+            // byte in a -mrep archive reached the old unchecked memcpy).
+            int dl = datalens[i];
+            if (dl < 0  ||  dl > buf_end - buf  ||  dl > data_end - data)
+                ReturnErrorCode (FREEARC_ERRCODE_BAD_COMPRESSED_DATA);
+            memcpy (data, buf, dl);  buf += dl;  data += dl;
             debug (verbose>1 && printf ("Match %d %d %d\n", -offsets[i], data-data0, lens[i]));
             // If the offset falls before the start of the buffer, subtract BlockSize from it in order to "wrap" around the buffer boundary
             int offset = offsets[i] <= data-data0 ?  offsets[i] : offsets[i]-BlockSize;
-            memcpy_lz_match (data, data-offset, lens[i]);  data += lens[i];
+            int ln = lens[i];
+            // offset must land the match source inside [data0, data); ln must
+            // keep the destination inside the output buffer.
+            if (offset <= 0  ||  offset > data - data0  ||  ln < 0  ||  ln > data_end - data)
+                ReturnErrorCode (FREEARC_ERRCODE_BAD_COMPRESSED_DATA);
+            memcpy_lz_match (data, data-offset, ln);  data += ln;
         }
         // Plus one more block of uncompressed data at the very end (possibly of zero length)
-        memcpy (data, buf, datalens[num]);  buf += datalens[num];  data += datalens[num];
+        int dl = datalens[num];
+        if (dl < 0  ||  dl > buf_end - buf  ||  dl > data_end - data)
+            ReturnErrorCode (FREEARC_ERRCODE_BAD_COMPRESSED_DATA);
+        memcpy (data, buf, dl);  buf += dl;  data += dl;
 
         // Output the decompressed data, print debug statistics and prepare for the next loop iteration
         WRITE(last_data, data-last_data);


### PR DESCRIPTION
`rep_decompress` read four sizes straight from the compressed stream — `ComprSize`, `num`, and every `datalens[i]`/`lens[i]` — and used them with no bound. The function's own trailing comment admitted it:

```c
// NB! check that buf==buf0+Size, data==data0+UncomprSize,
// and add buffer overflowing checks inside cycle
```

On data the archiver feeds in from a corrupt archive:
- a negative `ComprSize` made `READ` memcpy a negative → huge size;
- a corrupt `num` made the `lens`/`offsets`/`datalens` pointers and every table read walk off the input buffer;
- unchecked `datalens[i]`/`lens[i]` overran the `data0` output heap block — **a write overflow**, the exploitable kind.

## Reachable through `arc t`/`arc x`, not just crafted input

Sweeping every byte of a small `-mrep` archive and flipping it to `0xFF`, **27 of 452 single-byte corruptions** drove the old code into an AddressSanitizer memory error (the rest were caught by the block CRC). Stack: `rep_decompress` ← `REP_METHOD::decompress` ← `arc t`.

## Fix

Validate before use, rejecting a bad block with `FREEARC_ERRCODE_BAD_COMPRESSED_DATA` instead of over-reading/writing:
- `ComprSize` must hold at least the header (`2*sizeof(int32)`); this also rejects negatives — the `(int)` cast matters, an unsigned compare would let a negative through as huge.
- `num` validated in 64-bit against `ComprSize` **before** the table pointers are derived, since huge `num` otherwise overflows the pointer arithmetic itself.
- each literal length checked against both remaining input and remaining output; each match length against remaining output; each match offset kept inside `[data0, data)`.

## Verification

Transparent to valid archives — valid blocks satisfy every bound, so no check fires and the copies are unchanged:

| check | result |
|---|---|
| suite | 17/17, all fingerprints identical (`chain-rep-lzma` exercises this decoder) |
| valid `-mrep` extract | byte-for-byte identical |
| corruption sweep (452 single-byte) after fix | 0 ASan reports (was 27) |
| random multi-byte fuzz (700 iters) | 0 ASan reports |

## Scope

Found by the decompressor-hardening pass from the read-before-bounds sweep. Other codecs (Tornado `len==0`, LZP truncated header, TTA `get_unary`) share the unchecked-stream-length shape and are still to do; REP was the one with a **write** overflow, so it went first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)