### PR TITLE
4x4: give the worker threads an explicit stack size

### DIFF
--- a/Compression/4x4/C_4x4.cpp
+++ b/Compression/4x4/C_4x4.cpp
@@ -317,11 +317,30 @@ static int pool_init (_4x4Ctx *c)
   for (int i = 0; i < c->num_jobs; i++)
     c->free_q.put (&c->jobs[i]);
 
-  // Spawn workers
+  // Spawn workers.
+  //
+  // Give them an explicit stack instead of inheriting the platform default,
+  // which differs by an order of magnitude: glibc gives a non-main thread 8MB,
+  // macOS gives it 512KB. These threads run whole codecs -- the inner method of
+  // a "4x4:..." chain executes here, not on the caller's stack -- and some are
+  // stack-hungry. Tornado's decoder overflowed 512KB roughly half the time in an
+  // AddressSanitizer build, whose frames carry redzones, faulting inside
+  // DataTables::add (a leaf function that was merely the call that ran out).
+  // That was the intermittent -m1 failure seen only on macOS, never in Linux CI.
+  // 8MB matches glibc and costs nothing: the mapping is reserved, not committed.
+  pthread_attr_t attr;
+  pthread_attr_t *attrp = NULL;
+  if (pthread_attr_init (&attr) == 0) {
+    if (pthread_attr_setstacksize (&attr, 8*1024*1024) == 0)  attrp = &attr;
+    else                                                      pthread_attr_destroy (&attr);
+  }
+
   c->worker_threads = (pthread_t*) calloc (c->num_workers, sizeof(pthread_t));
   for (int i = 0; i < c->num_workers; i++)
-    pthread_create (&c->worker_threads[i], NULL, worker_thread, c);
-  pthread_create (&c->writer_thread, NULL, writer_thread_fn, c);
+    pthread_create (&c->worker_threads[i], attrp, worker_thread, c);
+  pthread_create (&c->writer_thread, attrp, writer_thread_fn, c);
+
+  if (attrp)  pthread_attr_destroy (attrp);
   return 0;
 }
 


### PR DESCRIPTION
Fixes the intermittent `-m1` suite failure under AddressSanitizer on macOS — a stack overflow that never appeared in Linux CI.

## It was not a Tornado bug

The reported frame was `DataTables::add`, which made it look like one. That is a three-line leaf function; it merely happened to be the call that ran out of stack.

The cause is the **thread** it runs on. 4x4 spawns its own worker pool, and the inner method of a `4x4:…` chain executes there — for `-m1`, Tornado's decoder, whose match handling is stack-hungry:

```
#0 DataTables::add
#1 tor_decompress0<LZ77_Decoder<HuffmanDecoder<832>>>
#5 worker_thread            <- created by pool_init(), 4x4
```

`pool_init` passed a **NULL pthread attr**, so those threads inherited the platform default — and that differs by an order of magnitude: **glibc 8 MB, macOS 512 KB**. An ASan build, whose frames carry redzones, doesn't fit. They now get an explicit 8 MB stack, matching glibc; the mapping is reserved, not committed, so it costs nothing.

## Evidence

Measured on the suite's own corpus, 25 create/test/extract cycles per binary:

| | stack-overflow |
|---|---|
| before | **25/25** |
| after | **0/25** |

Full suite **19/19 on three consecutive runs**. Since the fault was intermittent, one green run would not have been evidence.

The rate varied between runs on identical input (11/25 in an earlier sample, 25/25 later), so it tracks **machine load**, not the data — which is why it presented as random.

## Deliberately not changed, having tested both

- **`Environment.cpp`'s pipeline threads** have the same NULL attr and also run codecs, so an equivalent patch looked justified. It isn't: `-mtor`, which puts Tornado on those threads instead of 4x4's, overflows **0/25** on an unfixed binary. I wrote that patch first, measured it, and reverted it — without a reproduction it's an unjustified change to threading behaviour.
- **`CThread::Create`** (`LZMA/Windows/Thread.h`) inits an attr without setting a stack size, and GRZip's decompression threads use it. Fuzzing GRZip never produced a stack overflow, and it's vendored code the repo keeps pristine for re-syncing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)