### PR TITLE
Build and ship Windows ARM64 release binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -264,9 +264,9 @@ jobs:
       run: |
         chmod +x compile-win64-c compile-mhs-win64
         DARC_WIN_ARCH=aarch64 ./compile-mhs-win64
-    # compile-mhs-win64 already checks the PE machine field, which is the only
-    # thing that tells an ARM64 image apart from an x86-64 one -- `file` calls
-    # both "PE32+ executable (console)".
+    # compile-mhs-win64 already checks the PE machine field against the
+    # requested architecture, so a build that silently fell back to the host
+    # toolchain fails there rather than being uploaded here.
     - uses: actions/upload-artifact@v4
       with:
         name: arc-win-arm64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,6 +214,84 @@ jobs:
         chmod +x Tests/win-test.sh
         Tests/win-test.sh
 
+  # ── Windows on ARM64 ────────────────────────────────────────────────────────
+  # Split across two jobs because neither half can be done alone:
+  #
+  #   build   Debian's mingw-w64 packages x86_64 and i686 only, so this target
+  #           needs llvm-mingw (Clang). Cross-compiling from Linux is the only
+  #           option -- MicroHs would otherwise have to be bootstrapped on the
+  #           Windows runner.
+  #   test    Wine has no ARM64 emulation, so unlike windows-cross above there
+  #           is no way to exercise the result on the machine that built it.
+  #
+  # The upside of that constraint is that this target gets tested on real
+  # hardware rather than on Wine, which is the stronger of the two checks.
+  windows-arm64-cross:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6.0.2
+      with:
+        lfs: false
+    - name: Install llvm-mingw
+      run: |
+        set -euo pipefail
+        # Pinned with a checksum for the same reason MicroHs is: the compiler is
+        # part of what produces the shipped binary, so it should not drift
+        # underneath us between runs.
+        ver="20260616"
+        tarball="llvm-mingw-$ver-ucrt-ubuntu-22.04-x86_64.tar.xz"
+        sha256="534b92e067b22a6b4441f48ae9240a3341b17825d04d577eab0cf85c44b4deda"
+        curl -fsSL "https://github.com/mstorsjo/llvm-mingw/releases/download/$ver/$tarball" -o /tmp/"$tarball"
+        echo "$sha256  /tmp/$tarball" | sha256sum -c -
+        tar -xJf /tmp/"$tarball" -C /opt
+        echo "/opt/llvm-mingw-$ver-ucrt-ubuntu-22.04-x86_64/bin" >> "$GITHUB_PATH"
+    - name: Install packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends cpphs
+    - name: Install MicroHs
+      run: |
+        microhs_sha="05a3fbd5d73ae6a37111a6ced5b57bb1717b8975"
+        microhs_tar="/tmp/microhs.tar.gz"
+        microhs_expected_sha256="a1f85821cbae877d0ea3e173235d45c833d9145b2ca9e92e77d284b6730c63b6"
+        curl -fsSL "https://github.com/augustss/MicroHs/archive/$microhs_sha.tar.gz" -o "$microhs_tar"
+        echo "$microhs_expected_sha256  $microhs_tar" | sha256sum -c -
+        tar -xzf "$microhs_tar" -C /tmp
+        cd "/tmp/MicroHs-$microhs_sha"
+        make minstall
+        echo "$HOME/.mcabal/bin" >> "$GITHUB_PATH"
+    - name: Build (Windows ARM64 cross)
+      run: |
+        chmod +x compile-win64-c compile-mhs-win64
+        DARC_WIN_ARCH=aarch64 ./compile-mhs-win64
+    # compile-mhs-win64 already checks the PE machine field, which is the only
+    # thing that tells an ARM64 image apart from an x86-64 one -- `file` calls
+    # both "PE32+ executable (console)".
+    - uses: actions/upload-artifact@v4
+      with:
+        name: arc-win-arm64
+        path: Tests/arc-mhs-win-arm64.exe
+        if-no-files-found: error
+
+  windows-arm64-test:
+    needs: windows-arm64-cross
+    runs-on: windows-11-arm
+    steps:
+    - uses: actions/checkout@v6.0.2
+      with:
+        lfs: false
+    - uses: actions/download-artifact@v4
+      with:
+        name: arc-win-arm64
+        path: Tests
+    # Git Bash, so the same script that runs under Wine on Linux runs here with
+    # the Wine prefix dropped.
+    # Invoked through bash rather than directly: a Windows checkout does not
+    # preserve the executable bit.
+    - name: Smoke-test on native ARM64 Windows
+      shell: bash
+      run: bash Tests/win-test.sh Tests/arc-mhs-win-arm64.exe
+
   # ── Rust codec ports ────────────────────────────────────────────────────────
   # Two things are checked, and they are not the same thing:
   #

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,11 @@ name: Release
 # against a different compiler revision than CI validates would be a silent
 # difference between what is tested and what is shipped.
 #
-# Windows arm64 is absent on purpose: Debian's mingw-w64 provides x86_64 and
-# i686 only, and compile-mhs-win64 is written against the x86_64 triplet, so
-# that target needs llvm-mingw and a reworked script rather than another matrix
-# entry. Tracked as follow-up work.
+# The two Windows targets use different toolchains -- Debian's mingw-w64 (GCC)
+# for amd64, llvm-mingw (Clang) for arm64, because Debian packages x86_64 and
+# i686 only -- and are verified differently: amd64 under Wine on the runner
+# that built it, arm64 on a real windows-11-arm runner, since Wine has no ARM64
+# emulation. publish waits on both.
 
 on:
   push:
