### PR TITLE
MM/TTA: fix the WAV header struct on 64-bit, so detection works at all

### DIFF
--- a/Compression/MM/mmdet.cpp
+++ b/Compression/MM/mmdet.cpp
@@ -626,16 +626,23 @@ default:
 // WAV header recognition
 int autodetect_wav_header (void *buf, long size, int *is_float, int *num_chan, int *word_size, int *offset)
 {
+    // Every one of these is a 32-bit field in the RIFF/WAVE layout. They were
+    // declared "unsigned long", which is 8 bytes on LP64, so on any 64-bit build
+    // the struct did not match the file at all: each field read picked up
+    // adjacent bytes and detection failed for every WAV ever passed in. TTA then
+    // fell back to autodetect_by_entropy, which guesses 8- and 16-bit right and
+    // therefore hid the breakage -- but not 24-bit or 32-bit float, which were
+    // silently stored instead of compressed.
     struct wave_hdr_t {
-        unsigned long   ChunkID;
-        unsigned long   ChunkSize;
-        unsigned long   Format;
-        unsigned long   Subchunk1ID;
-        unsigned long   Subchunk1Size;
+        uint32          ChunkID;
+        uint32          ChunkSize;
+        uint32          Format;
+        uint32          Subchunk1ID;
+        uint32          Subchunk1Size;
         unsigned short  AudioFormat;
         unsigned short  NumChannels;
-        unsigned long   SampleRate;
-        unsigned long   ByteRate;
+        uint32          SampleRate;
+        uint32          ByteRate;
         unsigned short  BlockAlign;
         unsigned short  BitsPerSample;
     } *wave_hdr = (wave_hdr_t*)buf;
@@ -667,9 +674,9 @@ int autodetect_wav_header (void *buf, long size, int *is_float, int *num_chan, i
     }
 
     // Skip any extra subchunks and header of wave data subchunk itself
-    struct subchunk_hdr {
-        unsigned long   SubchunkID;
-        unsigned long   SubchunkSize;
+    struct subchunk_hdr {   // also 32-bit fields; see above
+        uint32          SubchunkID;
+        uint32          SubchunkSize;
     };
 
     if (sizeof(subchunk_hdr) >= (BYTE*)buf+size-p)   return 0;  // detection fails


### PR DESCRIPTION
`autodetect_wav_header` has **never once succeeded on a 64-bit build**.

Its `wave_hdr_t` declares the RIFF/WAVE fields as `unsigned long`. Every one of them is **32 bits in the file format**, while `unsigned long` is **8 bytes on LP64** — so the struct doesn't overlay the file. Each field read picks up adjacent bytes, the signature checks fail, and it returns "not a WAV" for every input.

Probing the function directly:

```
before:  st16 detect=0   st8 detect=0   st24 detect=0   f32 detect=0
after:   st16 detect=1  2ch 16bit  offset=44
         st8  detect=1  2ch  8bit  offset=44
         st24 detect=1  2ch 24bit  offset=44
         f32  detect=1  float 2ch 32bit offset=46   <- extra cbSize handled
         (+ a file with a JUNK chunk before "data": offset=54, skipped correctly)
```

## Why it stayed hidden

TTA falls back to `autodetect_by_entropy`, which guesses 8- and 16-bit correctly. Those kept compressing, so the detector looked fine. **24-bit and 32-bit float are what the entropy analyser doesn't recognise** — and they were silently *stored* instead of compressed. Lossless, but pointless.

| real WAV file | before | after |
|---|---|---|
| 24-bit stereo | 1.001 | **0.479** |
| 32-bit float | 1.000 | **0.642** |
| 16-bit stereo / mono, 8-bit | 0.501 / 0.527 / 0.229 | unchanged |

## Same mistake, third time in this codec

2002-era code written when `long` was 32 bits, silently mis-executed by every 64-bit build since — after the entropy coder and the filter.

It went unnoticed because **nothing exercised it**: raw PCM has no RIFF header, and passing explicit parameters (`-mtta:c2:w24`) bypasses detection entirely. Both of the ways TTA had been tested skipped this path. It only appears with an actual WAV file.

## Scope

`mmdet.cpp` is shared, so **MM's `detect_mm_header` was equally blind to WAV headers** and gains the same fix.

No archive format change — what a stream was compressed with is recorded in it, so existing archives still decode; only the choice made for newly created ones improves. Suite **19/19 with every fingerprint unchanged** (the corpus contains no WAV data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)