### PR TITLE
Check that Windows and Linux builds can read each other's archives

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -306,11 +306,13 @@ jobs:
         path: interop
     # Own archives first. If this build cannot read back what it just wrote,
     # the codec is broken on Windows and any interop failure below is a
-    # consequence rather than a finding -- so run it before the cross-platform
-    # check, and with no xfail, because a build failing to round-trip itself is
-    # never expected.
+    # consequence rather than a finding. That is exactly what this step
+    # established for tta: neither Windows build can even create a tta
+    # archive, so it is xfail here too -- see interop-test.sh.
     - name: Round-trip this build's own archives
       shell: bash
+      env:
+        DARC_INTEROP_XFAIL: tta
       run: |
         set -euo pipefail
         tar -xf interop/corpus.tar -C interop
@@ -431,7 +433,10 @@ jobs:
         chmod +x winbin/arc
     # Own archives first, for the same reason as the arm64 job: a build that
     # cannot read back what it just wrote has a codec bug, not an interop one.
+    # tta is xfail here because it turned out to be exactly that.
     - name: Round-trip this build's own archives
+      env:
+        DARC_INTEROP_XFAIL: tta
       run: |
         set -euo pipefail
         Tests/interop-test.sh make  winbin/arc interop/corpus out-amd64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -304,17 +304,26 @@ jobs:
       with:
         name: interop-linux
         path: interop
-    - name: Read Linux-written archives
+    # Own archives first. If this build cannot read back what it just wrote,
+    # the codec is broken on Windows and any interop failure below is a
+    # consequence rather than a finding -- so run it before the cross-platform
+    # check, and with no xfail, because a build failing to round-trip itself is
+    # never expected.
+    - name: Round-trip this build's own archives
       shell: bash
       run: |
         set -euo pipefail
         tar -xf interop/corpus.tar -C interop
-        bash Tests/interop-test.sh check Tests/arc-mhs-win-arm64.exe interop/corpus interop/archives
-    - name: Write archives for the Linux side to read
+        bash Tests/interop-test.sh make  Tests/arc-mhs-win-arm64.exe interop/corpus out-arm64
+        bash Tests/interop-test.sh check Tests/arc-mhs-win-arm64.exe interop/corpus out-arm64
+    # See the XFAIL comment block in interop-test.sh for why tta is listed.
+    - name: Read Linux-written archives
       shell: bash
+      env:
+        DARC_INTEROP_XFAIL: tta
       run: |
         set -euo pipefail
-        bash Tests/interop-test.sh make Tests/arc-mhs-win-arm64.exe interop/corpus out-arm64
+        bash Tests/interop-test.sh check Tests/arc-mhs-win-arm64.exe interop/corpus interop/archives
     - uses: actions/upload-artifact@v4
       with:
         name: interop-win-arm64
@@ -403,7 +412,7 @@ jobs:
       with:
         name: arc-win-amd64
         path: winbin
-    - name: Read Linux-written archives, then write our own
+    - name: Set up Wine and a shim
       run: |
         set -euo pipefail
         tar -xf interop/corpus.tar -C interop
@@ -416,11 +425,22 @@ jobs:
         # interop-test.sh runs one archiver binary; give it a Wine-invoking
         # shim so the script needs no notion of which platform it is driving.
         { echo '#!/bin/sh'
+          echo 'export WINEDEBUG=-all WINEPREFIX="$HOME/.darc-wineprefix"'
           echo 'exec wine "$(dirname "$0")/arc-mhs-win64.exe" "$@"'
         } > winbin/arc
         chmod +x winbin/arc
-        Tests/interop-test.sh check winbin/arc interop/corpus interop/archives
+    # Own archives first, for the same reason as the arm64 job: a build that
+    # cannot read back what it just wrote has a codec bug, not an interop one.
+    - name: Round-trip this build's own archives
+      run: |
+        set -euo pipefail
         Tests/interop-test.sh make  winbin/arc interop/corpus out-amd64
+        Tests/interop-test.sh check winbin/arc interop/corpus out-amd64
+    # See the XFAIL comment block in interop-test.sh for why tta is listed.
+    - name: Read Linux-written archives
+      env:
+        DARC_INTEROP_XFAIL: tta
+      run: Tests/interop-test.sh check winbin/arc interop/corpus interop/archives
     - uses: actions/upload-artifact@v4
       with:
         name: interop-win-amd64
@@ -448,7 +468,10 @@ jobs:
       with:
         name: interop-win-arm64
         path: from-arm64
+    # See the XFAIL comment block in interop-test.sh for why tta is listed.
     - name: Read Windows-written archives on Linux
+      env:
+        DARC_INTEROP_XFAIL: tta
       run: |
         set -euo pipefail
         tar -xf interop/corpus.tar -C interop

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,6 +213,14 @@ jobs:
       run: |
         chmod +x Tests/win-test.sh
         Tests/win-test.sh
+    # Uploaded so the interop jobs can exercise this exact binary without
+    # rebuilding it, which also means they test what this job produced rather
+    # than a second build of the same source.
+    - uses: actions/upload-artifact@v4
+      with:
+        name: arc-win-amd64
+        path: Tests/arc-mhs-win64.exe
+        if-no-files-found: error
 
   # ── Windows on ARM64 ────────────────────────────────────────────────────────
   # Split across two jobs because neither half can be done alone:
@@ -274,7 +282,7 @@ jobs:
         if-no-files-found: error
 
   windows-arm64-test:
-    needs: windows-arm64-cross
+    needs: [ windows-arm64-cross, interop-produce ]
     runs-on: windows-11-arm
     steps:
     - uses: actions/checkout@v6.0.2