@@ -132,10 +133,26 @@ jobs:
         path: dist/*
         if-no-files-found: error
 
-  # ── Windows amd64, cross-compiled from Linux ────────────────────────────────
+  # ── Windows, cross-compiled from Linux ──────────────────────────────────────
+  # amd64 uses Debian's mingw-w64 (GCC); arm64 uses llvm-mingw (Clang), because
+  # Debian packages x86_64 and i686 only. See compile-win64-c.
+  #
+  # amd64 is smoke-tested here under Wine. arm64 cannot be -- Wine has no ARM64
+  # emulation -- so it is verified on a real ARM64 Windows runner in the
+  # windows-arm64-verify job below, which publish waits for.
   windows-cross:
-    name: windows-amd64
+    name: ${{ matrix.label }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            label: windows-amd64
+            exe: arc-mhs-win64.exe
+          - arch: aarch64
+            label: windows-arm64
+            exe: arc-mhs-win-arm64.exe
     steps:
     - uses: actions/checkout@v6.0.2
       with:
@@ -143,9 +160,26 @@ jobs:
         ref: ${{ github.event.inputs.tag || github.ref }}
 
     - name: Install cross toolchain and Wine
+      if: matrix.arch == 'x86_64'
       run: |
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends mingw-w64 mingw-w64-tools cpphs wine64 wine
+
+    - name: Install llvm-mingw
+      if: matrix.arch == 'aarch64'
+      run: |
+        set -euo pipefail
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends cpphs
+        # Pinned with a checksum for the same reason MicroHs is: the compiler is
+        # part of what produces the shipped binary.
+        ver="20260616"
+        tarball="llvm-mingw-$ver-ucrt-ubuntu-22.04-x86_64.tar.xz"
+        sha256="534b92e067b22a6b4441f48ae9240a3341b17825d04d577eab0cf85c44b4deda"
+        curl -fsSL "https://github.com/mstorsjo/llvm-mingw/releases/download/$ver/$tarball" -o /tmp/"$tarball"
+        echo "$sha256  /tmp/$tarball" | sha256sum -c -
+        tar -xJf /tmp/"$tarball" -C /opt
+        echo "/opt/llvm-mingw-$ver-ucrt-ubuntu-22.04-x86_64/bin" >> "$GITHUB_PATH"
 
     - name: Install MicroHs
       run: |
@@ -160,13 +194,24 @@ jobs:
     - name: Build (Windows cross)
       run: |
         chmod +x compile-win64-c compile-mhs-win64
-        ./compile-mhs-win64
+        DARC_WIN_ARCH=${{ matrix.arch }} ./compile-mhs-win64
 
+    # compile-mhs-win64 checks the PE machine field itself, which is the only
+    # thing that distinguishes these two artifacts -- `file` reports both as
+    # "PE32+ executable (console)", so a build that silently fell back to the
+    # wrong toolchain would pass a `file` check.
     - name: Verify binary
       run: |
-        exe=Tests/arc-mhs-win64.exe
-        test -s "$exe" || { echo "::error::no $exe"; exit 1; }
-        file "$exe" | grep -qi "PE32+" || { echo "::error::not a PE32+ binary"; exit 1; }
+        test -s "Tests/${{ matrix.exe }}" || { echo "::error::no Tests/${{ matrix.exe }}"; exit 1; }
+        echo "binary: $(wc -c < "Tests/${{ matrix.exe }}") bytes"
+
+    # Only amd64 can be exercised on this runner. arm64 is exercised on real
+    # hardware in windows-arm64-verify below.
+    - name: Smoke-test under Wine
+      if: matrix.arch == 'x86_64'
+      run: |
+        chmod +x Tests/win-test.sh
+        Tests/win-test.sh "Tests/${{ matrix.exe }}"
 
     - name: Package
       run: |
@@ -179,9 +224,9 @@ jobs:
           ver="$GITHUB_REF_NAME"
         fi
         ver="${ver#v}"
-        stage="darc-$ver-windows-amd64"
+        stage="darc-$ver-${{ matrix.label }}"
         mkdir -p "dist/$stage"
-        cp Tests/arc-mhs-win64.exe "dist/$stage/arc.exe"
+        cp "Tests/${{ matrix.exe }}" "dist/$stage/arc.exe"
         cp Tests/arc.groups "dist/$stage/arc.groups"
         cp README.md LICENSE "dist/$stage/" 2>/dev/null || true
         (cd dist && zip -r "$stage.zip" "$stage" >/dev/null)
@@ -190,13 +235,43 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: windows-amd64
+        name: ${{ matrix.label }}
         path: dist/*
         if-no-files-found: error
 
+  # ── Exercise the ARM64 Windows artifact on real ARM64 Windows ───────────────
+  # publish waits on this, so an arm64 binary that builds but cannot create an
+  # archive never reaches the release. It unpacks the artifact that will
+  # actually be uploaded rather than rebuilding, so what runs is what ships.
+  windows-arm64-verify:
+    needs: windows-cross
+    runs-on: windows-11-arm
+    steps:
+    - uses: actions/checkout@v6.0.2
+      with:
+        lfs: false
+        ref: ${{ github.event.inputs.tag || github.ref }}
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: windows-arm64
+        path: dist
+
+    - name: Unpack and smoke-test
+      shell: bash
+      run: |
+        set -euo pipefail
+        zip=$(ls dist/*.zip)
+        unzip -q "$zip" -d unpacked
+        exe=$(ls unpacked/*/arc.exe)
+        echo "testing $exe from $zip"
+        # Invoked through bash rather than directly: a Windows checkout does not
+        # preserve the executable bit.
+        bash Tests/win-test.sh "$exe"
+
   # ── Attach everything to the release ────────────────────────────────────────
   publish:
