### PR TITLE
LZP/GRZip: bound the LZP block decoders against corrupt input

### DIFF
--- a/Compression/GRZip/C_GRZip.cpp
+++ b/Compression/GRZip/C_GRZip.cpp
@@ -248,7 +248,7 @@ sint32 GRZip_DecompressBlock(uint8 * Input,sint32 Size,uint8 * Output)
       memcpy(Output,Input+28,Result);
       return (Result);
     }
-    Result=GRZip_LZP_Decode(Input+28,Result,Output,Get_LZP_MinMatchLen(Mode),Get_LZP_HT_Size(Mode));
+    Result=GRZip_LZP_Decode(Input+28,Result,Output,Get_LZP_MinMatchLen(Mode),Get_LZP_HT_Size(Mode),*(sint32 *)(Input));
     return (Result);
   }
 
@@ -327,7 +327,7 @@ sint32 GRZip_DecompressBlock(uint8 * Input,sint32 Size,uint8 * Output)
 
   if (LZP_Enabled(Mode))
   {
-    sint32 Result=GRZip_LZP_Decode(LZPBuffer,TSize,Output,Get_LZP_MinMatchLen(Mode),Get_LZP_HT_Size(Mode));
+    sint32 Result=GRZip_LZP_Decode(LZPBuffer,TSize,Output,Get_LZP_MinMatchLen(Mode),Get_LZP_HT_Size(Mode),*(sint32 *)(Input));
     if (Result==GRZ_NOT_ENOUGH_MEMORY)
     {
       BigFree(LZPBuffer);

--- a/Compression/GRZip/LZP.c
+++ b/Compression/GRZip/LZP.c
@@ -128,11 +128,20 @@ sint32 GRZip_LZP_Encode(uint8 * Input,uint32 Size,uint8 * Output,uint32 LZP_MinM
 
 #endif  // !defined (FREEARC_DECOMPRESS_ONLY)
 
-sint32 GRZip_LZP_Decode(uint8 * Input,uint32 Size,uint8 * Output,uint32 LZP_MinMatchLen,uint32 LZP_HT_Size)
+sint32 GRZip_LZP_Decode(uint8 * Input,uint32 Size,uint8 * Output,uint32 LZP_MinMatchLen,uint32 LZP_HT_Size,uint32 OutSize)
 {
   LZP_AllocHashTable();
   uint8  * InputEnd=Input+Size;
   uint8  * OutputBeg=Output;
+  uint8  * OutputEnd=Output+OutSize;
+
+  // Input/Output sizes come from a possibly corrupt block header. The header
+  // read/write below touch [0..3] of each buffer, and everything in the loop
+  // is bounded against InputEnd/OutputEnd, so a bad block is rejected instead
+  // of over-reading the input or over-running the output. Valid blocks satisfy
+  // every bound by construction -- OutSize is the block's decompressed size,
+  // which the caller allocated Output to hold -- so this is transparent.
+  if (Size < 4 || OutSize < 4)  { LZP_FreeHashTable(); return (GRZ_UNEXPECTED_EOF); }
 
   *((uint32 *)Output)=*((uint32 *)Input);
   uint32 Ctx=(Input[3]+(Input[2]<<8)+(Input[1]<<16)+(Input[0]<<24));
@@ -149,23 +158,36 @@ sint32 GRZip_LZP_Decode(uint8 * Input,uint32 Size,uint8 * Output,uint32 LZP_MinM
 
     if (Pointer)
      {
-       if ((*Input++)!=LZP_MatchFlag) Ctx=(Ctx<<8)|(*Output++=*(Input-1));
+       if ((*Input++)!=LZP_MatchFlag) {
+         if (Output>=OutputEnd)  { LZP_FreeHashTable(); return (GRZ_UNEXPECTED_EOF); }
+         Ctx=(Ctx<<8)|(*Output++=*(Input-1));
+       }
        else
        {
          uint32 CommonLength=0;
-         while (CommonLength+=((*Input)^LZP_XorFlag),(*Input++)==LZP_RunFlag);
+         // Bound the run-length reader against InputEnd -- it was unbounded and
+         // walked off the input on a truncated/hostile block.
+         while (Input<InputEnd && (CommonLength+=((*Input)^LZP_XorFlag),(*Input++)==LZP_RunFlag));
          if (CommonLength)
           {
             CommonLength=CommonLength+LZP_MinMatchLen-1;
+            // The copy writes CommonLength bytes and reads them from Pointer,
+            // an earlier output position, so bounding the destination bounds
+            // the source too. Reject a length that would run past OutputEnd.
+            if (CommonLength > (uint32)(OutputEnd-Output))  { LZP_FreeHashTable(); return (GRZ_UNEXPECTED_EOF); }
             while (CommonLength--) *Output++=*Pointer++;
             Ctx=(Output[-1]+(Output[-2]<<8)+(Output[-3]<<16)+(Output[-4]<<24));
           }
-         else
+         else {
+          if (Output>=OutputEnd)  { LZP_FreeHashTable(); return (GRZ_UNEXPECTED_EOF); }
           Ctx=(Ctx<<8)|(*Output++=LZP_MatchFlag);
+         }
        }
      }
-    else
+    else {
+      if (Output>=OutputEnd)  { LZP_FreeHashTable(); return (GRZ_UNEXPECTED_EOF); }
       Ctx=(Ctx<<8)|((*Output++)=(*Input++));
+    }
   }
   LZP_FreeHashTable();
   return (Output-OutputBeg);

--- a/Compression/LZP/C_LZP.cpp
+++ b/Compression/LZP/C_LZP.cpp
@@ -97,28 +97,47 @@ MATCH_NOT_FOUND:
 }
 #endif  // !defined (FREEARC_DECOMPRESS_ONLY)
 
-int LZPDecode(BYTE* In,UINT Size,BYTE* Out,int MinLen,int HashSize,int Barrier,int SmallestLen)
+int LZPDecode(BYTE* In,UINT Size,BYTE* Out,int MinLen,int HashSize,int Barrier,int SmallestLen,UINT OutSize)
 {
-    // LZP_INIT reads In[0..15] unconditionally -- the 12-byte header copied to
+    // LZP_INIT reads In[0..11] unconditionally -- the 12-byte header copied to
     // the output plus the first context word. A block shorter than that (a
     // truncated archive is the common way to get one) made it read past the
     // input buffer. Reject it; valid compressed blocks always carry the full
-    // header, so this is transparent to real data. Note this guards only the
-    // header read: fully bounding the match-copy loop below against a crafted
-    // (not merely truncated) block needs the output capacity threaded in and is
-    // deliberately left to a dedicated pass -- see darc-open-work memory.
+    // header, so this is transparent to real data.
     if (Size < 16)  return FREEARC_ERRCODE_BAD_COMPRESSED_DATA;
     LZP_INIT(HashSize,Out);
+    // OutSize is the capacity of the Out buffer. Everything below is bounded
+    // against it and against InEnd so a corrupt or hostile block is rejected
+    // rather than over-reading the input or over-writing the output. Valid
+    // blocks satisfy every bound by construction, so this is transparent.
+    //
+    // The input forward pointer is already safe: In advances by at most one per
+    // iteration (the leftmost "*In++" always runs) and the do/while re-checks
+    // In<InEnd, so it can never pass InEnd. Two things were unbounded -- the
+    // backward length walk (InEnd stepping down with no floor) and the output
+    // writes -- and each gets a bound below. Bounding the output length also
+    // removes a denial-of-service: a match length of 0 made "while(--i)" wrap
+    // to 4G and copy a byte at a time for minutes before finally faulting.
+    BYTE *OutEnd = OutStart + OutSize;
     do {
         p=HTable[k];
         if ( !--n )  { HTable[k]=Out;       n=n1; }
-        if (*In++ != LZP_MATCH_FLAG || i != lzpC(p) || *--InEnd == 255)
+        if (*In++ != LZP_MATCH_FLAG || i != lzpC(p) || *--InEnd == 255) {
+                if (Out >= OutEnd)  {free(HTable); return FREEARC_ERRCODE_BAD_COMPRESSED_DATA;}
                 *Out++ = In[-1];
-        else {
+        } else {
             HTable[k]=Out;                  n1 += (Out-p > (n1+1)*HashSize && n1 < 7);
-            for (i=(Out-p>Barrier? SmallestLen:MinLen)-1;*InEnd == 0;InEnd--)
+            // "InEnd > In" keeps the backward length walk from stepping below
+            // the forward pointer (and thus below the buffer). It never fires
+            // on valid data, whose length bytes always sit above In.
+            for (i=(Out-p>Barrier? SmallestLen:MinLen)-1;InEnd > In && *InEnd == 0;InEnd--)
                     i += 254;
             i += *InEnd;                    k=2*n1+2;
+            // The copy writes i bytes to Out and reads i bytes from p (an
+            // earlier output position, so p+i stays below OutEnd once Out+i
+            // does). Reject i==0 (would wrap --i) and any length that would run
+            // past OutEnd. UINT compare avoids pointer overflow on a huge i.
+            if (i == 0 || i > (UINT)(OutEnd - Out))  {free(HTable); return FREEARC_ERRCODE_BAD_COMPRESSED_DATA;}
             do {
                 if ( !--k ) { k=2*n1+1;     HTable[lzpH(lzpC(Out),Out,HashMask)]=Out; }
                 *Out++ = *p++;
@@ -205,7 +224,7 @@ int lzp_decompress (MemSize BlockSize, int MinCompression, int MinMatchLen, int 
             MALLOC (BYTE, In,  InSize);
             MALLOC (BYTE, Out, BlockSize);
             READ  (In, InSize);
-            OutSize = LZPDecode (In, InSize, Out, MinMatchLen, 1<<HashSizeLog, Barrier, SmallestLen);
+            OutSize = LZPDecode (In, InSize, Out, MinMatchLen, 1<<HashSizeLog, Barrier, SmallestLen, BlockSize);
             if (OutSize < 0)  {errcode = OutSize; goto finished;}   // reject a block LZPDecode refused
             FreeAndNil(In);
             Out = (BYTE*) realloc (Out, OutSize);


### PR DESCRIPTION
Continues the decompressor-hardening pass. Both changes thread the output buffer capacity into the LZP decode function and bound every read/write, rejecting a corrupt block with an error instead of over-reading input or over-running output. Verified by fuzzing `arc t` under ASan, and transparent to valid archives (suite **18/18**, all fingerprints unchanged incl. the new `-mlzp` case).

## LZP (`C_LZP.cpp`, the standalone codec, used by the default build)
`LZPDecode` gained an `OutSize` parameter; it now bounds the backward length-walk against the forward pointer and every write against `OutSize`. This also removes the DoS a previous partial fix left: `len==0` → `while(--i)` wrapping to 4G. **Fuzz: 0 ASan reports** after the fix.

## GRZip (`GRZip_LZP_Decode` + both call sites)
Same treatment — `OutSize` = the block's decompressed size (which the caller already allocated `Output` to hold), run-reader bounded against `InputEnd`, copy against `OutputEnd`.

## Scope — this does NOT finish GRZip

Two known residuals, stated honestly:

- **GRZip is five decoders** (LZP, BWT, ST4, MTF_Ari, WFC_Ari); only the LZP one is bounded here. Fuzzing still reaches an over-read in **`GRZip_WFC_Ari_Decode` (WFC_Ari.c:661)** — the arithmetic decoders take no input-end pointer and stop only on a decoded escape. MTF_Ari and BWT/ST4 are likely the same. A larger separate pass.
- The LZP wrapper can still spend real time on a corrupt stream (re-initialising a hash table per garbage block). Bounded by input size, no longer over-reads; follow-up.

## TTA — attempted and reverted

`-mtta` doesn't round-trip *any* input because the **encoder** is broken: `encode_frame` reads `bit_mask32[33]` out of bounds on ordinary audio (unbounded Rice parameter), a cascade of buffer bugs reachable via `arc a -mtta`. A decoder-hardening change there can't be verified and would ship unverified edits to a codec that already crashes. It needs a dedicated fix of the whole path (or disabling `-mtta`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)