@@ -291,6 +299,178 @@ jobs:
     - name: Smoke-test on native ARM64 Windows
       shell: bash
       run: bash Tests/win-test.sh Tests/arc-mhs-win-arm64.exe
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: interop-linux
+        path: interop
+    - name: Read Linux-written archives
+      shell: bash
+      run: |
+        set -euo pipefail
+        tar -xf interop/corpus.tar -C interop
+        bash Tests/interop-test.sh check Tests/arc-mhs-win-arm64.exe interop/corpus interop/archives
+    - name: Write archives for the Linux side to read
+      shell: bash
+      run: |
+        set -euo pipefail
+        bash Tests/interop-test.sh make Tests/arc-mhs-win-arm64.exe interop/corpus out-arm64
+    - uses: actions/upload-artifact@v4
+      with:
+        name: interop-win-arm64
+        path: out-arm64
+        if-no-files-found: error
+
+  # ── Cross-build archive interoperability ────────────────────────────────────
+  # run-tests.sh only ever asks whether a build can read back its own archives.
+  # Nothing asked whether the Windows builds -- which use a different compiler
+  # over the same codec sources -- write archives the Linux build can read, or
+  # the reverse. A build can pass every round-trip test while producing output
+  # no other build can open, and compile-win64-c already warns that PPMD does
+  # exactly that if its flags drift.
+  #
+  # interop-produce writes the reference archives; the two Windows jobs read
+  # them and write their own; interop-verify reads those back on Linux. The
+  # corpus is shipped between jobs rather than regenerated on each side, so a
+  # corpus difference can never masquerade as a format incompatibility.
+  #
+  # This builds its own Linux binary rather than depending on the `build`
+  # matrix: `needs` is job-level, so waiting on `build` would mean waiting on
+  # the macOS leg too. A duplicate ~10-minute build that runs in parallel is
+  # cheaper than serialising the whole Windows chain behind it.
+  interop-produce:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6.0.2
+      with:
+        lfs: false
+    - uses: KyleMayes/install-llvm-action@v2
+      with:
+        version: "21.1.8"
+    - name: Install packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y liblua5.1-dev libncurses-dev libcurl4-openssl-dev cpphs
+    - name: Install MicroHs
+      run: |
+        microhs_sha="05a3fbd5d73ae6a37111a6ced5b57bb1717b8975"
+        microhs_expected_sha256="a1f85821cbae877d0ea3e173235d45c833d9145b2ca9e92e77d284b6730c63b6"
+        curl -fsSL "https://github.com/augustss/MicroHs/archive/$microhs_sha.tar.gz" -o /tmp/microhs.tar.gz
+        echo "$microhs_expected_sha256  /tmp/microhs.tar.gz" | sha256sum -c -
+        tar -xzf /tmp/microhs.tar.gz -C /tmp
+        cd "/tmp/MicroHs-$microhs_sha"
+        make minstall
+        echo "$HOME/.mcabal/bin" >> "$GITHUB_PATH"
+    - name: Build
+      run: |
+        chmod +x compile*
+        ./compile-O2
+    - name: Write reference archives
+      run: |
+        set -euo pipefail
+        chmod +x Tests/make-corpus.sh Tests/interop-test.sh
+        ( cd Tests && ./make-corpus.sh corpus )
+        Tests/interop-test.sh make Tests/arc Tests/corpus interop/archives
+        # Tarred rather than shipped as loose files: artifact upload/download
+        # does not preserve modes, and 218 files move faster as one.
+        tar -cf interop/corpus.tar -C Tests corpus
+        cp Tests/arc interop/arc
+    - uses: actions/upload-artifact@v4
+      with:
+        name: interop-linux
+        path: interop
+        if-no-files-found: error
+
+  # amd64 is a separate job rather than more steps on windows-cross so that the
+  # two do not serialise: windows-cross and interop-produce run in parallel and
+  # this picks up both artifacts afterwards.
+  interop-windows-amd64:
+    needs: [ interop-produce, windows-cross ]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6.0.2
+      with:
+        lfs: false
+    - name: Install Wine
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends wine64 wine
+    - uses: actions/download-artifact@v4
+      with:
+        name: interop-linux
+        path: interop
+    - uses: actions/download-artifact@v4
+      with:
+        name: arc-win-amd64
+        path: winbin
+    - name: Read Linux-written archives, then write our own
+      run: |
+        set -euo pipefail
+        tar -xf interop/corpus.tar -C interop
+        chmod +x Tests/interop-test.sh
+        # A .exe is not executable after an artifact round-trip, and the script
+        # refuses to run a non-executable archiver.
+        chmod +x winbin/arc-mhs-win64.exe
+        export WINEDEBUG=-all WINEPREFIX="$HOME/.darc-wineprefix"
+        wineboot -i >/dev/null 2>&1 || true
+        # interop-test.sh runs one archiver binary; give it a Wine-invoking
+        # shim so the script needs no notion of which platform it is driving.
+        { echo '#!/bin/sh'
+          echo 'exec wine "$(dirname "$0")/arc-mhs-win64.exe" "$@"'
+        } > winbin/arc
+        chmod +x winbin/arc
+        Tests/interop-test.sh check winbin/arc interop/corpus interop/archives
+        Tests/interop-test.sh make  winbin/arc interop/corpus out-amd64
+    - uses: actions/upload-artifact@v4
+      with:
+        name: interop-win-amd64
+        path: out-amd64
+        if-no-files-found: error
+
+  # The other direction: archives written by each Windows build, read back by
+  # the Linux build that wrote the reference set.
+  interop-verify:
+    needs: [ interop-produce, interop-windows-amd64, windows-arm64-test ]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6.0.2
+      with:
+        lfs: false
+    - uses: actions/download-artifact@v4
+      with:
+        name: interop-linux
+        path: interop
+    - uses: actions/download-artifact@v4
+      with:
+        name: interop-win-amd64
+        path: from-amd64
+    - uses: actions/download-artifact@v4
+      with:
+        name: interop-win-arm64
+        path: from-arm64
+    - name: Read Windows-written archives on Linux
+      run: |
+        set -euo pipefail
+        tar -xf interop/corpus.tar -C interop
+        chmod +x interop/arc Tests/interop-test.sh
+        for src in from-amd64 from-arm64; do
+          echo "=== archives written by ${src#from-} ==="
+          Tests/interop-test.sh check interop/arc interop/corpus "$src"
+        done
+    # Informational, deliberately not a pass/fail gate. If every build turns out
+    # to emit byte-identical archives then this could become one, which would be
+    # a far stronger guarantee than "reads back correctly" -- but a difference
+    # here is not by itself a bug (path separators and stored attributes are
+    # legitimately platform-dependent), so it is reported and left to a human.
+    - name: Compare archive bytes across builds
+      run: |
+        echo "method              linux == amd64   linux == arm64"
+        for a in interop/archives/*.arc; do
+          m=$(basename "$a" .arc)
+          x=$(cmp -s "$a" "from-amd64/$m.arc" && echo same || echo DIFFERS)
+          y=$(cmp -s "$a" "from-arm64/$m.arc" && echo same || echo DIFFERS)
+          printf '%-20s %-16s %s\n' "$m" "$x" "$y"
+        done
 
   # ── Rust codec ports ────────────────────────────────────────────────────────
   # Two things are checked, and they are not the same thing:

--- a/Tests/interop-test.sh
+++ b/Tests/interop-test.sh
@@ -43,7 +43,21 @@ usage () {
 
 # Absolutise before anything cds, and so the executable check below names the
 # path the user actually passed.
-abspath () { case "$1" in /*) echo "$1" ;; *) echo "$(cd "$(dirname "$1")" 2>/dev/null && pwd)/$(basename "$1")" ;; esac; }
+#
+# This must NOT require the path to exist: in make mode the output directory
+# legitimately does not yet. The obvious "cd $(dirname "$1") && pwd" form does
+# require it, and fails in the worst possible way -- with cd's error
+# suppressed, a missing parent makes the command substitution empty, so
+# "interop/archives" becomes "/archives": still absolute, still plausible, and
+# wrong. It got past a local test suite because every path used there happened
+# to have an existing parent, and surfaced on CI as the archiver failing to
+# open a temporary file.
+abspath () {
+  case "$1" in
+    /*) echo "${1%/}" ;;
+    *)  echo "${PWD%/}/${1#./}" ;;
+  esac
+}
 ARC="$(abspath "$ARC")"
 CORPUS="$(abspath "$CORPUS")"
 DIR="$(abspath "$DIR")"
@@ -101,7 +115,7 @@ case "$MODE" in
 
 # ---------------------------------------------------------------------------
 make)
-  mkdir -p "$DIR"
+  mkdir -p "$DIR" || { echo "error: cannot create output directory: $DIR" >&2; exit 2; }
   rm -f "$DIR"/*.arc "$DIR"/SHA256SUMS 2>/dev/null
   echo "writing archives with $ARC"
   echo "corpus: $n_want files, tree $EXPECTED_TREE"

--- a/Tests/interop-test.sh
+++ b/Tests/interop-test.sh
@@ -100,6 +100,41 @@ CASES="
 -mdelta+lzma:chain-delta-lzma
 "
 
+# Codecs allowed to fail, named by the caller in DARC_INTEROP_XFAIL. Kept in
+# CASES rather than deleted from it, because a quietly shortened list is
+# indistinguishable from full coverage six months later -- every run prints
+# these as xfail, so the gap stays visible in the log.
+#
+# An xfail that PASSES is reported as an error, not a success: the list is a
+# claim about what is broken, and a stale entry understates coverage just as
+# badly as deleting the case would.
+#
+# The default is empty, and it has to be, because whether a codec interoperates
+# is a property of the PAIR of builds involved. tta below is fine when a build
+# reads its own archives and only fails across the Linux/Windows boundary; a
+# list baked into this script would turn every same-build run into a false
+# XPASS. So each CI call site names what it expects to fail.
+#
+# Currently expected, set by the cross-platform check steps in build.yml:
+#
+#   tta   The Windows builds reject a TTA archive written by the Linux build.
+#         Both Windows targets fail identically -- GCC-mingw amd64 and Clang
+#         arm64 -- so this is a Windows/Linux difference, not a compiler one,
+#         which points at LLP64 (long is 4 bytes) against LP64 (8). TTA has a
+#         long history of exactly that: nine such bugs were fixed in it for
+#         v2.0.0, every one validated by round-tripping on LP64 hosts only.
+#         -mtta has never been exercised on Windows at all -- win-test.sh
+#         covers -m0/-m1/-m4 and run-tests.sh does not run there -- so this
+#         may be a codec that has never worked on Windows rather than a new
+#         divergence. The self-round-trip step in CI is what tells the two
+#         apart: if a Windows build cannot read even its OWN tta archive, the
+#         bug is in the codec on Windows and has nothing to do with interop.
+XFAIL="${DARC_INTEROP_XFAIL:-}"
+
+is_xfail () {
+  case " $XFAIL " in *" $1 "*) return 0 ;; *) return 1 ;; esac
+}
+
 hash_of  () { $SHA "$1" 2>/dev/null | cut -d' ' -f1; }
 tree_hash () {   # order-independent hash of a directory's file contents+names
   [ -d "$1" ] || { echo "no-such-dir"; return; }
@@ -155,21 +190,36 @@ check)
   # to reintroduce whenever the inputs arrive from another job.
   [ "$n_arc" -gt 0 ] || { echo "error: no .arc files in $DIR -- nothing was checked" >&2; exit 2; }
 
-  fail=0
+  fail=0; xfail=0; xpass=0
+
+  # Report an outcome, routing it through the xfail list. Everything below
+  # reports by calling this rather than by touching the counters directly, so
+  # a known-broken codec cannot accidentally be counted as a hard failure or
+  # -- worse -- pass silently once it is fixed.
+  bad () {   # bad <label> <reason>
+    if is_xfail "$1"; then
+      printf '  %-20s xfail %s (known, see XFAIL in %s)\n' "$1" "$2" "$(basename "$0")"
+      xfail=$((xfail+1))
+    else
+      printf '  %-20s FAIL  %s\n' "$1" "$2"
+      fail=$((fail+1))
+    fi
+  }
+
   for arc in "$DIR"/*.arc; do
     label="$(basename "$arc" .arc)"
     out="$WORK/x-$label"
     rm -rf "$out"; mkdir -p "$out"
 
     if ! "$ARC" t -y "$(winpath "$arc")" >"$WORK/$label.t.log" 2>&1; then
-      printf '  %-20s FAIL  integrity test rejected the archive\n' "$label"
+      bad "$label" "integrity test rejected the archive"
       tail -3 "$WORK/$label.t.log" | sed 's/^/      /'
-      fail=$((fail+1)); continue
+      continue
     fi
     if ! "$ARC" x -y -dp"$(winpath "$out")" "$(winpath "$arc")" >"$WORK/$label.x.log" 2>&1; then
-      printf '  %-20s FAIL  extract\n' "$label"
+      bad "$label" "extract failed"
       tail -3 "$WORK/$label.x.log" | sed 's/^/      /'
-      fail=$((fail+1)); continue
+      continue
     fi
 
     # Entries are stored corpus-relative, so the tree lands at the extraction
@@ -177,29 +227,48 @@ check)
     # is what once made this class of check report phantom empty directories.
     n_got="$(find "$out" -type f 2>/dev/null | wc -l | tr -d ' ')"
     if [ "$n_got" -eq 0 ]; then
-      printf '  %-20s FAIL  extracted no files (expected %s)\n' "$label" "$n_want"
-      fail=$((fail+1)); continue
+      bad "$label" "extracted no files (expected $n_want)"
+      continue
     fi
     got="$(tree_hash "$out")"
     if [ "$got" != "$EXPECTED_TREE" ]; then
       detail="content differs"
       [ "$n_got" -ne "$n_want" ] && detail="file count $n_got, expected $n_want"
-      printf '  %-20s FAIL  extracted tree differs: %s\n' "$label" "$detail"
+      bad "$label" "extracted tree differs: $detail"
       ( cd "$CORPUS" && find . -type f | LC_ALL=C sort ) > "$WORK/$label.want" 2>/dev/null
       ( cd "$out"    && find . -type f | LC_ALL=C sort ) > "$WORK/$label.got"  2>/dev/null
       diff "$WORK/$label.want" "$WORK/$label.got" 2>/dev/null | head -4 | sed 's/^/      /'
-      fail=$((fail+1)); continue
+      continue
     fi
-    printf '  %-20s ok    %s files\n' "$label" "$n_got"
+    if is_xfail "$label"; then
+      printf '  %-20s XPASS %s files -- remove it from XFAIL\n' "$label" "$n_got"
+      xpass=$((xpass+1))
+    else
+      printf '  %-20s ok    %s files\n' "$label" "$n_got"
+    fi
     rm -rf "$out"
   done
 
   echo
+  # An xfail that started passing is reported as an error on purpose. The list
+  # is a claim about what is broken; leaving a stale entry in it understates
+  # coverage just as badly as deleting the case would.
+  if [ "$xpass" -gt 0 ]; then
+    echo "interop: $xpass archive(s) marked xfail now pass -- update XFAIL in $0" >&2
+    # Named separately rather than returned to: a summary that mentioned only
+    # the stale xfail would bury a genuine regression in the same run.
+    [ "$fail" -gt 0 ] && echo "interop: and $fail archive(s) failed outright" >&2
+    exit 1
+  fi
   if [ "$fail" -eq 0 ]; then
-    echo "interop: all $n_arc archive(s) read back identically"
+    if [ "$xfail" -gt 0 ]; then
+      echo "interop: $((n_arc-xfail))/$n_arc read back identically, $xfail known-broken (xfail)"
+    else
+      echo "interop: all $n_arc archive(s) read back identically"
+    fi
     exit 0
   fi
-  echo "interop: $fail of $n_arc archive(s) failed" >&2
+  echo "interop: $fail of $n_arc archive(s) failed ($xfail known-broken)" >&2
   exit 1
   ;;
 

--- a/Tests/interop-test.sh
+++ b/Tests/interop-test.sh
@@ -127,13 +127,27 @@ CASES="
 #         and run-tests.sh does not run on Windows, so nothing ever invoked
 #         -mtta on a Windows build; this suite is the first thing to try.
 #
-#         Both targets fail identically -- GCC-mingw on amd64 and Clang on
-#         arm64 -- so it is a Windows/Linux difference rather than a compiler
-#         one, which points at LLP64 (long is 4 bytes) against LP64 (8). TTA
-#         has a long history of exactly that family: nine such bugs were fixed
-#         in it for v2.0.0, every one validated by round-tripping on LP64
-#         hosts only. Tracked as follow-up work; it is a pre-existing defect,
-#         not a regression from anything in this suite.
+#         Root cause, confirmed: malloc2d in Compression/MM/tta.cpp lays a
+#         pointer table and a data block into one allocation, and steps over
+#         the table with
+#
+#             tmp = (long *) array + num;
+#
+#         That advances by num * sizeof(long). The table it is skipping is
+#         num * sizeof(long *) bytes. Those are equal on LP64 and NOT on
+#         Windows, where long is 4 bytes and pointers are still 8 -- so the
+#         data block starts halfway inside the pointer table and the samples
+#         overwrite the pointers. Hence "page fault on write access to
+#         0x00007f3600000000": a live heap pointer whose low 32 bits have been
+#         replaced by sample data. Both directions crash, encode and decode.
+#
+#         The fix is to step over the table as pointers, "(long *)(array +
+#         num)", which is identical on LP64 and therefore leaves Linux archive
+#         bytes untouched. Remove tta from the xfail sites in build.yml when
+#         it lands -- an XPASS will insist on it anyway.
+#
+#         Tenth instance of the family that produced nine fixes for v2.0.0,
+#         and a pre-existing defect rather than a regression from this suite.
 XFAIL="${DARC_INTEROP_XFAIL:-}"
 
 is_xfail () {

--- a/Tests/interop-test.sh
+++ b/Tests/interop-test.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Cross-build archive interoperability.
+#
+# run-tests.sh asks whether a build can read back its OWN archives. This asks
+# the different question of whether builds can read each OTHER'S, which is the
+# property users actually depend on and the one nothing was checking:
+#
+#     linux binary  --writes-->  archive  --reads-->  windows binary
+#     windows binary --writes--> archive  --reads-->  linux binary
+#
+# It matters here because the Windows targets are built with a different
+# compiler from everything else -- Debian's mingw-w64 (GCC) for amd64,
+# llvm-mingw (Clang) for arm64 -- over the same codec sources. compile-win64-c
+# already warns that PPMD in particular produces cross-incompatible streams if
+# its flags do not match, and a build can pass every round-trip test while
+# writing archives no other build can open. That is the highest-risk failure
+# mode in this project precisely because everything looks green.
+#
+# The two halves run on different machines, so they are separate subcommands
+# communicating through a directory that CI ships between jobs as an artifact:
+#
+#   interop-test.sh make  <arc> <corpus-dir> <out-dir>
+#   interop-test.sh check <arc> <corpus-dir> <archive-dir>
+#
+# The corpus is passed in rather than regenerated on each side. make-corpus.sh
+# is deterministic by design, but "deterministic" is exactly the assumption a
+# cross-platform test should not be resting on -- if it ever drifted, this
+# would report a format incompatibility that did not exist. Shipping the same
+# bytes to both sides removes the question.
+set -u
+
+MODE="${1:-}"
+ARC="${2:-}"
+CORPUS="${3:-}"
+DIR="${4:-}"
+
+usage () {
+  echo "usage: $0 make  <arc> <corpus-dir> <out-dir>" >&2
+  echo "       $0 check <arc> <corpus-dir> <archive-dir>" >&2
+  exit 2
+}
+[ -n "$MODE" ] && [ -n "$ARC" ] && [ -n "$CORPUS" ] && [ -n "$DIR" ] || usage
+
+# Absolutise before anything cds, and so the executable check below names the
+# path the user actually passed.
+abspath () { case "$1" in /*) echo "$1" ;; *) echo "$(cd "$(dirname "$1")" 2>/dev/null && pwd)/$(basename "$1")" ;; esac; }
+ARC="$(abspath "$ARC")"
+CORPUS="$(abspath "$CORPUS")"
+DIR="$(abspath "$DIR")"
+
+[ -x "$ARC" ]   || { echo "error: archiver not found or not executable: $ARC" >&2; exit 2; }
+[ -d "$CORPUS" ] || { echo "error: corpus not found: $CORPUS" >&2; exit 2; }
+
+command -v sha256sum >/dev/null && SHA=sha256sum || SHA="shasum -a 256"
+WORK="${DARC_INTEROP_WORK:-${TMPDIR:-/tmp}/darc-interop-work}"
+
+# Paths given to a native Windows .exe have to be Windows paths. MSYS rewrites
+# some arguments on the way through and gets others wrong -- "-dp/tmp/x" is
+# exactly the shape it mishandles, which is why win-test.sh sidesteps the
+# question by staying in relative paths. That is not available here: the corpus
+# and the archives deliberately live in different trees, so the paths must be
+# absolute. Convert them explicitly instead of hoping. cygpath exists only on
+# Windows shells, so this is the identity everywhere else.
+winpath () {
+  if command -v cygpath >/dev/null 2>&1; then cygpath -w "$1"; else echo "$1"; fi
+}
+
+# One archive per codec. Solid-mode and thread-count variants are deliberately
+# absent: they change how data is grouped, not how any codec encodes it, so
+# they add runtime without adding coverage of the thing under test. Every
+# method that reaches C is represented once.
+CASES="
+-m0:store
+-m1:m1
+-m4:m4
+-m9:m9
+-m4x:m4x
+-mtor:tor
+-mlzp:lzp
+-mtta:tta
+-mlzma:lzma
+-mppmd:ppmd
+-mgrzip:grzip
+-mdict -s-:dict
+-mrep+lzma:chain-rep-lzma
+-mdelta+lzma:chain-delta-lzma
+"
+
+hash_of  () { $SHA "$1" 2>/dev/null | cut -d' ' -f1; }
+tree_hash () {   # order-independent hash of a directory's file contents+names
+  [ -d "$1" ] || { echo "no-such-dir"; return; }
+  ( cd "$1" && find . -type f -print0 2>/dev/null | LC_ALL=C sort -z |
+    while IFS= read -r -d '' f; do printf '%s  %s\n' "$(hash_of "$f")" "$f"; done ) | $SHA | cut -d' ' -f1
+}
+
+rm -rf "$WORK"; mkdir -p "$WORK"
+EXPECTED_TREE="$(tree_hash "$CORPUS")"
+n_want="$(find "$CORPUS" -type f | wc -l | tr -d ' ')"
+
+case "$MODE" in
+
+# ---------------------------------------------------------------------------
+make)
+  mkdir -p "$DIR"
+  rm -f "$DIR"/*.arc "$DIR"/SHA256SUMS 2>/dev/null
+  echo "writing archives with $ARC"
+  echo "corpus: $n_want files, tree $EXPECTED_TREE"
+  # Herestring, not a pipeline: a "| while read" loop runs in a subshell in
+  # most shells, so anything it counted would be discarded at the done.
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    opts="${line%%:*}"; label="${line##*:}"
+    arc="$DIR/$label.arc"
+    # --nodates so the bytes do not carry mtimes, and created from inside the
+    # corpus so entries are stored corpus-relative -- both exactly as
+    # run-tests.sh does it, so archives are comparable with its fingerprints.
+    if ( cd "$CORPUS" && "$ARC" a --nodates -r -y $opts "$(winpath "$arc")" . ) >"$WORK/$label.log" 2>&1; then
+      printf '  %-20s %s\n' "$label" "$(hash_of "$arc")"
+    else
+      printf '  %-20s CREATE FAILED\n' "$label"
+      tail -3 "$WORK/$label.log" | sed 's/^/      /'
+    fi
+  done <<< "$CASES"
+  # Counted from disk rather than from the loop, so the pass condition rests on
+  # files that exist rather than on a variable. "CREATE FAILED printed three
+  # times, exit status 0" is a defect this repo has already shipped once.
+  made="$(ls "$DIR"/*.arc 2>/dev/null | wc -l | tr -d ' ')"
+  want="$(echo "$CASES" | grep -c ':')"
+  ( cd "$DIR" && $SHA ./*.arc > SHA256SUMS 2>/dev/null )
+  echo "wrote $made/$want archives to $DIR"
+  [ "$made" -eq "$want" ] || { echo "error: $((want-made)) archive(s) were not created" >&2; exit 1; }
+  ;;
+
+# ---------------------------------------------------------------------------
+check)
+  echo "reading archives with $ARC"
+  echo "corpus: $n_want files, tree $EXPECTED_TREE"
+  n_arc="$(ls "$DIR"/*.arc 2>/dev/null | wc -l | tr -d ' ')"
+  # A check with nothing to check must fail. An earlier version of the Windows
+  # smoke test went green while performing zero operations; the shape is easy
+  # to reintroduce whenever the inputs arrive from another job.
+  [ "$n_arc" -gt 0 ] || { echo "error: no .arc files in $DIR -- nothing was checked" >&2; exit 2; }
+
+  fail=0
+  for arc in "$DIR"/*.arc; do
+    label="$(basename "$arc" .arc)"
+    out="$WORK/x-$label"
+    rm -rf "$out"; mkdir -p "$out"
+
+    if ! "$ARC" t -y "$(winpath "$arc")" >"$WORK/$label.t.log" 2>&1; then
+      printf '  %-20s FAIL  integrity test rejected the archive\n' "$label"
+      tail -3 "$WORK/$label.t.log" | sed 's/^/      /'
+      fail=$((fail+1)); continue
+    fi
+    if ! "$ARC" x -y -dp"$(winpath "$out")" "$(winpath "$arc")" >"$WORK/$label.x.log" 2>&1; then
+      printf '  %-20s FAIL  extract\n' "$label"
+      tail -3 "$WORK/$label.x.log" | sed 's/^/      /'
+      fail=$((fail+1)); continue
+    fi
+
+    # Entries are stored corpus-relative, so the tree lands at the extraction
+    # root itself. Derived, not searched for by name: "find -name corpus -quit"
+    # is what once made this class of check report phantom empty directories.
+    n_got="$(find "$out" -type f 2>/dev/null | wc -l | tr -d ' ')"
+    if [ "$n_got" -eq 0 ]; then
+      printf '  %-20s FAIL  extracted no files (expected %s)\n' "$label" "$n_want"
+      fail=$((fail+1)); continue
+    fi
+    got="$(tree_hash "$out")"
+    if [ "$got" != "$EXPECTED_TREE" ]; then
+      detail="content differs"
+      [ "$n_got" -ne "$n_want" ] && detail="file count $n_got, expected $n_want"
+      printf '  %-20s FAIL  extracted tree differs: %s\n' "$label" "$detail"
+      ( cd "$CORPUS" && find . -type f | LC_ALL=C sort ) > "$WORK/$label.want" 2>/dev/null
+      ( cd "$out"    && find . -type f | LC_ALL=C sort ) > "$WORK/$label.got"  2>/dev/null
+      diff "$WORK/$label.want" "$WORK/$label.got" 2>/dev/null | head -4 | sed 's/^/      /'
+      fail=$((fail+1)); continue
+    fi
+    printf '  %-20s ok    %s files\n' "$label" "$n_got"
+    rm -rf "$out"
+  done
+
+  echo
+  if [ "$fail" -eq 0 ]; then
+    echo "interop: all $n_arc archive(s) read back identically"
+    exit 0
+  fi
+  echo "interop: $fail of $n_arc archive(s) failed" >&2
+  exit 1
+  ;;
+
+*) usage ;;
+esac

--- a/Tests/interop-test.sh
+++ b/Tests/interop-test.sh
@@ -117,18 +117,23 @@ CASES="
 #
 # Currently expected, set by the cross-platform check steps in build.yml:
 #
-#   tta   The Windows builds reject a TTA archive written by the Linux build.
-#         Both Windows targets fail identically -- GCC-mingw amd64 and Clang
-#         arm64 -- so this is a Windows/Linux difference, not a compiler one,
-#         which points at LLP64 (long is 4 bytes) against LP64 (8). TTA has a
-#         long history of exactly that: nine such bugs were fixed in it for
-#         v2.0.0, every one validated by round-tripping on LP64 hosts only.
-#         -mtta has never been exercised on Windows at all -- win-test.sh
-#         covers -m0/-m1/-m4 and run-tests.sh does not run there -- so this
-#         may be a codec that has never worked on Windows rather than a new
-#         divergence. The self-round-trip step in CI is what tells the two
-#         apart: if a Windows build cannot read even its OWN tta archive, the
-#         bug is in the codec on Windows and has nothing to do with interop.
+#   tta   -mtta does not work on Windows at all. This started as an interop
+#         failure -- both Windows builds rejected a TTA archive written by the
+#         Linux build -- but the self-round-trip step settled it: neither
+#         Windows build can even CREATE a tta archive, so there is no interop
+#         question here. It is a codec that is broken on Windows.
+#
+#         It had simply never been run there. win-test.sh covers -m0/-m1/-m4
+#         and run-tests.sh does not run on Windows, so nothing ever invoked
+#         -mtta on a Windows build; this suite is the first thing to try.
+#
+#         Both targets fail identically -- GCC-mingw on amd64 and Clang on
+#         arm64 -- so it is a Windows/Linux difference rather than a compiler
+#         one, which points at LLP64 (long is 4 bytes) against LP64 (8). TTA
+#         has a long history of exactly that family: nine such bugs were fixed
+#         in it for v2.0.0, every one validated by round-tripping on LP64
+#         hosts only. Tracked as follow-up work; it is a pre-existing defect,
+#         not a regression from anything in this suite.
 XFAIL="${DARC_INTEROP_XFAIL:-}"
 
 is_xfail () {
@@ -140,6 +145,19 @@ tree_hash () {   # order-independent hash of a directory's file contents+names
   [ -d "$1" ] || { echo "no-such-dir"; return; }
   ( cd "$1" && find . -type f -print0 2>/dev/null | LC_ALL=C sort -z |
     while IFS= read -r -d '' f; do printf '%s  %s\n' "$(hash_of "$f")" "$f"; done ) | $SHA | cut -d' ' -f1
+}
+
+# Show why the archiver failed. "tail -3" is not enough: DArc prints a version
+# and host banner after an error, so the last three lines of a failed run are
+# "Version: Windows 10 / Host system: Linux / Host version: ..." and the actual
+# message scrolls past. Prefer lines that look like the diagnosis, and fall
+# back to the tail only when none match.
+why () {  # why <logfile>
+  grep -iE 'error|exception|failed|cannot|unable|not supported' "$1" 2>/dev/null |
+    grep -viE '^ *(Version|Host system|Host version):' | head -3 |
+    sed 's/^/      /'
+  grep -qiE 'error|exception|failed|cannot|unable|not supported' "$1" 2>/dev/null ||
+    tail -3 "$1" | sed 's/^/      /'
 }
 
 rm -rf "$WORK"; mkdir -p "$WORK"
@@ -154,6 +172,7 @@ make)
   rm -f "$DIR"/*.arc "$DIR"/SHA256SUMS 2>/dev/null
   echo "writing archives with $ARC"
   echo "corpus: $n_want files, tree $EXPECTED_TREE"
+  xfail=0; xpass=0
   # Herestring, not a pipeline: a "| while read" loop runs in a subshell in
   # most shells, so anything it counted would be discarded at the done.
   while IFS= read -r line; do
@@ -164,10 +183,19 @@ make)
     # corpus so entries are stored corpus-relative -- both exactly as
     # run-tests.sh does it, so archives are comparable with its fingerprints.
     if ( cd "$CORPUS" && "$ARC" a --nodates -r -y $opts "$(winpath "$arc")" . ) >"$WORK/$label.log" 2>&1; then
-      printf '  %-20s %s\n' "$label" "$(hash_of "$arc")"
+      if is_xfail "$label"; then
+        printf '  %-20s XPASS created -- remove it from XFAIL\n' "$label"
+        xpass=$((xpass+1))
+      else
+        printf '  %-20s %s\n' "$label" "$(hash_of "$arc")"
+      fi
+    elif is_xfail "$label"; then
+      printf '  %-20s xfail cannot create (known, see XFAIL in %s)\n' "$label" "$(basename "$0")"
+      why "$WORK/$label.log"
+      xfail=$((xfail+1))
     else
       printf '  %-20s CREATE FAILED\n' "$label"
-      tail -3 "$WORK/$label.log" | sed 's/^/      /'
+      why "$WORK/$label.log"
     fi
   done <<< "$CASES"
   # Counted from disk rather than from the loop, so the pass condition rests on
@@ -176,8 +204,13 @@ make)
   made="$(ls "$DIR"/*.arc 2>/dev/null | wc -l | tr -d ' ')"
   want="$(echo "$CASES" | grep -c ':')"
   ( cd "$DIR" && $SHA ./*.arc > SHA256SUMS 2>/dev/null )
-  echo "wrote $made/$want archives to $DIR"
-  [ "$made" -eq "$want" ] || { echo "error: $((want-made)) archive(s) were not created" >&2; exit 1; }
+  echo "wrote $made/$want archives to $DIR ($xfail known-broken)"
+  if [ "$xpass" -gt 0 ]; then
+    echo "error: $xpass archive(s) marked xfail were created -- update XFAIL in $0" >&2
+    exit 1
+  fi
+  [ "$made" -eq "$((want - xfail))" ] ||
+    { echo "error: $((want - xfail - made)) archive(s) were not created" >&2; exit 1; }
   ;;
 
 # ---------------------------------------------------------------------------
@@ -213,12 +246,12 @@ check)
 
     if ! "$ARC" t -y "$(winpath "$arc")" >"$WORK/$label.t.log" 2>&1; then
       bad "$label" "integrity test rejected the archive"
-      tail -3 "$WORK/$label.t.log" | sed 's/^/      /'
+      why "$WORK/$label.t.log"
       continue
     fi
     if ! "$ARC" x -y -dp"$(winpath "$out")" "$(winpath "$arc")" >"$WORK/$label.x.log" 2>&1; then
       bad "$label" "extract failed"
-      tail -3 "$WORK/$label.x.log" | sed 's/^/      /'
+      why "$WORK/$label.x.log"
       continue
     fi
 


### PR DESCRIPTION
Follow-up to #49, which flagged this gap. **It found a real bug on its first working run.**

## The gap

`run-tests.sh` only ever asks whether a build can read back its **own** archives. Nothing asked whether the Windows builds — which compile the same codec sources with a *different compiler*, GCC-mingw for amd64 and Clang for arm64 — write archives the Linux build can read, or the reverse. A build can pass every existing test while producing output no other build can open.

## What this adds

`Tests/interop-test.sh`, in two halves because they run on different machines (`make` writes one archive per codec; `check` reads a directory of archives and compares the extracted tree against the corpus). CI wires them into a loop:

```
interop-produce ──(reference archives + corpus + linux arc)──> windows-amd64 (Wine)
                                                               windows-arm64 (native)
interop-verify  <──(archives each Windows build wrote)─────────┘
```

Both directions, all three builds, 14 codecs each — every method that reaches C.

## What it found: -mtta does not work on Windows at all

Not an interop divergence — the Windows builds cannot even **create** a TTA archive, on both targets:

```
tta   xfail cannot create
      Unhandled exception: page fault on write access to 0x00007f3600000000
```

That address is a live heap pointer whose low 32 bits have been overwritten with sample data. **Root cause, confirmed** — `malloc2d`, `Compression/MM/tta.cpp:96`:

```c
array = (long **) calloc (num, sizeof(long *) + len * sizeof(long));
for(i = 0, tmp = (long *) array + num; i < num; i++)
```

`(long *) array + num` advances by `num * sizeof(long)` over a table that is `num * sizeof(long *)` bytes. Equal on LP64; **not** on Windows, where `long` is 4 bytes and pointers are still 8 — so the data block starts halfway inside the pointer table and the samples overwrite the pointers. Encode and decode both crash.

The fix is `(long *)(array + num)`, identical on LP64 and therefore incapable of changing Linux archive bytes. Kept out of this PR on purpose: this branch adds the test, the fix belongs with the codec. It is the **tenth** instance of the family that produced nine fixes for v2.0.0, and a pre-existing defect — `-mtta` had never once been run on Windows (`win-test.sh` covers `-m0/-m1/-m4`, `run-tests.sh` does not run there).

`tta` is marked xfail on the Windows paths rather than deleted from the case list, because a quietly shortened list is indistinguishable from full coverage six months later. An xfail that **passes** is reported as an error, so the entry cannot go stale — fixing the codec will force it out.

## Also learned: byte-identity is thread-count dependent

`interop-verify` reports whether builds emit byte-identical archives:

| | linux == amd64 | linux == arm64 |
|---|---|---|
| store, dict | same | same |
| the other 11 | same | DIFFERS |

amd64-under-Wine matches Linux **exactly** on all 13. arm64 differs on everything except `store` and `dict` — the two methods that do no multithreaded block splitting — which points at the runner's core count driving `-mt`, not at anything platform-specific. All 13 read back correctly in both directions, so this is not a correctness issue. It is reported and deliberately not a gate. Adding `-mt1` would make it deterministic and could turn this into a much stronger check than "reads back correctly"; worth a follow-up.

## Verification

Every failure path was made to fail on purpose before being trusted — this repo has shipped a check that printed `CREATE FAILED` three times and exited 0:

| deliberate fault | result |
|---|---|
| empty archive directory | exit 2, `nothing was checked` |
| corrupted archive body | exit 1, correct codec named |
| corpus not matching the archives | exit 1, all 14 flagged |
| archives cannot be written | exit 1, `wrote 0/14` |
| xfail entry that actually passes | exit 1, `XPASS -- remove it from XFAIL` |
| real failure alongside an XPASS | exit 1, **both** reported |

Also confirmed the script works when the archiver is a wrapper script (the shape the Wine job uses), and that its output is byte-identical either way.

## Two bugs of mine along the way

- `abspath()` used `cd $(dirname) && pwd`, which requires the parent to exist. In `make` mode the output directory does not, so `cd` failed, its error was suppressed, and `interop/archives` silently became `/archives` — still absolute, still plausible, pointing nowhere. Every local test had happened to use an existing parent. Reproduced the exact shape locally, then fixed.
- Failure reporting used `tail -3`, but DArc prints a version/host banner *after* an error, so failed runs showed `Version: Windows 10 / Host system: Linux / …` while the real message scrolled past. That is why the first TTA diagnosis had to come from an exit code rather than the log. Failures now prefer lines that look like a diagnosis.

CI: 12/12 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)