-    needs: [ build, windows-cross ]
+    needs: [ build, windows-cross, windows-arm64-verify ]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,10 +196,10 @@ jobs:
         chmod +x compile-win64-c compile-mhs-win64
         DARC_WIN_ARCH=${{ matrix.arch }} ./compile-mhs-win64
 
-    # compile-mhs-win64 checks the PE machine field itself, which is the only
-    # thing that distinguishes these two artifacts -- `file` reports both as
-    # "PE32+ executable (console)", so a build that silently fell back to the
-    # wrong toolchain would pass a `file` check.
+    # compile-mhs-win64 checks the PE machine field against the requested
+    # architecture, so a build that silently fell back to the wrong toolchain
+    # fails there. Note the old `file ... | grep PE32+` check here could not
+    # have caught it: that string is identical for both targets.
     - name: Verify binary
       run: |
         test -s "Tests/${{ matrix.exe }}" || { echo "::error::no Tests/${{ matrix.exe }}"; exit 1; }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,16 @@ The codebase is roughly half Haskell (application logic, archive format, UI) and
 ./compile-ghc         # console binary  -> Tests/arc-ghc  (GHC 9.4.7+, Linux x64)
 ./compile-mhs-win64   # cross-compile   -> Tests/arc-mhs-win64.exe (mingw-w64)
 make clean            # remove object files from all tempdirs
