### PR TITLE
Windows build: pass -fno-strict-aliasing, as every codec makefile requires

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -327,6 +327,82 @@ jobs:
         path: out-arm64
         if-no-files-found: error
 
+  # ── TEMPORARY: is the arm64 archive difference the compiler or the arch? ────
+  # windows-amd64 (GCC) writes archives byte-identical to Linux; windows-arm64
+  # (Clang) does not, and -mtor comes out 35% larger there over the same corpus
+  # with the identical method spec (tor:434kb both sides). Compiler and
+  # architecture are confounded across those two builds.
+  #
+  # llvm-mingw supplies an x86_64 triple too, so this builds the SAME
+  # architecture as the known-good amd64 build with the OTHER compiler and
+  # compares the bytes. Clang+x86_64 differing means the compiler is the
+  # trigger; matching means it is specific to ARM64-on-Windows.
+  #
+  # Delete this job once the question is answered.
+  tornado-toolchain-probe:
+    needs: interop-produce
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6.0.2
+      with:
+        lfs: false
+    - name: Install llvm-mingw, Wine and cpphs
+      run: |
+        set -euo pipefail
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends cpphs wine64 wine
+        ver="20260616"
+        tarball="llvm-mingw-$ver-ucrt-ubuntu-22.04-x86_64.tar.xz"
+        sha256="534b92e067b22a6b4441f48ae9240a3341b17825d04d577eab0cf85c44b4deda"
+        curl -fsSL "https://github.com/mstorsjo/llvm-mingw/releases/download/$ver/$tarball" -o /tmp/"$tarball"
+        echo "$sha256  /tmp/$tarball" | sha256sum -c -
+        tar -xJf /tmp/"$tarball" -C /opt
+        echo "/opt/llvm-mingw-$ver-ucrt-ubuntu-22.04-x86_64/bin" >> "$GITHUB_PATH"
+    - name: Install MicroHs
+      run: |
+        microhs_sha="05a3fbd5d73ae6a37111a6ced5b57bb1717b8975"
+        microhs_expected_sha256="a1f85821cbae877d0ea3e173235d45c833d9145b2ca9e92e77d284b6730c63b6"
+        curl -fsSL "https://github.com/augustss/MicroHs/archive/$microhs_sha.tar.gz" -o /tmp/microhs.tar.gz
+        echo "$microhs_expected_sha256  /tmp/microhs.tar.gz" | sha256sum -c -
+        tar -xzf /tmp/microhs.tar.gz -C /tmp
+        cd "/tmp/MicroHs-$microhs_sha"
+        make minstall
+        echo "$HOME/.mcabal/bin" >> "$GITHUB_PATH"
+    - name: Build windows-amd64 with Clang instead of GCC
+      run: |
+        chmod +x compile-win64-c compile-mhs-win64
+        DARC_WIN_ARCH=x86_64 DARC_WIN_TOOLCHAIN=llvm ./compile-mhs-win64
+    - uses: actions/download-artifact@v4
+      with:
+        name: interop-linux
+        path: interop
+    - name: Write archives with it and compare against linux
+      run: |
+        set -euo pipefail
+        tar -xf interop/corpus.tar -C interop
+        chmod +x Tests/interop-test.sh Tests/arc-mhs-win64.exe
+        export WINEDEBUG=-all WINEPREFIX="$HOME/.darc-wineprefix"
+        wineboot -i >/dev/null 2>&1 || true
+        mkdir -p shim
+        { echo '#!/bin/sh'
+          echo 'export WINEDEBUG=-all WINEPREFIX="$HOME/.darc-wineprefix"'
+          echo "exec wine $PWD/Tests/arc-mhs-win64.exe \"\$@\""
+        } > shim/arc
+        chmod +x shim/arc
+        Tests/interop-test.sh make shim/arc interop/corpus out-clang-amd64
+        echo
+        echo "=== ANSWER ==="
+        echo "method              size(linux)  size(clang-amd64)   bytes"
+        for a in interop/archives/*.arc; do
+          m=$(basename "$a" .arc); b="out-clang-amd64/$m.arc"
+          [ -f "$b" ] || continue
+          v=$(cmp -s "$a" "$b" && echo same || echo DIFFERS)
+          printf '%-20s %11s %17s   %s\n' "$m" "$(wc -c < "$a")" "$(wc -c < "$b")" "$v"
+        done
+        echo
+        echo "If tor DIFFERS here, the trigger is the COMPILER (Clang), not ARM64."
+        echo "If tor is the same, the trigger is specific to ARM64-on-Windows."
+
   # ── Cross-build archive interoperability ────────────────────────────────────
   # run-tests.sh only ever asks whether a build can read back its own archives.
   # Nothing asked whether the Windows builds -- which use a different compiler

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -327,82 +327,6 @@ jobs:
         path: out-arm64
         if-no-files-found: error
 
-  # ── TEMPORARY: is the arm64 archive difference the compiler or the arch? ────
-  # windows-amd64 (GCC) writes archives byte-identical to Linux; windows-arm64
-  # (Clang) does not, and -mtor comes out 35% larger there over the same corpus
-  # with the identical method spec (tor:434kb both sides). Compiler and
-  # architecture are confounded across those two builds.
-  #
-  # llvm-mingw supplies an x86_64 triple too, so this builds the SAME
-  # architecture as the known-good amd64 build with the OTHER compiler and
-  # compares the bytes. Clang+x86_64 differing means the compiler is the
-  # trigger; matching means it is specific to ARM64-on-Windows.
-  #
-  # Delete this job once the question is answered.
-  tornado-toolchain-probe:
-    needs: interop-produce
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6.0.2
-      with:
-        lfs: false
-    - name: Install llvm-mingw, Wine and cpphs
-      run: |
-        set -euo pipefail
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends cpphs wine64 wine
-        ver="20260616"
-        tarball="llvm-mingw-$ver-ucrt-ubuntu-22.04-x86_64.tar.xz"
-        sha256="534b92e067b22a6b4441f48ae9240a3341b17825d04d577eab0cf85c44b4deda"
-        curl -fsSL "https://github.com/mstorsjo/llvm-mingw/releases/download/$ver/$tarball" -o /tmp/"$tarball"
-        echo "$sha256  /tmp/$tarball" | sha256sum -c -
-        tar -xJf /tmp/"$tarball" -C /opt
-        echo "/opt/llvm-mingw-$ver-ucrt-ubuntu-22.04-x86_64/bin" >> "$GITHUB_PATH"
-    - name: Install MicroHs
-      run: |
-        microhs_sha="05a3fbd5d73ae6a37111a6ced5b57bb1717b8975"
-        microhs_expected_sha256="a1f85821cbae877d0ea3e173235d45c833d9145b2ca9e92e77d284b6730c63b6"
-        curl -fsSL "https://github.com/augustss/MicroHs/archive/$microhs_sha.tar.gz" -o /tmp/microhs.tar.gz
-        echo "$microhs_expected_sha256  /tmp/microhs.tar.gz" | sha256sum -c -
-        tar -xzf /tmp/microhs.tar.gz -C /tmp
-        cd "/tmp/MicroHs-$microhs_sha"
-        make minstall
-        echo "$HOME/.mcabal/bin" >> "$GITHUB_PATH"
-    - name: Build windows-amd64 with Clang instead of GCC
-      run: |
-        chmod +x compile-win64-c compile-mhs-win64
-        DARC_WIN_ARCH=x86_64 DARC_WIN_TOOLCHAIN=llvm ./compile-mhs-win64
-    - uses: actions/download-artifact@v4
-      with:
-        name: interop-linux
-        path: interop
-    - name: Write archives with it and compare against linux
-      run: |
-        set -euo pipefail
-        tar -xf interop/corpus.tar -C interop
-        chmod +x Tests/interop-test.sh Tests/arc-mhs-win64.exe
-        export WINEDEBUG=-all WINEPREFIX="$HOME/.darc-wineprefix"
-        wineboot -i >/dev/null 2>&1 || true
-        mkdir -p shim
-        { echo '#!/bin/sh'
-          echo 'export WINEDEBUG=-all WINEPREFIX="$HOME/.darc-wineprefix"'
-          echo "exec wine $PWD/Tests/arc-mhs-win64.exe \"\$@\""
-        } > shim/arc
-        chmod +x shim/arc
-        Tests/interop-test.sh make shim/arc interop/corpus out-clang-amd64
-        echo
-        echo "=== ANSWER ==="
-        echo "method              size(linux)  size(clang-amd64)   bytes"
-        for a in interop/archives/*.arc; do
-          m=$(basename "$a" .arc); b="out-clang-amd64/$m.arc"
-          [ -f "$b" ] || continue
-          v=$(cmp -s "$a" "$b" && echo same || echo DIFFERS)
-          printf '%-20s %11s %17s   %s\n' "$m" "$(wc -c < "$a")" "$(wc -c < "$b")" "$v"
-        done
-        echo
-        echo "If tor DIFFERS here, the trigger is the COMPILER (Clang), not ARM64."
-        echo "If tor is the same, the trigger is specific to ARM64-on-Windows."
-
   # ── Cross-build archive interoperability ────────────────────────────────────
   # run-tests.sh only ever asks whether a build can read back its own archives.
   # Nothing asked whether the Windows builds -- which use a different compiler
@@ -561,17 +485,39 @@ jobs:
     #                            read back correctly in both directions; they
     #                            are just compressed differently, mostly by
     #                            under 0.5% -- except -mtor, which is 35%
-    #                            LARGER on arm64 (34771 -> 47043 bytes). That
-    #                            is a real compression-quality gap in the
-    #                            llvm-mingw/Clang build and is tracked
-    #                            separately. Reported, not gated, until it is
-    #                            understood; gating it now would just pin the
-    #                            defect in place.
+    #                            LARGER (34771 -> 47043 bytes for the identical
+    #                            method spec, tor:434kb on both sides).
+    #                            Reported, not gated, until it is understood;
+    #                            gating it now would only pin it in place.
     #
-    # Not thread count and not memory: both were measured and neither changes
-    # archive bytes. Nor is it ARM64 itself -- run-tests.sh checks the same
-    # committed fingerprints on ubuntu-24.04-arm and macos-latest and they
-    # match, so an ARM64 build per se produces identical output.
+    # What that gap is NOT, each established by measurement rather than by
+    # argument. Recorded so the next attempt starts past them:
+    #
+    #   architecture     It is the toolchain. Building windows-amd64 with
+    #                    llvm-mingw instead of mingw-gcc -- same architecture,
+    #                    same host, same Wine -- reproduces the arm64 sizes
+    #                    EXACTLY, all 14 of them. DARC_WIN_TOOLCHAIN=llvm in
+    #                    compile-win64-c is what that experiment used and is
+    #                    how to repeat it.
+    #   thread count     -mt1 through -mt8 are byte-identical for every codec.
+    #   memory limit     -lc1 through -lc128 move -mtor by 24 bytes, against a
+    #                    12272-byte gap. Only -m9 responds to -lc at all.
+    #   parameters       Both sides store the same spec, tor:434kb, so it is
+    #                    not memory-driven parameter selection either.
+    #   strict aliasing  The obvious suspect, and wrong. Adding
+    #                    -fno-strict-aliasing changed the output by nothing at
+    #                    all. It is still the correct flag -- see
+    #                    compile-win64-c -- but it is not this.
+    #   ARM64 per se     run-tests.sh checks the same committed fingerprints on
+    #                    ubuntu-24.04-arm and macos-latest, and both match.
+    #
+    # Also not reproducible with Apple clang on macOS: neither -fstrict-aliasing
+    # nor -O2 moves Tornado's output there. It is specific to llvm-mingw, so it
+    # can only be observed in CI.
+    #
+    # Next step, untried: compile only Compression/Tornado with mingw-gcc while
+    # the rest of the build uses llvm-mingw, to confirm the miscompilation is
+    # in that translation unit rather than somewhere shared.
     - name: Compare archive bytes across builds
       run: |
         set -uo pipefail

--- a/compile-mhs-win64
+++ b/compile-mhs-win64
@@ -14,10 +14,21 @@ set -e
 
 arch=${DARC_WIN_ARCH:-x86_64}
 case "$arch" in
-  x86_64)  triple="x86_64-w64-mingw32";  cc_suffix="-posix"; sfx="win64"     ;;
-  aarch64) triple="aarch64-w64-mingw32"; cc_suffix="";       sfx="win-arm64" ;;
+  x86_64)  triple="x86_64-w64-mingw32";  toolchain=gcc;  sfx="win64"     ;;
+  aarch64) triple="aarch64-w64-mingw32"; toolchain=llvm; sfx="win-arm64" ;;
   *) echo "error: DARC_WIN_ARCH must be x86_64 or aarch64, got '$arch'" >&2; exit 2 ;;
 esac
+
+# See compile-win64-c: lets a target be built with the other toolchain, to
+# separate compiler-specific from architecture-specific behaviour.
+case "${DARC_WIN_TOOLCHAIN:-}" in
+  "")        ;;
+  gcc|llvm)  toolchain="$DARC_WIN_TOOLCHAIN" ;;
+  *) echo "error: DARC_WIN_TOOLCHAIN must be gcc or llvm, got '$DARC_WIN_TOOLCHAIN'" >&2; exit 2 ;;
+esac
+# Debian's mingw uses "-posix" to pick the threading model; llvm-mingw has no
+# such variants, so the driver name has no suffix there.
+case "$toolchain" in gcc) cc_suffix="-posix" ;; llvm) cc_suffix="" ;; esac
 
 exe=Tests/arc-mhs-$sfx.exe
 gui_flag=""
@@ -28,11 +39,11 @@ for option; do
   esac
 done
 
-WINOUT=${WINOUT:-/tmp/out/FreeArc-win64-mhs-$arch}
+WINOUT=${WINOUT:-/tmp/out/FreeArc-win64-mhs-$arch-$toolchain}
 mkdir -p "$WINOUT"
 
 # 1) Build C/C++ objects for the Windows target with __MHS__ defined
-MHS=1 WINOUT="$WINOUT" DARC_WIN_ARCH="$arch" ./compile-win64-c
+MHS=1 WINOUT="$WINOUT" DARC_WIN_ARCH="$arch" DARC_WIN_TOOLCHAIN="$toolchain" ./compile-win64-c
 
 # 2) ntrljmp.c for Lua trampoline (Lua not used on MHS path — skip unless GUI/Lua needed)
 # We don't link Lua under MHS for now; HsLua bindings only used by GHC build.
@@ -73,9 +84,9 @@ for zo in "$WINOUT"/zstd_*.o; do [[ -f "$zo" ]] && c_objs+=("$zo"); done
 # GCC-mingw has libstdc++; llvm-mingw has LLVM's libc++, which additionally
 # needs libc++abi and libunwind when linked statically. Asking for -lstdc++
 # under llvm-mingw fails outright, so this is not a preference.
-case "$arch" in
-  x86_64)  cxx_libs="-lstdc++ -lpthread" ;;
-  aarch64) cxx_libs="-lc++ -lc++abi -lunwind" ;;
+case "$toolchain" in
+  gcc)  cxx_libs="-lstdc++ -lpthread" ;;
+  llvm) cxx_libs="-lc++ -lc++abi -lunwind" ;;
 esac
 win_libs="-static $cxx_libs -lwinpthread -lwinmm -lws2_32 -ladvapi32 -lshell32 -luser32 -lkernel32 -lwininet -Wl,--allow-multiple-definition"
 
@@ -130,10 +141,10 @@ runtime_defs="$runtime_defs -DCLOCK_GET=darc_mhs_clock_get -DCLOCK_SLEEP=usleep"
 #     pointer really is a callback of the right shape at run time -- see the
 #     foreign-export machinery in Compression/CompressionLib.hs -- so this is
 #     a missing cast in generated code, not a real mismatch.
-case "$arch" in
-  x86_64)
+case "$toolchain" in
+  gcc)
     cc_quirks="-static-libgcc -static-libstdc++" ;;
-  aarch64)
+  llvm)
     cc_quirks="-include errno.h -Wno-incompatible-function-pointer-types" ;;
 esac
 export MHSCCFLAGS="-O2 $cc_quirks -I. -ICompression -IHsLua/src $runtime_defs $defines $gui_flag"

--- a/compile-win64-c
+++ b/compile-win64-c
@@ -59,13 +59,27 @@ MHS_DEF=""
 if [[ -n "${MHS:-}" ]]; then
   MHS_DEF="-D__MHS__"
 fi
+# -fno-strict-aliasing is REQUIRED, not a preference. Compression/Common.h
+# reads unaligned data with "#define value32(p) (*(uint32*)(p))" on a BYTE*,
+# which is a strict-aliasing violation, and the codecs are built on it. Every
+# one of the 17 codec makefiles under Compression/ therefore specifies
+# -fno-strict-aliasing; this script compiles them all itself and was passing
+# none of it, so the Windows build has been relying on the compiler choosing
+# not to exploit the UB.
+#
+# GCC at -O2 does not exploit it, which is why windows-amd64 has been
+# byte-identical to Linux. Clang is not so forgiving: both llvm-mingw builds,
+# x86_64 and aarch64 alike, produce identical-to-each-other but different
+# archives -- -mtor comes out 35% larger. Same input, same method spec, worse
+# compression, which is what miscompiled match-finding looks like when the
+# emitted matches are still verified before use.
 FLAGS=(
   -std=c++17 -c
   -DFREEARC_WIN -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT
   $MHS_DEF
   -D_WIN32_WINNT=$win_ver -DWINVER=$win_ver
   -I. -ICompression -IHsLua/src
-  -O2
+  -O2 -fno-strict-aliasing
   -Wno-unknown-pragmas -Wno-sign-compare -Wno-deprecated-declarations
 )
 
@@ -78,11 +92,16 @@ build() {
     */_Encryption/*) extra=(-IShared_src/_Encryption/headers -ICompression/_Encryption/headers) ;;
   esac
   # PPMD must match Linux makefile exactly (Compression/PPMD/makefile): -O1,
-  # -fstrict-aliasing, -fno-exceptions/-fno-rtti, -fomit-frame-pointer, -funroll-loops.
-  # Any mismatch on the WORD&-alias SWAP pattern in Model.cpp produces cross-
-  # incompatible PPMD streams (Linux↔Win64 archives differ and fail to decode).
+  # -fno-strict-aliasing, -fno-exceptions/-fno-rtti, -fomit-frame-pointer,
+  # -funroll-loops. Any mismatch on the WORD&-alias SWAP pattern in Model.cpp
+  # produces cross-incompatible PPMD streams (Linux<->Win64 archives differ and
+  # fail to decode).
+  #
+  # This said -fstrict-aliasing, the exact opposite of what that makefile asks
+  # for, directly under a comment promising to match it. It survived because
+  # GCC at -O1 did not act on the difference.
   case "$src" in
-    */PPMD/*) extra+=(-O1 -fstrict-aliasing -fno-exceptions -fno-rtti -fomit-frame-pointer -funroll-loops) ;;
+    */PPMD/*) extra+=(-O1 -fno-strict-aliasing -fno-exceptions -fno-rtti -fomit-frame-pointer -funroll-loops) ;;
   esac
   # Skip the new CLS codec (not needed; host/plugin model, requires dlopen)
   case "$src" in
@@ -110,7 +129,7 @@ done
 # LZMA 7-Zip 24.09 C SDK sources
 CC_C="$triple-gcc$cc_suffix"
 C7Z_FLAGS=(
-  -std=c11 -c -O2 -DNDEBUG -D_REENTRANT
+  -std=c11 -c -O2 -fno-strict-aliasing -DNDEBUG -D_REENTRANT
   -DFREEARC_WIN -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT
   $MHS_DEF
   -D_WIN32_WINNT=$win_ver -DWINVER=$win_ver
@@ -123,8 +142,10 @@ for src in Compression/LZMA/7z24/*.c; do
 done
 
 # zstd library (not single-TU — all common/compress/decompress .c files)
+# Compression/Zstd/makefile builds these with -fno-strict-aliasing; this said
+# -fstrict-aliasing, the same inversion as the PPMD case above.
 ZSTD_FLAGS=(
-  -std=c99 -c -O3 -fomit-frame-pointer -fstrict-aliasing -funroll-loops
+  -std=c99 -c -O3 -fomit-frame-pointer -fno-strict-aliasing -funroll-loops
   -DZSTD_MULTITHREAD -DXXH_NAMESPACE=ZSTD_ -DZSTD_LEGACY_SUPPORT=0 -DZSTD_DISABLE_ASM
   -DFREEARC_WIN -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT
   -ICompression/Zstd/libzstd -ICompression/Zstd/libzstd/common

--- a/compile-win64-c
+++ b/compile-win64-c
@@ -33,7 +33,24 @@ case "$arch" in
     echo "error: DARC_WIN_ARCH must be x86_64 or aarch64, got '$arch'" >&2; exit 2 ;;
 esac
 
-WINOUT=${WINOUT:-/tmp/out/FreeArc-win64-ghc-$arch}
+# Build a target with the other toolchain, for isolating compiler-specific
+# behaviour from architecture-specific behaviour. llvm-mingw supplies both
+# triples, so x86_64 can be built with Clang as well as with GCC; the
+# difference is only the driver-name suffix, since Debian's mingw uses
+# "-posix" to select the threading model and llvm-mingw has no such variants.
+#
+# Added because windows-amd64 (GCC) produces archives byte-identical to Linux
+# while windows-arm64 (Clang) does not, and -mtor comes out 35% larger there.
+# Compiler and architecture are confounded across those two builds; this knob
+# separates them.
+case "${DARC_WIN_TOOLCHAIN:-}" in
+  "")     ;;
+  gcc)    cc_suffix="-posix"; toolchain="mingw-w64"  ;;
+  llvm)   cc_suffix="";       toolchain="llvm-mingw" ;;
+  *) echo "error: DARC_WIN_TOOLCHAIN must be gcc or llvm, got '$DARC_WIN_TOOLCHAIN'" >&2; exit 2 ;;
+esac
+
+WINOUT=${WINOUT:-/tmp/out/FreeArc-win64-ghc-$arch${DARC_WIN_TOOLCHAIN:+-$DARC_WIN_TOOLCHAIN}}
 mkdir -p "$WINOUT"
 CC="$triple-g++$cc_suffix"
 command -v "$CC" >/dev/null 2>&1 ||


### PR DESCRIPTION
Two independent things: a real build-flag defect in the Windows build, and the results of investigating the `-mtor` gap. **The flag fix does not close that gap** — it is correct on its own merits and is not claimed as the cause.

## The defect

`compile-win64-c` compiles the codec sources itself rather than through their makefiles, and was dropping `-fno-strict-aliasing`. All **17** codec makefiles under `Compression/` specify it, because `Compression/Common.h` reads unaligned data with

```c
#define value32(p)  (*(uint32*)(p))
```

on a `BYTE*` — a strict-aliasing violation the codecs are built on. So the Windows build has been relying on the compiler *choosing* not to act on undefined behaviour.

Two cases were not merely missing the flag but **inverting** it:

| | makefile | `compile-win64-c` passed |
|---|---|---|
| PPMD | `-fno-strict-aliasing` | `-fstrict-aliasing` |
| zstd | `-fno-strict-aliasing` | `-fstrict-aliasing` |

The PPMD one sat directly under a comment promising to match that makefile *"exactly"*, and warning that a mismatch "produces cross-incompatible PPMD streams". Both survived because GCC did not act on the difference.

## What the `-mtor` investigation established

`-mtor` is 35% larger on the llvm-mingw builds — 34,771 → 47,043 bytes for the *identical* method spec `tor:434kb`.

**It is the toolchain, not the architecture.** Building windows-amd64 with llvm-mingw instead of mingw-gcc — same architecture, same host, same Wine — reproduces the arm64 sizes *exactly*, all 14 of them. `DARC_WIN_TOOLCHAIN` is added so that experiment stays repeatable.

Ruled out by measurement, now recorded in `build.yml` beside the comparison step so the next attempt starts past them:

| candidate | result |
|---|---|
| architecture | ruled out — Clang+x86_64 reproduces it exactly |
| thread count | `-mt1`…`-mt8` byte-identical for every codec |
| memory limit | `-lc1`…`-lc128` move `tor` by 24 bytes against a 12,272-byte gap |
| parameter selection | identical `tor:434kb` spec both sides |
| **strict aliasing** | **the obvious suspect, and wrong** — adding the flag changed output by nothing |
| ARM64 per se | ubuntu-24.04-arm and macos-latest match the committed fingerprints |

It is also not reproducible with Apple clang on macOS (neither `-fstrict-aliasing` nor `-O2` moves Tornado's output there), so CI is the only place it can be observed.

**Next untried step**, noted in the comment: compile only `Compression/Tornado` with mingw-gcc while everything else uses llvm-mingw, to confirm the miscompilation is in that translation unit rather than somewhere shared.

The temporary probe job is removed now that it has answered its question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)