### PR TITLE
TTA: step over the row-pointer table by pointer, not by long

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -306,23 +306,18 @@ jobs:
         path: interop
     # Own archives first. If this build cannot read back what it just wrote,
     # the codec is broken on Windows and any interop failure below is a
-    # consequence rather than a finding. That is exactly what this step
-    # established for tta: neither Windows build can even create a tta
-    # archive, so it is xfail here too -- see interop-test.sh.
+    # consequence rather than a finding -- which is exactly what this step
+    # established for tta, whose malloc2d bug it found before the interop
+    # check could mislead anyone into calling it a format divergence.
     - name: Round-trip this build's own archives
       shell: bash
-      env:
-        DARC_INTEROP_XFAIL: tta
       run: |
         set -euo pipefail
         tar -xf interop/corpus.tar -C interop
         bash Tests/interop-test.sh make  Tests/arc-mhs-win-arm64.exe interop/corpus out-arm64
         bash Tests/interop-test.sh check Tests/arc-mhs-win-arm64.exe interop/corpus out-arm64
-    # See the XFAIL comment block in interop-test.sh for why tta is listed.
     - name: Read Linux-written archives
       shell: bash
-      env:
-        DARC_INTEROP_XFAIL: tta
       run: |
         set -euo pipefail
         bash Tests/interop-test.sh check Tests/arc-mhs-win-arm64.exe interop/corpus interop/archives
@@ -433,18 +428,12 @@ jobs:
         chmod +x winbin/arc
     # Own archives first, for the same reason as the arm64 job: a build that
     # cannot read back what it just wrote has a codec bug, not an interop one.
-    # tta is xfail here because it turned out to be exactly that.
     - name: Round-trip this build's own archives
-      env:
-        DARC_INTEROP_XFAIL: tta
       run: |
         set -euo pipefail
         Tests/interop-test.sh make  winbin/arc interop/corpus out-amd64
         Tests/interop-test.sh check winbin/arc interop/corpus out-amd64
-    # See the XFAIL comment block in interop-test.sh for why tta is listed.
     - name: Read Linux-written archives
-      env:
-        DARC_INTEROP_XFAIL: tta
       run: Tests/interop-test.sh check winbin/arc interop/corpus interop/archives
     - uses: actions/upload-artifact@v4
       with:
@@ -473,10 +462,7 @@ jobs:
       with:
         name: interop-win-arm64
         path: from-arm64
-    # See the XFAIL comment block in interop-test.sh for why tta is listed.
     - name: Read Windows-written archives on Linux
-      env:
-        DARC_INTEROP_XFAIL: tta
       run: |
         set -euo pipefail
         tar -xf interop/corpus.tar -C interop

--- a/Compression/MM/tta.cpp
+++ b/Compression/MM/tta.cpp
@@ -93,7 +93,22 @@ long **malloc2d (long num, unsigned long len)
     array = (long **) calloc (num, sizeof(long *) + len * sizeof(long));
     if (array == NULL) tta_error (MEMORY_ERROR, NULL);
 
-    for(i = 0, tmp = (long *) array + num; i < num; i++)
+    // One allocation holds num row pointers followed by num*len samples, so
+    // the data starts immediately past the pointer table. Step over it in
+    // units of the pointer -- "(long *)(array + num)" -- not in units of long.
+    //
+    // The original "(long *) array + num" advances by num * sizeof(long) over
+    // a table that is num * sizeof(long *) bytes. Those are the same size only
+    // where long is as wide as a pointer. On Windows they are not: long is 4
+    // bytes and pointers are 8, so the data block began halfway inside the
+    // pointer table and the first samples written overwrote the row pointers.
+    // Both encode and decode then died with a page fault on an address like
+    // 0x00007f3600000000 -- a live heap pointer whose low half had been
+    // replaced by sample data.
+    //
+    // Equivalent on LP64, where the two strides coincide, so archives written
+    // by Linux and macOS builds are unchanged by this.
+    for(i = 0, tmp = (long *) (array + num); i < num; i++)
         array[i] = tmp + i * len;
 
     return (array);

--- a/Tests/interop-test.sh
+++ b/Tests/interop-test.sh
@@ -100,54 +100,30 @@ CASES="
 -mdelta+lzma:chain-delta-lzma
 "
 
-# Codecs allowed to fail, named by the caller in DARC_INTEROP_XFAIL. Kept in
-# CASES rather than deleted from it, because a quietly shortened list is
-# indistinguishable from full coverage six months later -- every run prints
-# these as xfail, so the gap stays visible in the log.
+# Codecs allowed to fail, named by the caller in DARC_INTEROP_XFAIL. A case
+# marked here stays in CASES and is still run and printed, because a quietly
+# shortened list is indistinguishable from full coverage six months later.
 #
 # An xfail that PASSES is reported as an error, not a success: the list is a
 # claim about what is broken, and a stale entry understates coverage just as
 # badly as deleting the case would.
 #