+
+# Windows on ARM64. Same script, different toolchain: Debian's mingw-w64
+# packages x86_64 and i686 only, so this target needs llvm-mingw (Clang) on
+# PATH -> Tests/arc-mhs-win-arm64.exe
+DARC_WIN_ARCH=aarch64 ./compile-mhs-win64
 ```
+
+`DARC_WIN_ARCH` (`x86_64` by default, or `aarch64`) is read by both `compile-mhs-win64` and `compile-win64-c` and picks the cross toolchain, the target Windows version and the output name. Clang needs two flags GCC does not — see the `cc_quirks` block in `compile-mhs-win64` for what each is for. `compile-ghc-win64` is x86-64 only; there is no GHC bindist for this target.
+
+Since Wine has no ARM64 emulation, the ARM64 binary cannot be exercised on the machine that cross-builds it. CI runs `Tests/win-test.sh` against it on a real `windows-11-arm` runner instead, and the release workflow's `publish` job waits on that result. `win-test.sh` detects whether it is on Windows or on a Unix host and adds Wine only in the latter case; it works in relative paths throughout, because MSYS rewrites POSIX-looking arguments before handing them to a native `.exe`.
 
 Binaries land in `Tests/`, which despite the name is a build *output* directory, not a test suite — it holds the produced binaries (gitignored via `Tests/*arc`) alongside the committed `arc.groups` solid-ordering config.
 

--- a/Tests/win-test.sh
+++ b/Tests/win-test.sh
@@ -64,7 +64,13 @@ if [ -n "$WINE" ]; then
   wine --version 2>&1 | head -1
   wineboot -i >/dev/null 2>&1 || true      # first run initialises the prefix
 else
-  echo "native Windows (${PROCESSOR_ARCHITECTURE:-unknown})"
+  # PROCESSOR_ARCHITECTURE is per-process, not per-machine: Git Bash is an x64
+  # binary and runs emulated on an ARM64 host, where it reports "AMD64" and
+  # Windows puts the real answer in PROCESSOR_ARCHITEW6432. Reporting the
+  # process architecture here would invite exactly the wrong conclusion from a
+  # green log. (The run itself is not in doubt either way -- x64 Windows cannot
+  # execute an ARM64 image at all, so getting this far already proves the host.)
+  echo "native Windows (${PROCESSOR_ARCHITEW6432:-${PROCESSOR_ARCHITECTURE:-unknown}})"
 fi
 echo "exe: $EXE"
 echo

--- a/Tests/win-test.sh
+++ b/Tests/win-test.sh
@@ -64,15 +64,37 @@ if [ -n "$WINE" ]; then
   wine --version 2>&1 | head -1
   wineboot -i >/dev/null 2>&1 || true      # first run initialises the prefix
 else
-  # PROCESSOR_ARCHITECTURE is per-process, not per-machine: Git Bash is an x64
-  # binary and runs emulated on an ARM64 host, where it reports "AMD64" and
-  # Windows puts the real answer in PROCESSOR_ARCHITEW6432. Reporting the
-  # process architecture here would invite exactly the wrong conclusion from a
-  # green log. (The run itself is not in doubt either way -- x64 Windows cannot
-  # execute an ARM64 image at all, so getting this far already proves the host.)
-  echo "native Windows (${PROCESSOR_ARCHITEW6432:-${PROCESSOR_ARCHITECTURE:-unknown}})"
+  echo "native Windows"
 fi
-echo "exe: $EXE"
+
+# Which architecture is under test, read out of the PE header rather than
+# guessed from the environment.
+#
+# The obvious-looking $PROCESSOR_ARCHITECTURE is wrong here: it is per-process,
+# and Git Bash is an x64 binary that runs emulated on an ARM64 host, so it
+# reports "AMD64" on an ARM64 runner. PROCESSOR_ARCHITEW6432 does not rescue
+# it either -- that one is specific to 32-bit-on-64-bit WOW64 and is unset
+# under x64-on-ARM64 emulation. And what the reader wants is the architecture
+# of the *binary* anyway, which is the thing being claimed.
+#
+# `file` would report it, but it is not installed everywhere -- which is the
+# same reason the MZ check in compile-mhs-win64 is open-coded. Little-endian
+# fields assembled a byte at a time, so this does not depend on the byte order
+# of the host either. e_lfanew sits at 0x3c; the machine word is 4 bytes past
+# the "PE\0\0" signature it points at.
+read_le () {  # read_le <byte-offset> <length> -> decimal value
+  local byte value=0 shift_by=0
+  for byte in $(od -An -tu1 -j "$1" -N "$2" "$EXE"); do
+    value=$(( value + byte * (1 << shift_by) )); shift_by=$(( shift_by + 8 ))
+  done
+  echo "$value"
+}
+case "$(printf '0x%04x' "$(read_le $(( $(read_le 60 4) + 4 )) 2)")" in
+  0x8664) arch_name="x86-64" ;;
+  0xaa64) arch_name="ARM64"  ;;
+  *)      arch_name="unrecognised PE machine" ;;
+esac
+echo "exe: $EXE ($arch_name)"
 echo
 
 rm -rf "$WORK"; mkdir -p "$WORK/in/sub"

--- a/Tests/win-test.sh
+++ b/Tests/win-test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Smoke-test the cross-built Windows binary under Wine.
+# Smoke-test a Windows binary, either under Wine on a Unix host or natively on
+# Windows itself.
 #
 # A PE header only proves the toolchain was wired up correctly. The first
 # working cross-build produced a valid PE32+ image that printed its help and
@@ -16,82 +17,115 @@ set -uo pipefail
 
 EXE=${1:-Tests/arc-mhs-win64.exe}
 
-# Wine refuses to create its configuration directory when the parent is not
-# owned by the current user, which is the case for /tmp on the CI runners:
-#   wine: '/tmp' is not owned by you, refusing to create a configuration directory there
-# Keep the prefix under HOME, which is always ours.
-export WINEDEBUG=${WINEDEBUG:--all}
-export WINEPREFIX=${WINEPREFIX:-$HOME/.darc-wineprefix}
+[ -f "$EXE" ] || { echo "error: $EXE not found -- run ./compile-mhs-win64 first" >&2; exit 2; }
+
+# Everything below runs from a scratch directory using *relative* paths. That is
+# not tidiness: MSYS/Git-Bash rewrites POSIX-looking arguments into Windows
+# paths before handing them to a native .exe, and "-dp/tmp/whatever" is exactly
+# the shape that mangling trips over. Relative arguments pass through untouched,
+# so one command line works under both Wine and Windows -- and the extracted
+# tree then lands somewhere predictable instead of at a location derived from
+# the absolute path of the source tree.
+case "$EXE" in
+  /*) ;;
+  *)  EXE="$PWD/$EXE" ;;
+esac
+
+# On Windows the binary is native and runs directly; anywhere else it needs Wine.
+case "${OSTYPE:-}" in
+  msys*|cygwin*|win32*) WINE="" ;;
+  *)                    WINE="wine" ;;
+esac
+
+if [ -n "$WINE" ]; then
+  command -v "$WINE" >/dev/null 2>&1 || { echo "error: wine not found in PATH" >&2; exit 2; }
+  # Wine refuses to create its configuration directory when the parent is not
+  # owned by the current user, which is the case for /tmp on the CI runners:
+  #   wine: '/tmp' is not owned by you, refusing to create a configuration directory there
+  # Keep the prefix under HOME, which is always ours.
+  export WINEDEBUG=${WINEDEBUG:--all}
+  export WINEPREFIX=${WINEPREFIX:-$HOME/.darc-wineprefix}
+fi
+
+# Invoke the binary the way this host requires. A function rather than an array
+# because macOS ships bash 3.2, where expanding an *empty* array under `set -u`
+# is an "unbound variable" error.
+run_arc () {
+  if [ -n "$WINE" ]; then "$WINE" "$EXE" "$@"; else "$EXE" "$@"; fi
+}
 
 WORK=${WORK:-${TMPDIR:-/tmp}/darc-win-test.$$}
-
-[ -f "$EXE" ] || { echo "error: $EXE not found -- run ./compile-mhs-win64 first" >&2; exit 2; }
-command -v wine >/dev/null 2>&1 || { echo "error: wine not found in PATH" >&2; exit 2; }
 
 fail=0
 note_fail () { echo "  $*"; fail=$((fail+1)); }
 
-echo "--- wine ---"
-wine --version 2>&1 | head -1
-wineboot -i >/dev/null 2>&1 || true      # first run initialises the prefix
+echo "--- host ---"
+if [ -n "$WINE" ]; then
+  wine --version 2>&1 | head -1
+  wineboot -i >/dev/null 2>&1 || true      # first run initialises the prefix
+else
+  echo "native Windows (${PROCESSOR_ARCHITECTURE:-unknown})"
+fi
+echo "exe: $EXE"
 echo
 
+rm -rf "$WORK"; mkdir -p "$WORK/in/sub"
+cd "$WORK" || { echo "error: cannot enter $WORK" >&2; exit 2; }
+
 echo "--- arc --help ---"
-if wine "$EXE" --help > "$WORK.help" 2> "$WORK.help.err"; then
-  if grep -qi 'command' "$WORK.help"; then
+if run_arc --help > help.out 2> help.err; then
+  if grep -qi 'command' help.out; then
     echo "  help output looks right"
   else
     note_fail "no recognisable help output"
-    head -5 "$WORK.help" "$WORK.help.err" | sed 's/^/     /'
+    head -5 help.out help.err | sed 's/^/     /'
   fi
 else
   note_fail "--help exited $?"
-  head -5 "$WORK.help" "$WORK.help.err" | sed 's/^/     /'
+  head -5 help.out help.err | sed 's/^/     /'
 fi
 echo
 
 echo "--- round-trip a small tree ---"
-rm -rf "$WORK"; mkdir -p "$WORK/in/sub"
-echo "hello windows"            > "$WORK/in/a.txt"
-printf 'binary\x00\x01\x02data' > "$WORK/in/sub/b.bin"
-head -c 20000 /dev/urandom      > "$WORK/in/big.bin"
+echo "hello windows"            > in/a.txt
+printf 'binary\x00\x01\x02data' > in/sub/b.bin
+head -c 20000 /dev/urandom      > in/big.bin
 
 for m in -m0 -m1 -m4; do
-  out="$WORK/out$m"
-  rm -rf "$out"; mkdir -p "$out"; rm -f "$WORK/t.arc"
+  out="out$m"
+  rm -rf "$out"; mkdir -p "$out"; rm -f t.arc
 
-  if ! wine "$EXE" a --nodates -r -y $m "$WORK/t.arc" "$WORK/in" > "$WORK/c.log" 2>&1; then
-    note_fail "$m: create failed"; tail -3 "$WORK/c.log" | sed 's/^/     /'; continue
+  if ! run_arc a --nodates -r -y $m t.arc in > c.log 2>&1; then
+    note_fail "$m: create failed"; tail -3 c.log | sed 's/^/     /'; continue
   fi
-  if ! wine "$EXE" t -y "$WORK/t.arc" > "$WORK/t.log" 2>&1; then
-    note_fail "$m: integrity test failed"; tail -3 "$WORK/t.log" | sed 's/^/     /'; continue
+  if ! run_arc t -y t.arc > t.log 2>&1; then
+    note_fail "$m: integrity test failed"; tail -3 t.log | sed 's/^/     /'; continue
   fi
-  if ! wine "$EXE" x -y -dp"$out" "$WORK/t.arc" > "$WORK/x.log" 2>&1; then
-    note_fail "$m: extract failed"; tail -3 "$WORK/x.log" | sed 's/^/     /'; continue
+  if ! run_arc x -y -dp"$out" t.arc > x.log 2>&1; then
+    note_fail "$m: extract failed"; tail -3 x.log | sed 's/^/     /'; continue
   fi
 
-  # Archives store paths with the leading separator stripped, so the extracted
-  # tree lands at a known place. Derived rather than searched for by name:
-  # "find -name in -print -quit" picks whichever entry readdir yields first,
-  # which is what made the main suite report phantom empty directories.
-  root="$out/${WORK#/}/in"
-  if [ ! -d "$root" ]; then
-    note_fail "$m: no extracted tree at $root"
+  # A relative input path means the archive stores "in/...", so the extracted
+  # tree is at a known place. Derived rather than searched for by name: an
+  # earlier "find -name in -print -quit" picked whichever entry readdir yielded
+  # first, which is what made the main suite report phantom empty directories.
+  if [ ! -d "$out/in" ]; then
+    note_fail "$m: no extracted tree at $out/in"
     find "$out" -maxdepth 4 -type d | head -5 | sed 's/^/     /'
     continue
   fi
-  if diff -r "$WORK/in" "$root" >/dev/null 2>&1; then
-    echo "  $m: round-trip OK ($(wc -c < "$WORK/t.arc" | tr -d ' ') bytes)"
+  if diff -r in "$out/in" >/dev/null 2>&1; then
+    echo "  $m: round-trip OK ($(wc -c < t.arc | tr -d ' ') bytes)"
   else
     note_fail "$m: content mismatch"
-    diff -rq "$WORK/in" "$root" 2>&1 | head -3 | sed 's/^/     /'
+    diff -rq in "$out/in" 2>&1 | head -3 | sed 's/^/     /'
   fi
 done
 
 echo
 if [ "$fail" -eq 0 ]; then
   echo "windows smoke test: all checks passed"
-  rm -rf "$WORK" "$WORK".help "$WORK".help.err
+  cd /; rm -rf "$WORK"
   exit 0
 fi
 echo "windows smoke test: $fail check(s) failed" >&2

--- a/compile-mhs-win64
+++ b/compile-mhs-win64
@@ -1,23 +1,38 @@
 #!/usr/bin/env bash
-# Cross-compile DArc to Windows x64 via MicroHs combinator-VM.
-# Uses mhs -tenvironment to redirect C codegen through x86_64-w64-mingw32 toolchain.
-# Output: Tests/arc-mhs-win64.exe (target ~2.7MB vs 22MB GHC build)
+# Cross-compile DArc to 64-bit Windows via the MicroHs combinator-VM.
+# Uses mhs -tenvironment to redirect C codegen through a mingw-w64 toolchain.
+#
+# Target architecture is DARC_WIN_ARCH (default x86_64); see compile-win64-c
+# for what each value selects and why. Output:
+#
+#   x86_64    Tests/arc-mhs-win64.exe        (~2.7MB vs 22MB for the GHC build)
+#   aarch64   Tests/arc-mhs-win-arm64.exe
+#
+# The x86_64 name is left exactly as it was so the existing CI jobs, release
+# packaging and Tests/win-test.sh default keep working untouched.
 set -e
 
-exe=Tests/arc-mhs-win64.exe
+arch=${DARC_WIN_ARCH:-x86_64}
+case "$arch" in
+  x86_64)  triple="x86_64-w64-mingw32";  cc_suffix="-posix"; sfx="win64"     ;;
+  aarch64) triple="aarch64-w64-mingw32"; cc_suffix="";       sfx="win-arm64" ;;
+  *) echo "error: DARC_WIN_ARCH must be x86_64 or aarch64, got '$arch'" >&2; exit 2 ;;
+esac
+
+exe=Tests/arc-mhs-$sfx.exe
 gui_flag=""
 for option; do
   case $option in
-    -DFREEARC_GUI) exe=Tests/freearc-mhs-win64.exe; gui_flag="-DFREEARC_GUI" ;;
+    -DFREEARC_GUI) exe=Tests/freearc-mhs-$sfx.exe; gui_flag="-DFREEARC_GUI" ;;
     -O*) echo "warning: ignoring optimization flag '$option' for mhs build" >&2 ;;
   esac
 done
 
-WINOUT=${WINOUT:-/tmp/out/FreeArc-win64-mhs}
+WINOUT=${WINOUT:-/tmp/out/FreeArc-win64-mhs-$arch}
 mkdir -p "$WINOUT"
 
-# 1) Build C/C++ objects for Win64 with __MHS__ defined
-MHS=1 WINOUT="$WINOUT" ./compile-win64-c
+# 1) Build C/C++ objects for the Windows target with __MHS__ defined
+MHS=1 WINOUT="$WINOUT" DARC_WIN_ARCH="$arch" ./compile-win64-c
 
 # 2) ntrljmp.c for Lua trampoline (Lua not used on MHS path — skip unless GUI/Lua needed)
 # We don't link Lua under MHS for now; HsLua bindings only used by GHC build.
@@ -51,14 +66,26 @@ c_objs=(
 [[ -f "$WINOUT/C_BCJ.o" ]] && c_objs+=("$WINOUT/C_BCJ.o")
 for zo in "$WINOUT"/zstd_*.o; do [[ -f "$zo" ]] && c_objs+=("$zo"); done
 
-# Windows system libs (mingw provides these)
-win_libs="-static -lstdc++ -lpthread -lwinpthread -lwinmm -lws2_32 -ladvapi32 -lshell32 -luser32 -lkernel32 -lwininet -Wl,--allow-multiple-definition"
+# Windows system libs (mingw provides these).
+#
+# The link is driven by the C compiler, not the C++ one, so the C++ runtime has
+# to be named explicitly -- and the two toolchains do not ship the same one.
+# GCC-mingw has libstdc++; llvm-mingw has LLVM's libc++, which additionally
+# needs libc++abi and libunwind when linked statically. Asking for -lstdc++
+# under llvm-mingw fails outright, so this is not a preference.
+case "$arch" in
+  x86_64)  cxx_libs="-lstdc++ -lpthread" ;;
+  aarch64) cxx_libs="-lc++ -lc++abi -lunwind" ;;
+esac
+win_libs="-static $cxx_libs -lwinpthread -lwinmm -lws2_32 -ladvapi32 -lshell32 -luser32 -lkernel32 -lwininet -Wl,--allow-multiple-definition"
 
 # Build MHSCCLIBS from C objects (one space-separated string)
 linker_inputs=""
 for o in "${c_objs[@]}"; do linker_inputs="$linker_inputs $o"; done
 
-export CC="x86_64-w64-mingw32-gcc-posix"
+export CC="$triple-gcc$cc_suffix"
+command -v "$CC" >/dev/null 2>&1 ||
+  { echo "error: $CC not found in PATH" >&2; exit 2; }
 # Everything below makes up for what runtime/mingw/config.h does not provide.
 # See the MHSCONF note further down for why neither shipped config works alone.
 
@@ -81,7 +108,35 @@ runtime_defs="$runtime_defs -DISWINDOWS=1"
 runtime_defs="$runtime_defs -include compat-win/mhs_win_compat.h"
 runtime_defs="$runtime_defs -DCLOCK_T=int64_t -DCLOCK_INIT=darc_mhs_clock_init"
 runtime_defs="$runtime_defs -DCLOCK_GET=darc_mhs_clock_get -DCLOCK_SLEEP=usleep"
-export MHSCCFLAGS="-O2 -static-libgcc -static-libstdc++ -I. -ICompression -IHsLua/src $runtime_defs $defines $gui_flag"
+# What the two toolchains need that the other does not. Both of the aarch64
+# entries are about Clang rather than about ARM64 -- llvm-mingw is simply the
+# only toolchain that targets it -- so if a Clang x86-64 mingw build is ever
+# added, it wants this same set.
+#
+#   -static-libgcc/-static-libstdc++  name GCC's runtimes. Clang accepts the
+#     flags but has neither, so it warns about an unused argument on every
+#     single file it compiles.
+#
+#   -include errno.h  mhs generates errno accessors (mhs_EACCES and friends)
+#     that reference the macros without including <errno.h> themselves. That
+#     header happens to be reached transitively under Debian's mingw-w64
+#     headers and is not under llvm-mingw's, where the build stops with
+#     "use of undeclared identifier 'EACCES'". Force-including it costs
+#     nothing and does not depend on which chain pulls it in.
+#
+#   -Wno-incompatible-function-pointer-types  mhs's FFI glue passes HsFunPtr,
+#     i.e. void(*)(void), straight into CompressionService's CALLBACK_FUNC*
+#     parameter without a cast. GCC warns; Clang 16 and later reject it. The
+#     pointer really is a callback of the right shape at run time -- see the
+#     foreign-export machinery in Compression/CompressionLib.hs -- so this is
+#     a missing cast in generated code, not a real mismatch.
+case "$arch" in
+  x86_64)
+    cc_quirks="-static-libgcc -static-libstdc++" ;;
+  aarch64)
+    cc_quirks="-include errno.h -Wno-incompatible-function-pointer-types" ;;
+esac
+export MHSCCFLAGS="-O2 $cc_quirks -I. -ICompression -IHsLua/src $runtime_defs $defines $gui_flag"
 export MHSCCLIBS="$linker_inputs $win_libs"
 # Neither MicroHs runtime config fits a mingw cross-build on its own, so use
 # "mingw" and supply what it is missing (see runtime_defs above).
@@ -134,6 +189,32 @@ fi
 # failure for a binary that was sitting right there.
 if [[ "$(head -c 2 "$exe")" != "MZ" ]]; then
   echo "error: $exe does not start with the MZ signature -- not a Windows executable" >&2
+  exit 1
+fi
+
+# ...and that it is a Windows binary for the architecture that was *asked* for.
+# "MZ" cannot tell the two targets apart, and neither can `file`, which reports
+# "PE32+ executable (console)" for both -- so a build that silently fell back to
+# the host toolchain would pass every check above. The PE machine field is the
+# only thing here that actually distinguishes them, so read it directly: the
+# e_lfanew offset lives at 0x3c and the machine word is 4 bytes past the "PE\0\0"
+# signature it points at.
+case "$arch" in
+  x86_64)  want_machine=0x8664; want_name="AMD64" ;;
+  aarch64) want_machine=0xaa64; want_name="ARM64" ;;
+esac
+# Little-endian fields, assembled a byte at a time so this does not depend on
+# the byte order of whatever host is doing the cross-compiling.
+read_le () {  # read_le <byte-offset> <length> -> decimal value
+  local byte value=0 shift_by=0
+  for byte in $(od -An -tu1 -j "$1" -N "$2" "$exe"); do
+    value=$(( value + byte * (1 << shift_by) )); shift_by=$(( shift_by + 8 ))
+  done
+  echo "$value"
+}
+got_machine=$(printf '0x%04x' "$(read_le $(( $(read_le 60 4) + 4 )) 2)")
+if [[ "$got_machine" != "$want_machine" ]]; then
+  echo "error: $exe is PE machine $got_machine, expected $want_machine ($want_name)" >&2
   exit 1
 fi
 

--- a/compile-mhs-win64
+++ b/compile-mhs-win64
@@ -193,11 +193,12 @@ if [[ "$(head -c 2 "$exe")" != "MZ" ]]; then
 fi
 
 # ...and that it is a Windows binary for the architecture that was *asked* for.
-# "MZ" cannot tell the two targets apart, and neither can `file`, which reports
-# "PE32+ executable (console)" for both -- so a build that silently fell back to
-# the host toolchain would pass every check above. The PE machine field is the
-# only thing here that actually distinguishes them, so read it directly: the
-# e_lfanew offset lives at 0x3c and the machine word is 4 bytes past the "PE\0\0"
+# "MZ" is identical for both targets, so a build that silently fell back to the
+# host toolchain would pass every check above. `file` does name the
+# architecture ("PE32+ executable (console) Aarch64"), but it is not installed
+# everywhere -- the same reason the MZ check above is open-coded rather than
+# shelling out to it. So read the PE machine field directly: the e_lfanew
+# offset lives at 0x3c and the machine word is 4 bytes past the "PE\0\0"
 # signature it points at.
 case "$arch" in
   x86_64)  want_machine=0x8664; want_name="AMD64" ;;

--- a/compile-win64-c
+++ b/compile-win64-c
@@ -1,10 +1,43 @@
 #!/usr/bin/env bash
-# Build all C/C++ objects for Windows x64 target using mingw-w64 cross toolchain.
+# Build all C/C++ objects for a Windows target using a mingw-w64 cross toolchain.
 # Shared by both GHC and MHS Windows builds; DOES NOT define __MHS__.
+#
+# Target architecture is selected with DARC_WIN_ARCH (default x86_64):
+#
+#   x86_64    Debian's mingw-w64, i.e. GCC. The "-posix" suffix picks the
+#             POSIX threading model, which is the one that has libstdc++
+#             threads; the "-win32" variant does not.
+#   aarch64   llvm-mingw (https://github.com/mstorsjo/llvm-mingw), i.e. Clang.
+#             Debian's mingw-w64 packages x86_64 and i686 only, so there is no
+#             distro toolchain for this target. llvm-mingw's "-gcc"/"-g++"
+#             names are wrappers around clang, so the driver names below stay
+#             uniform even though the compilers do not.
+#
+# Both targets are little-endian, so FREEARC_INTEL_BYTE_ORDER is right for
+# each -- that define names the byte order, not the instruction set.
 set -e
-WINOUT=${WINOUT:-/tmp/out/FreeArc-win64-ghc}
+
+arch=${DARC_WIN_ARCH:-x86_64}
+case "$arch" in
+  x86_64)
+    triple="x86_64-w64-mingw32"; cc_suffix="-posix"; toolchain="mingw-w64"
+    # Windows 7. Kept as-is for x86-64 so this stays a no-op refactor for the
+    # target that already ships.
+    win_ver=0x0601 ;;
+  aarch64)
+    triple="aarch64-w64-mingw32"; cc_suffix=""; toolchain="llvm-mingw"
+    # Windows 10: the first release for which ARM64 desktop Windows exists,
+    # so there is nothing older to stay compatible with.
+    win_ver=0x0A00 ;;
+  *)
+    echo "error: DARC_WIN_ARCH must be x86_64 or aarch64, got '$arch'" >&2; exit 2 ;;
+esac
+
+WINOUT=${WINOUT:-/tmp/out/FreeArc-win64-ghc-$arch}
 mkdir -p "$WINOUT"
-CC="x86_64-w64-mingw32-g++-posix"
+CC="$triple-g++$cc_suffix"
+command -v "$CC" >/dev/null 2>&1 ||
+  { echo "error: $CC not found in PATH -- $arch needs $toolchain" >&2; exit 2; }
 MHS_DEF=""
 if [[ -n "${MHS:-}" ]]; then
   MHS_DEF="-D__MHS__"
@@ -13,7 +46,7 @@ FLAGS=(
   -std=c++17 -c
   -DFREEARC_WIN -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT
   $MHS_DEF
-  -D_WIN32_WINNT=0x0601 -DWINVER=0x0601
+  -D_WIN32_WINNT=$win_ver -DWINVER=$win_ver
   -I. -ICompression -IHsLua/src
   -O2
   -Wno-unknown-pragmas -Wno-sign-compare -Wno-deprecated-declarations
@@ -58,12 +91,12 @@ for src in Compression/*/C_*.cpp; do
 done
 
 # LZMA 7-Zip 24.09 C SDK sources
