### PR TITLE
arc a -r <dir>: archive that directory, not every one sharing its basename

### DIFF
--- a/FileInfo.hs
+++ b/FileInfo.hs
@@ -443,7 +443,17 @@ find_filter_and_process_files filespecs ff@FileFind{ ff_ep=ep, ff_scan_subdirs=s
             -- Is one of the names given as "dir/"?
             dir_slash    =  dirname>"" && masks `contains` ""
             -- Scan subdirectories if the "-r" option is given or one of the names is given as "dir/"
-            recursive    =  scan_subdirs || dir_slash
+            --
+            -- ...except in the addDir pass. That pass exists only to emit the
+            -- entry for a directory named literally on the command line, and
+            -- that directory sits exactly one level below dirname (the caller
+            -- splits "work/data" into dirname "work" + mask "data"). Letting it
+            -- recurse made the mask match by basename anywhere underneath, so
+            -- "arc a -r arch work/data" also stored an entry for "work/sub/data"
+            -- -- and stored it bare, without its contents, since this pass only
+            -- adds the directory itself. That both archived a directory the user
+            -- never named and leaked the surrounding filesystem layout.
+            recursive    =  not addDir && (scan_subdirs || dir_slash)
             -- Include all files/directories in the list if one of the names is given as "dir/" or "*" or "dir/*"
             include_all  =  dir_slash || masks `contains` reANY_FILE
             -- Predicate determining which files and directories will be included in the list being built:

--- a/Tests/run-tests.sh
+++ b/Tests/run-tests.sh
@@ -41,7 +41,10 @@ esac
 # becomes.
 #
 # The original failure is worth knowing, because it presented as a codec bug.
-# "arc a -r ... $CORPUS" treats the final path component as a mask and searches
+# (The archiver defect behind it is FIXED -- see "recursive" in FileInfo.hs and
+# the -r basename-mask check further down -- but archiving from inside the corpus
+# is kept regardless, since it is also what pins the deterministic scan order.)
+# "arc a -r ... $CORPUS" treated the final path component as a mask and searched
 # for it recursively beneath the corpus's parent -- which was "$HERE". Extraction
 # reproduces the full stored path, so every "$HERE/.work/out-<label>" ended up
 # containing another directory named "corpus", and the next create matched those
@@ -188,6 +191,34 @@ raw "a writing to /tmp"                   a -y -m0 "/tmp/darc-e2-$$.arc" "$WORK/
 rm -f "/tmp/darc-e2-$$.arc"
 raw "t on a non-archive"                  t -y "$WORK/tiny/one.txt"
 raw "lb on a non-archive"                 lb "$WORK/tiny/one.txt"
+
+# "arc a -r <dir>" must archive exactly that directory, not every directory
+# sharing its basename. The final component used to be treated as a mask and
+# matched recursively beneath the *parent*, so naming "w/data" also stored a bare
+# entry for "w/sub/data" -- someone else's directory, without its contents, which
+# both archived something the user never asked for and leaked the surrounding
+# layout. Checked by content, not exit status: the buggy version succeeded.
+echo
+echo "  -r names one directory, not a basename mask:"
+rm -rf "$WORK/rmask"; mkdir -p "$WORK/rmask/w/data" "$WORK/rmask/w/sub/data"
+echo a > "$WORK/rmask/w/data/a.txt"
+echo b > "$WORK/rmask/w/sub/data/b.txt"
+rm -f "$WORK/rmask/r.arc"
+if ( cd "$WORK/rmask" && "$ARC" a -r -y -m0 --nodates r.arc w/data ) >"$WORK/rmask.log" 2>&1; then
+  listing=$("$ARC" l "$WORK/rmask/r.arc" 2>/dev/null)
+  if printf '%s' "$listing" | grep -q "sub/data"; then
+    printf '  %-38s FAIL: also stored w/sub/data\n' "excludes same-named sibling dir"
+  else
+    printf '  %-38s ok\n' "excludes same-named sibling dir"
+  fi
+  if printf '%s' "$listing" | grep -q "data/a.txt"; then
+    printf '  %-38s ok\n' "keeps the named directory's contents"
+  else
+    printf '  %-38s FAIL: lost w/data/a.txt\n' "keeps the named directory's contents"
+  fi
+else
+  printf '  %-38s FAIL: create failed\n' "-r basename-mask check"
+fi
 
 # How far did it get? DArc writes into a temp file and renames on success, so
 # whatever is left behind after the crash bounds the failure point far more


### PR DESCRIPTION
`arc a -r arch.arc w/data` also stored an entry for **`w/sub/data`** — a different directory that merely shares the final path component — and stored it **bare, without its contents**. That archived something the user never named and leaked the surrounding filesystem layout into the archive.

## Cause

A directory filespec triggers two searches (`find_filter_and_process_files`, FileInfo.hs). The caller splits `w/data` into dirname `w` + mask `data`, then runs:

1. one pass with `addDir=True`, to emit the entry for the directory itself
2. a second over `w/data/`, for its contents

Only the second needs to recurse — the directory named on the command line sits exactly one level below `dirname`. But the addDir pass inherited `recursive = scan_subdirs || dir_slash` anyway, so with `-r` it walked **all of `w/`** applying the mask by basename, matching anything called `data` at any depth. And because that pass only adds directory entries, the extra matches were stored contents-less.

## Fix

The addDir pass no longer recurses.

| command | before | after |
|---|---|---|
| `-r arch w/data` | `w/data`, **`w/sub/data`** (bare), `w/data/a.txt` | `w/data` + its contents only |
| `-r arch w/data/` | differed from the above | **identical** to the above |
| `-r arch w` | full recursion | unchanged — `w/sub/data` **with** `b.txt` |
| `-r arch 'w/*'` | full recursion | unchanged |

Naming a directory outright still recurses into it; wildcards are untouched.

## This is the defect the suite has been working around

`Tests/run-tests.sh` archives from *inside* the corpus precisely because `arc a -r ... $CORPUS` matched the corpus name under `$HERE` — so each extracted output directory became another match and the entry count compounded across configurations (228, 290, 482 …) until MicroHs ran out of heap. It presented as a codec bug.

The suite keeps archiving from within the corpus — that is also what pins the deterministic scan order — but the comment no longer describes the archiver bug as live.

## Verification

Adds a behavioural check to the suite. It compares the **listing**, not the exit status, because the buggy version *succeeded*. Verified that it **fails against a pre-fix binary** and passes after — a regression test that can't fail is worthless.

Suite **19/19**, all fingerprints unchanged (the corpus is archived from within, so the fix doesn't move them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)