-# The default is empty, and it has to be, because whether a codec interoperates
-# is a property of the PAIR of builds involved. tta below is fine when a build
-# reads its own archives and only fails across the Linux/Windows boundary; a
-# list baked into this script would turn every same-build run into a false
-# XPASS. So each CI call site names what it expects to fail.
+# The default is empty, and it has to be, because whether a codec
+# interoperates is a property of the PAIR of builds involved -- a codec can be
+# fine when a build reads its own archives and fail only across the
+# Linux/Windows boundary. A list baked into this script would turn every
+# same-build run into a false XPASS. So each call site names what it expects
+# to fail.
 #
-# Currently expected, set by the cross-platform check steps in build.yml:
+# Nothing is currently expected to fail; no CI step sets this.
 #
-#   tta   -mtta does not work on Windows at all. This started as an interop
-#         failure -- both Windows builds rejected a TTA archive written by the
-#         Linux build -- but the self-round-trip step settled it: neither
-#         Windows build can even CREATE a tta archive, so there is no interop
-#         question here. It is a codec that is broken on Windows.
-#
-#         It had simply never been run there. win-test.sh covers -m0/-m1/-m4
-#         and run-tests.sh does not run on Windows, so nothing ever invoked
-#         -mtta on a Windows build; this suite is the first thing to try.
-#
-#         Root cause, confirmed: malloc2d in Compression/MM/tta.cpp lays a
-#         pointer table and a data block into one allocation, and steps over
-#         the table with
-#
-#             tmp = (long *) array + num;
-#
-#         That advances by num * sizeof(long). The table it is skipping is
-#         num * sizeof(long *) bytes. Those are equal on LP64 and NOT on
-#         Windows, where long is 4 bytes and pointers are still 8 -- so the
-#         data block starts halfway inside the pointer table and the samples
-#         overwrite the pointers. Hence "page fault on write access to
-#         0x00007f3600000000": a live heap pointer whose low 32 bits have been
-#         replaced by sample data. Both directions crash, encode and decode.
-#
-#         The fix is to step over the table as pointers, "(long *)(array +
-#         num)", which is identical on LP64 and therefore leaves Linux archive
-#         bytes untouched. Remove tta from the xfail sites in build.yml when
-#         it lands -- an XPASS will insist on it anyway.
-#
-#         Tenth instance of the family that produced nine fixes for v2.0.0,
-#         and a pre-existing defect rather than a regression from this suite.
+# The one entry this ever held was tta, which turned out not to be an interop
+# problem at all: neither Windows build could CREATE a tta archive, because
+# malloc2d in Compression/MM/tta.cpp stepped over its pointer table in units
+# of long rather than of pointer -- the same size on LP64, half the size on
+# Windows, so the samples overwrote the pointers. Fixed; the XPASS check is
+# what forced this list back to empty.
+
 XFAIL="${DARC_INTEROP_XFAIL:-}"
 
 is_xfail () {


### PR DESCRIPTION
Fixes the defect the interop suite from #50 found on its first working run: **`-mtta` could not create or read a single archive on Windows.**

## The bug

Both Windows targets died identically — GCC-mingw on amd64 and Clang on arm64:

```
Unhandled exception: page fault on write access to 0x00007f3600000000
```

That address is a live heap pointer whose low 32 bits have been replaced by sample data — the signature of a buffer written over its own pointer table.

`malloc2d` (`Compression/MM/tta.cpp`) packs `num` row pointers and `num*len` samples into one allocation, so the data starts immediately past the table. It stepped over the table with:

```c
tmp = (long *) array + num;
```

That advances by `num * sizeof(long)` over a table that is `num * sizeof(long *)` bytes. Equal only where `long` is as wide as a pointer. On Windows it is not — `long` is 4 bytes, pointers are 8 — so the data block began **halfway inside the pointer table**, and the first samples written destroyed the row pointers. Encode and decode both crashed.

Stepping over it as pointers, `(long *)(array + num)`, is correct under both models.

## Evidence, rather than argument

Two compilations pin down the effect:

| built for | before vs after | means |
|---|---|---|
| `aarch64-w64-mingw32` (LLP64) | objects **differ** | the change reaches Windows code generation |
| host (LP64) | objects **byte-identical** | it cannot alter what Linux/macOS builds write |

The LP64 result is a stronger statement than "the fingerprints still match", which would only have covered the corpus. Both objects were confirmed to exist and be non-empty before comparing — an earlier version of this check compared two files that had failed to compile and cheerfully reported "DIFFER".

## Why it survived v2.0.0

This is the **tenth** instance of the `long`-width family that produced nine fixes for v2.0.0. It survived because nothing had ever run `-mtta` on Windows: `win-test.sh` covers `-m0/-m1/-m4`, and `run-tests.sh` does not run there. The interop suite was the first thing to try it.

## Removing the xfail

The `tta` xfail entries #50 carried on the Windows paths are removed here, and `DARC_INTEROP_XFAIL` is now unset everywhere. That is not optional bookkeeping — the suite reports an xfail that *starts passing* as an error, so leaving them would have failed CI. The mechanism and the history stay documented in `interop-test.sh`.

**CI is the functional check**: `interop-windows-amd64` and `windows-arm64-test` now have to create and read a `tta` archive, in both directions, on real hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)