### PR TITLE
LZP: record what the per-block hash table costs, and why it stays

### DIFF
--- a/Compression/LZP/C_LZP.cpp
+++ b/Compression/LZP/C_LZP.cpp
@@ -209,6 +209,38 @@ int lzp_decompress (MemSize BlockSize, int MinCompression, int MinMatchLen, int 
     int errcode = FREEARC_OK;   // Error code returned by last operation or FREEARC_OK
     BYTE* In = NULL;  // pointer to the input data
     BYTE* Out= NULL;  // pointer to the output data
+
+    // Known and accepted: cost per block is dominated by the hash table, not by
+    // the block. LZP_INIT allocates HashSize pointers and fills every one of
+    // them, so at the default HashSizeLog=18 each block pays for a 2MB table
+    // regardless of how little data it carries. Real streams have few large
+    // blocks and this amortises away; a *hostile* stream can instead be built
+    // from thousands of 20-byte blocks (4-byte length + a 16-byte payload, the
+    // smallest LZPDecode accepts) and make the decoder do that work over and
+    // over.
+    //
+    // Measured rather than assumed, because it first showed up as a suspected
+    // denial of service:
+    //   - ordinary corruption costs nothing. 120 randomly damaged -mlzp archives
+    //     in a release build: median 0.14s, max 0.30s, against a 0.16s baseline
+    //     for the same archive undamaged. A damaged stream desynchronises and is
+    //     rejected long before it can spend real time here.
+    //   - the earlier 6-10s figures came from an AddressSanitizer build, which
+    //     instruments every store in the fill loop. That was measurement
+    //     overhead, not behaviour.
+    //   - a deliberately crafted stream costs ~0.05ms per block, i.e. about
+    //     2.6s of CPU per megabyte of input, linear. Roughly 40x the per-byte
+    //     cost of valid data, and bounded by the input size.
+    //
+    // Not fixed on purpose. Hoisting the allocation out of this loop is the
+    // tempting change and buys almost nothing: the fill loop dominates, not
+    // malloc. Making it genuinely cheap needs a generation counter in the table
+    // so a block can reset it in O(1), which rewrites the inner loop of a
+    // decoder that is correct, format-transparent and fuzz-clean today. That is
+    // a poor trade for a linear 40x factor on a hand-built file. If it is ever
+    // worth doing, do it on its own with before/after throughput numbers for the
+    // valid path -- do not bolt a size heuristic onto the block loop instead,
+    // since a small final block is perfectly legitimate.
     for(;;) {
         int InSize, OutSize;     // number of bytes in the input and output buffers, respectively
         READ4_OR_EOF (InSize);


### PR DESCRIPTION
Closes the last open item from the decompressor-hardening work — as a **documented characteristic, not a defect**. Comment only, no behaviour change, suite 19/19.

The suspicion was that a corrupt stream could make `lzp_decompress` burn CPU: every block pays `LZP_INIT`, which allocates `HashSize` pointers and fills all of them, so at the default `HashSizeLog=18` a block costs a **2 MB table** however little data it carries.

## Measured instead of assumed

| case | cost |
|---|---|
| undamaged archive (baseline) | 0.16s |
| **120 randomly damaged archives**, release build | median **0.14s**, max **0.30s** |
| crafted stream of 20-byte blocks | ~0.05 ms/block ≈ **2.6s CPU per MB**, linear |

Two things worth recording:

- **Ordinary corruption costs nothing.** A damaged stream desynchronises and is rejected long before it can spend time here.
- **The original 6–10s figures were an AddressSanitizer artifact** — it instruments every store in the fill loop. That is measurement overhead, not behaviour, and it is why this looked far worse than it is.

The crafted case is real but linear: ~40× valid data's per-byte cost, bounded by input size. Not zip-bomb class, and it requires a deliberately constructed file.

## Why it stays

Hoisting the allocation out of the block loop is the obvious change and **buys almost nothing** — the fill loop dominates, not `malloc`.

Making it genuinely cheap needs a generation counter in the table so a block resets in O(1). That rewrites the inner loop of a decoder that is currently correct, format-transparent and fuzz-clean — a poor trade for a linear 40× factor on a hand-built file. If it's ever worth doing, it wants its own change with before/after throughput on the valid path.

The comment also warns against the wrong fix: don't bolt a block-size heuristic onto the loop, because a **small final block is legitimate**.

Written into the source rather than only into notes, because the next reader will see the ASan timings and reach the same wrong conclusion I did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)