-CC_C="x86_64-w64-mingw32-gcc-posix"
+CC_C="$triple-gcc$cc_suffix"
 C7Z_FLAGS=(
   -std=c11 -c -O2 -DNDEBUG -D_REENTRANT
   -DFREEARC_WIN -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT
   $MHS_DEF
-  -D_WIN32_WINNT=0x0601 -DWINVER=0x0601
+  -D_WIN32_WINNT=$win_ver -DWINVER=$win_ver
   -Wno-unknown-pragmas -Wno-sign-compare -Wno-deprecated-declarations
 )
 for src in Compression/LZMA/7z24/*.c; do


### PR DESCRIPTION
Closes the one platform gap left after v2.0.0: DArc shipped a Windows amd64 binary and nothing for ARM64.

## Why it was blocked

Debian's `mingw-w64` packages x86_64 and i686 only, and both compile scripts were written against that single triplet. ARM64 needs [llvm-mingw](https://github.com/mstorsjo/llvm-mingw) (Clang), pinned here by version and sha256 exactly as MicroHs already is.

## What changed

`DARC_WIN_ARCH` (`x86_64` by default, or `aarch64`) now selects the cross toolchain, the target Windows version and the output name in `compile-win64-c` and `compile-mhs-win64`. **The x86_64 path keeps its compiler, flags, link line and output name unchanged** — it should be the same build it was.

Clang needed two things GCC did not, neither of them ARM-specific:

- mhs generates errno accessors (`mhs_EACCES` and friends) that reference the macros without including `<errno.h>`. That header is reached transitively under Debian's mingw-w64 headers and is not under llvm-mingw's, so it is force-included.
- mhs's FFI glue passes `HsFunPtr` straight into `CompressionService`'s `CALLBACK_FUNC*` parameter with no cast. GCC warns; Clang 16+ rejects it.

## Verification

The `MZ` signature is identical for both targets, so a build that silently fell back to the host toolchain would pass every check the script had. `compile-mhs-win64` now reads the **PE machine field** and compares it against the requested architecture. Checked against real x86-64 and ARM64 binaries that it reports `0x8664` and `0xaa64` respectively, so it can actually discriminate rather than merely accept.

Wine has no ARM64 emulation, so the binary cannot be run on the machine that cross-builds it. `Tests/win-test.sh` now detects Windows vs. a Unix host and adds Wine only in the latter case, and **CI runs it on a real `windows-11-arm` runner**. The release workflow's `publish` job waits on that result, so an ARM64 binary that builds but cannot create an archive never reaches a release.

Results on `de97a7c`, all eight jobs green:

| job | result |
|---|---|
| `windows-arm64-test` (native ARM64 Windows) | `exe: … (ARM64)`; `-m0`/`-m1`/`-m4` round-trip OK |
| `windows-cross` (amd64 under Wine) | `-m0`/`-m1`/`-m4` round-trip OK |

`win-test.sh` also moved to relative paths throughout, because MSYS rewrites POSIX-looking arguments before handing them to a native `.exe` and `-dp/tmp/...` is exactly the shape that mangling trips over. As a side effect the amd64 artifact gains a Wine smoke test in the release workflow, where it had been packaged on a `file` check alone.

Two things the last two commits fix, both mine:

- The first run logged `native Windows (AMD64)` on the ARM64 runner. `PROCESSOR_ARCHITECTURE` is per-process and Git Bash is an x64 binary running emulated; `PROCESSOR_ARCHITEW6432` does not rescue it either, being specific to 32-bit-on-64-bit WOW64. It now reads the architecture out of the PE header, which is what the log is claiming anyway.
- I had written in three comments that `file` cannot distinguish the two targets. It can — `PE32+ executable (console) Aarch64` vs `x86-64`. What could not was the old `file … | grep PE32+` check, since that substring is common to both. The reason these checks are open-coded is that `file` is not installed everywhere.

## Known gap, not addressed here

Neither Windows target has a **cross-build format-compatibility check** — nothing verifies that an archive written by a Windows build reads back on Linux, or vice versa. That gap predates this PR and applies to amd64 equally, but this change does introduce a second compiler for the same codec sources, and `compile-win64-c` already warns that PPMD flag mismatches produce cross-incompatible streams. Proposed as a follow-up covering both targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)