### PR TITLE
TTA: port the decoder to Rust — byte-identical, verified end-to-end

### DIFF
--- a/Compression/MM/tta.cpp
+++ b/Compression/MM/tta.cpp
@@ -438,6 +438,21 @@ finished:
 }
 #endif
 
+// DARC_RUST=1 selects the Rust port of the decoder (rust/darc-codecs).
+//
+// tta_decompress is declared in ttaenc.h, which C_TTA.h pulls in inside
+// C_TTA.cpp's extern "C" block, so this definition has C linkage and shares a
+// symbol with the Rust export. Excluded rather than redeclared: with both
+// present the linker resolves from this object and never pulls the Rust one --
+// and, both being C-linkage, GNU ld reports a multiple definition. So the
+// switch has to remove this definition, not merely add a declaration elsewhere.
+// The same is true of the other codecs (C_Dict.cpp, C_LZP.cpp, rep.cpp).
+//
+// The encoder (tta_compress) and everything it shares -- read_wave, split_*,
+// the entropy encoder, the filters -- stay compiled; only this entry point is
+// replaced. Verified byte-identical to the C decoder over a matrix of channel
+// counts, word sizes and levels; see rust/difftest/tta-check.sh.
+#ifndef DARC_RUST
 int tta_decompress (CALLBACK_FUNC *callback, void *auxdata)
 {
     long    **buffer=NULL;
@@ -548,6 +563,7 @@ finished:
     FreeAndNil (rest);
     return errcode;
 }
+#endif  // !DARC_RUST (tta_decompress)
 
 
 #ifndef TTA_LIBRARY

--- a/rust/darc-codecs/src/exports.rs
+++ b/rust/darc-codecs/src/exports.rs
@@ -8,7 +8,7 @@
 //! what wires them together; until then these are exercised by the differential
 //! harness rather than by the archiver.
 
-use crate::{delta, dict, dict_encode, lzp, rep};
+use crate::{delta, dict, dict_encode, lzp, rep, tta};
 use crate::ffi::{Io, CALLBACK_FUNC, FREEARC_ERRCODE_GENERAL};
 use core::ffi::{c_int, c_void};
 
@@ -247,6 +247,36 @@ pub unsafe extern "C" fn rep_decompress(
     callback: CALLBACK_FUNC, auxdata: *mut c_void,
 ) -> c_int {
     darc_rs_rep_decompress(block_size, a, b, c, d, e, f, callback, auxdata)
+}
+
+/// TTA decoder. `tta_decompress` takes no tuning parameters -- level, channel
+/// count and word size all travel in the stream header.
+///
+/// # Safety
+/// `callback` and `auxdata` must be what the C caller supplied.
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_tta_decompress(
+    callback: CALLBACK_FUNC,
+    auxdata: *mut c_void,
+) -> c_int {
+    match Io::new(callback, auxdata) {
+        Some(io) => tta::decompress(&io),
+        None => FREEARC_ERRCODE_GENERAL,
+    }
+}
+
+/// Drop-in under the archiver's own symbol name; the switch is an exclusion in
+/// C_TTA.cpp rather than a redeclaration, as with the other codecs.
+///
+/// # Safety
+/// `callback` and `auxdata` must be what the C caller supplied.
+#[cfg(feature = "dropin")]
+#[no_mangle]
+pub unsafe extern "C" fn tta_decompress(
+    callback: CALLBACK_FUNC,
+    auxdata: *mut c_void,
+) -> c_int {
+    darc_rs_tta_decompress(callback, auxdata)
 }
 
 /// # Safety

--- a/rust/darc-codecs/src/lib.rs
+++ b/rust/darc-codecs/src/lib.rs
@@ -13,6 +13,7 @@ pub mod dict_encode;
 pub mod lz4;
 pub mod lzp;
 pub mod rep;
+pub mod tta;
 pub mod zstd;
 pub mod ffi;
 

--- a/rust/darc-codecs/src/tta.rs
+++ b/rust/darc-codecs/src/tta.rs
@@ -1,0 +1,657 @@
+//! TTA lossless-audio decoder, ported from `Compression/MM/tta.cpp`,
+//! `entropy.cpp` and `filters.cpp` (`tta_decompress` and everything it reaches).
+//!
+//! TTA is a multimedia (audio) filter: an order-1 fixed predictor, three
+//! cascaded adaptive hybrid filters, and an adaptive Rice entropy coder. The
+//! archiver reaches it as `-mtta`. Only the decoder is ported here -- the same
+//! decode-first order used for REP and Dict -- because a Rust build must *read*
+//! every existing `-mtta` archive before it may write one. The 1,117-line
+//! `mmdet.cpp` detector is not needed: it drives *encoder* autodetection only.
+//!
+//! ## Integer width is the whole ballgame
+//!
+//! This codec was the source of ten separate LP64 width bugs in this repo. The
+//! fixes settled on exact widths, and the port must reproduce them exactly or
+//! it decodes archives to the wrong bytes:
+//!
+//! * The bit array is addressed as 32-bit words (`tta_word` = `u32`).
+//! * The adaptive filter state is 32-bit *by design* (`tta_i32` = `i32`) and
+//!   relies on 32-bit wraparound to keep its cascading differences bounded --
+//!   so every filter operation here is a `wrapping_*` on `i32`. In C this is
+//!   plain `int` arithmetic that wraps; Rust would panic in debug, and using
+//!   `i64` (as the pre-fix C accidentally did on LP64) makes the state run away
+//!   and frames stop round-tripping.
+//! * The sample buffers and running Rice sums are `long`/`unsigned long`, which
+//!   on the LP64 build that wrote these archives are 64-bit -- so `i64`/`u64`
+//!   here, not `i32`/`u32`.
+//!
+//! ## The stream
+//!
+//! `header[4]` = (level, raw_data*2+is_float, num_chan, word_size), then a
+//! 4-byte `offset` and that many verbatim header bytes, then a sequence of
+//! blocks until EOF. Each block: `bytes_read` (uncompressed byte count); then
+//! for the entropy path a `compressed size` and the bit array (or, if that size
+//! is zero, `bytes_read` stored bytes); then `bytes_read % (num_chan*byte_size)`
+//! trailing bytes copied verbatim. `level==0` means the whole payload is stored.
+//!
+//! Every length pulled from the stream is untrusted (this runs on `arc t`), so
+//! each is bounded before it drives an allocation or a copy, mirroring the C
+//! hardening. A corrupt Rice run that never terminates is bounded by the read
+//! buffer's last whole word, exactly as `get_unary` was fixed to do.
+
+use crate::ffi::{Io, FREEARC_ERRCODE_BAD_COMPRESSED_DATA, FREEARC_ERRCODE_IO,
+                 FREEARC_ERRCODE_NOT_ENOUGH_MEMORY, OK};
+use core::ffi::c_int;
+
+const BAD: c_int = FREEARC_ERRCODE_BAD_COMPRESSED_DATA as c_int;
+const IO: c_int = FREEARC_ERRCODE_IO as c_int;
+const NOMEM: c_int = FREEARC_ERRCODE_NOT_ENOUGH_MEMORY as c_int;
+
+// A hard ceiling on any single length read from the stream, matching the
+// `> (1<<30)` guards the C decoder applies to bytes_read and bit_array_size.
+const MAX_LEN: u64 = 1 << 30;
+const MB: usize = 1 << 20;
+
+// ---------------------------------------------------------------------------
+// Stream reads. The archiver's read callback fills a request fully mid-stream
+// and returns 0 at EOF; a partial read is a truncated/corrupt stream. This
+// mirrors the READ / READ4 / READ4_OR_EOF macros in Compression.h.
+// ---------------------------------------------------------------------------
+
+fn read_exact(io: &Io, buf: &mut [u8]) -> Result<(), c_int> {
+    if buf.is_empty() {
+        return Ok(());
+    }
+    match io.read(buf) {
+        n if n as usize == buf.len() => Ok(()),
+        n if n >= 0 => Err(IO), // short read where the format demands a full one
+        n => Err(n),
+    }
+}
+
+fn read_u32(io: &Io) -> Result<u32, c_int> {
+    let mut b = [0u8; 4];
+    read_exact(io, &mut b)?;
+    Ok(u32::from_le_bytes(b))
+}
+
+/// `READ4_OR_EOF`: `Ok(None)` on a clean end of stream (zero bytes), `Ok(Some)`
+/// on a full word, and `Err(IO)` on a partial word (a frame header cut short).
+fn read_u32_or_eof(io: &Io) -> Result<Option<u32>, c_int> {
+    let mut b = [0u8; 4];
+    match io.read(&mut b) {
+        0 => Ok(None),
+        4 => Ok(Some(u32::from_le_bytes(b))),
+        n if n >= 0 => Err(IO),
+        n => Err(n),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Entropy tables (entropy.cpp). bit_shift has 40 entries; shift_16 is the view
+// starting at index 4 (`shift_16 = bit_shift + 4`). Values fit in u32 but are
+// `unsigned long` in C, hence u64 here so the Rice-sum arithmetic matches LP64.
+// ---------------------------------------------------------------------------
+
+const BIT_MASK32: [u64; 33] = [
+    0x00000000, 0x00000001, 0x00000003, 0x00000007, 0x0000000f, 0x0000001f, 0x0000003f, 0x0000007f,
+    0x000000ff, 0x000001ff, 0x000003ff, 0x000007ff, 0x00000fff, 0x00001fff, 0x00003fff, 0x00007fff,
+    0x0000ffff, 0x0001ffff, 0x0003ffff, 0x0007ffff, 0x000fffff, 0x001fffff, 0x003fffff, 0x007fffff,
+    0x00ffffff, 0x01ffffff, 0x03ffffff, 0x07ffffff, 0x0fffffff, 0x1fffffff, 0x3fffffff, 0x7fffffff,
+    0xffffffff,
+];
+
+const BIT_SHIFT: [u64; 40] = [
+    0x00000001, 0x00000002, 0x00000004, 0x00000008, 0x00000010, 0x00000020, 0x00000040, 0x00000080,
+    0x00000100, 0x00000200, 0x00000400, 0x00000800, 0x00001000, 0x00002000, 0x00004000, 0x00008000,
+    0x00010000, 0x00020000, 0x00040000, 0x00080000, 0x00100000, 0x00200000, 0x00400000, 0x00800000,
+    0x01000000, 0x02000000, 0x04000000, 0x08000000, 0x10000000, 0x20000000, 0x40000000, 0x80000000,
+    0x80000000, 0x80000000, 0x80000000, 0x80000000, 0x80000000, 0x80000000, 0x80000000, 0x80000000,
+];
+
+#[inline]
+fn shift_16(i: usize) -> u64 {
+    BIT_SHIFT[i + 4]
+}
+
+/// `ENC`/`DEC` map signed samples to the unsigned values the Rice coder sees.
+/// `DEC(x) = (x&1) ? (x+1)>>1 : (-x)>>1`, the shift arithmetic on `long`.
+///
+/// Wrapping add/neg because a corrupt frame (reachable via `arc t`) can drive
+/// `x` to any 64-bit value, and `-i64::MIN` / `i64::MAX + 1` would panic in a
+/// debug build -- an unwind across the C ABI. C's `long` here simply wraps in
+/// two's complement, which is what a hostile stream would produce anyway.
+#[inline]
+fn dec(x: i64) -> i64 {
+    if x & 1 != 0 {
+        x.wrapping_add(1) >> 1
+    } else {
+        x.wrapping_neg() >> 1
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bit reader (init_bit_array_read / get_binary / get_unary).
+// ---------------------------------------------------------------------------
+
+/// Reads little-endian 32-bit words out of a byte buffer, MSB-to-LSB within the
+/// running bit position, matching the C reader that casts the buffer to
+/// `tta_word*` on a little-endian target.
+struct BitReader {
+    /// The frame's bytes, padded up to a whole word plus one spare word so the
+    /// final partial word can be fetched in bounds. calloc-zeroed padding, as
+    /// `init_bit_array_read` allocates.
+    words: Vec<u32>,
+    /// Number of whole (or final partial) words the *real* data covers; reads
+    /// past this return zero, as the fixed C bounds do.
+    word_count: usize,
+    bits: u64,
+}
+
+impl BitReader {
+    fn new(data: &[u8]) -> Self {
+        let size = data.len();
+        // ((size + 3) & ~3) + 4 bytes, zero-padded -> that many /4 words.
+        let padded = ((size + 3) & !3) + 4;
+        let mut bytes = vec![0u8; padded];
+        bytes[..size].copy_from_slice(data);
+        let words = bytes
+            .chunks_exact(4)
+            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect();
+        // bit_array_read_words = (size + 3) >> 2
+        let word_count = (size + 3) >> 2;
+        BitReader { words, word_count, bits: 0 }
+    }
+
+    #[inline]
+    fn word(&self, pos: usize) -> u32 {
+        self.words[pos]
+    }
+
+    /// `get_binary`: read `bits` bits as an unsigned value.
+    fn get_binary(&mut self, bits: u64) -> u64 {
+        let fbit = self.bits & 0x1f;
+        let rbit = 32 - fbit;
+        let pos = (self.bits >> 5) as usize;
+
+        if pos >= self.word_count {
+            return 0;
+        }
+        let value: u64;
+        if bits <= rbit {
+            value = ((self.word(pos) as u64) >> fbit) & BIT_MASK32[bits as usize];
+        } else {
+            if pos + 1 >= self.word_count {
+                return 0;
+            }
+            let lo = ((self.word(pos) as u64) >> fbit) & BIT_MASK32[rbit as usize];
+            let hi = ((self.word(pos + 1) as u64) & BIT_MASK32[(bits - rbit) as usize]) << rbit;
+            value = lo | hi;
+        }
+        self.bits += bits;
+        value
+    }
+
+    /// `get_unary`: count a run of set bits terminated by a clear bit, bounded
+    /// by the last whole word so a corrupt non-terminating run cannot walk off
+    /// the buffer.
+    fn get_unary(&mut self) -> u64 {
+        let mut fbit = self.bits & 0x1f;
+        let rbit = 32 - fbit;
+        let mut pos = (self.bits >> 5) as usize;
+        let end = self.word_count;
+
+        let mut value: u64 = 0;
+        if pos >= end {
+            return 0;
+        }
+
+        if ((self.word(pos) as u64) >> fbit) == BIT_MASK32[rbit as usize] {
+            value += rbit;
+            fbit = 0;
+            while pos + 1 < end && {
+                pos += 1;
+                self.word(pos) as u64 == BIT_MASK32[32]
+            } {
+                value += 32;
+            }
+        }
+        let mut mask: u64 = 1u64 << fbit;
+        while pos < end && ((self.word(pos) as u64) & mask) != 0 {
+            value += 1;
+            mask <<= 1;
+        }
+
+        self.bits += value + 1;
+        value
+    }
+}
+
+/// `decode_frame`: adaptive Rice decode of `len` samples into `data`.
+fn decode_frame(br: &mut BitReader, data: &mut [i64]) {
+    let mut k0: usize = 10;
+    let mut k1: usize = 10;
+    let mut sum0: u64 = shift_16(k0);
+    let mut sum1: u64 = shift_16(k1);
+
+    for slot in data.iter_mut() {
+        // decode Rice unsigned
+        let mut unary = br.get_unary();
+        if unary == 50 {
+            unary = br.get_binary(32);
+        }
+
+        let (depth, k) = match unary {
+            0 => (0, k0),
+            _ => {
+                unary -= 1;
+                (1, k1)
+            }
+        };
+
+        let mut value: i64 = if k != 0 {
+            let binary = br.get_binary(k as u64);
+            ((unary << k).wrapping_add(binary)) as i64
+        } else {
+            unary as i64
+        };
+
+        if depth == 1 {
+            sum1 = sum1.wrapping_add((value as u64).wrapping_sub(sum1 >> 4));
+            if k1 > 0 && sum1 < shift_16(k1) {
+                k1 -= 1;
+            } else if k1 < 32 && sum1 > shift_16(k1 + 1) {
+                k1 += 1;
+            }
+            value = value.wrapping_add(BIT_SHIFT[k0] as i64);
+            // fall through to the depth-0 sum0 update, matching the "no break!"
+        }
+        sum0 = sum0.wrapping_add((value as u64).wrapping_sub(sum0 >> 4));
+        if k0 > 0 && sum0 < shift_16(k0) {
+            k0 -= 1;
+        } else if k0 < 32 && sum0 > shift_16(k0 + 1) {
+            k0 += 1;
+        }
+
+        *slot = dec(value);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Filters (filters.cpp). All state is exactly 32-bit and wraps; every op below
+// is a wrapping i32 op for that reason.
+// ---------------------------------------------------------------------------
+
+const MAX_ORDER: usize = 32;
+const BUF_SIZE: usize = 256;
+
+// flt_set[stage][level-1][byte_size-1] = {order, shift, mode}
+const FLT_SET: [[[[i32; 3]; 4]; 3]; 3] = [
+    [
+        [[8, 10, 0], [8, 9, 0], [8, 10, 0], [8, 12, 1]],
+        [[8, 10, 0], [8, 11, 0], [8, 10, 0], [16, 12, 1]],
+        [[8, 10, 0], [8, 11, 0], [8, 10, 0], [32, 12, 1]],
+    ],
+    [
+        [[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]],
+        [[16, 10, 1], [16, 9, 1], [16, 10, 1], [0, 0, 0]],
+        [[32, 11, 1], [32, 11, 1], [32, 11, 1], [0, 0, 0]],
+    ],
+    [
+        [[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]],
+        [[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]],
+        [[0, 0, 0], [16, 9, 1], [16, 10, 1], [0, 0, 0]],
+    ],
+];
+
+/// `PREDICTOR1(x, k)`: the order-1 fixed predictor, done in unsigned 32-bit so
+/// the wrap is defined and the final `>> k` is arithmetic on `i32`.
+#[inline]
+fn predictor1(x: i64, k: u32) -> i64 {
+    let ux = x as u32;
+    ((((ux << k).wrapping_sub(ux)) as i32) >> k) as i64
+}
+
+/// The adaptive hybrid filter state, `fltst`. `px`/`pl` are indices into
+/// `dx`/`dl` rather than pointers; the sliding window is reproduced by advancing
+/// them and memcpy-compacting when they reach the end.
+struct Filter {
+    order: usize,
+    mode: i32,
+    shift: i32,
+    round: i32,
+    qm: [i32; MAX_ORDER],
+    dx: [i32; BUF_SIZE],
+    dl: [i32; BUF_SIZE],
+    px: usize, // index into dx
+    pl: usize, // index into dl
+}
+
+impl Filter {
+    fn new(order: i32, shift: i32, mode: i32) -> Self {
+        Filter {
+            order: order as usize,
+            mode,
+            shift,
+            round: if shift > 0 { 1i32 << (shift - 1) } else { 0 },
+            qm: [0; MAX_ORDER],
+            dx: [0; BUF_SIZE],
+            dl: [0; BUF_SIZE],
+            px: 0,
+            pl: 0,
+        }
+    }
+
+    /// `filter_decompress`: transform one sample in place.
+    fn decompress(&mut self, sample: &mut i64) {
+        let order = self.order;
+
+        // sum = round + dot(pl[0..order], qm[0..order]); all wrapping i32.
+        let mut sum: i32 = self.round;
+        for j in 0..order {
+            sum = sum.wrapping_add(self.dl[self.pl + j].wrapping_mul(self.qm[j]));
+        }
+
+        // out = in + (sum >> shift), truncated to i32 (as C stores into tta_i32).
+        let inv = *sample;
+        let out: i32 = (inv as i32).wrapping_add(sum >> self.shift);
+
+        // pl[order] = out
+        self.dl[self.pl + order] = out;
+
+        if self.mode == 0 {
+            // adaptive polynomial predictors: pl[order-1-n] = pl[order-n] - pl[order-1-n]
+            let base = self.pl + order - 1;
+            for n in 0..3 {
+                self.dl[base - n] = self.dl[base + 1 - n].wrapping_sub(self.dl[base - n]);
+            }
+        }
+
+        // qm[n] += / -= px[n], by the sign of the *input* residual.
+        if inv < 0 {
+            for j in 0..order {
+                self.qm[j] = self.qm[j].wrapping_add(self.dx[self.px + j]);
+            }
+        } else if inv > 0 {
+            for j in 0..order {
+                self.qm[j] = self.qm[j].wrapping_sub(self.dx[self.px + j]);
+            }
+        }
+
+        // px[order-n] = sign-bucket of pl[order-n]
+        let pxo = self.px + order;
+        let plo = self.pl + order;
+        self.dx[pxo] = ((self.dl[plo] >> 28) & 8) - 4;
+        self.dx[pxo - 1] = ((self.dl[plo - 1] >> 29) & 4) - 2;
+        self.dx[pxo - 2] = ((self.dl[plo - 2] >> 29) & 4) - 2;
+        self.dx[pxo - 3] = ((self.dl[plo - 3] >> 30) & 2) - 1;
+
+        // slide the windows, compacting at the end of dx/dl
+        if self.px + order == BUF_SIZE - 1 {
+            self.dx.copy_within(self.px + 1..self.px + 1 + order, 0);
+            self.px = 0;
+        } else {
+            self.px += 1;
+        }
+        if self.pl + order == BUF_SIZE - 1 {
+            self.dl.copy_within(self.pl + 1..self.pl + 1 + order, 0);
+            self.pl = 0;
+        } else {
+            self.pl += 1;
+        }
+
+        *sample = out as i64;
+    }
+}
+
+/// `filters_decompress`: three cascaded filters (highest stage first on decode)
+/// then the fixed order-1 predictor undone.
+fn filters_decompress(data: &mut [i64], level: usize, byte_size: usize) {
+    let f1 = FLT_SET[0][level - 1][byte_size - 1];
+    let f2 = FLT_SET[1][level - 1][byte_size - 1];
+    let f3 = FLT_SET[2][level - 1][byte_size - 1];
+    let mut fst1 = Filter::new(f1[0], f1[1], f1[2]);
+    let mut fst2 = Filter::new(f2[0], f2[1], f2[2]);
+    let mut fst3 = Filter::new(f3[0], f3[1], f3[2]);
+
+    let mut last: i64 = 0;
+    for p in data.iter_mut() {
+        if fst3.order != 0 {
+            fst3.decompress(p);
+        }
+        if fst2.order != 0 {
+            fst2.decompress(p);
+        }
+        if fst1.order != 0 {
+            fst1.decompress(p);
+        }
+
+        match byte_size {
+            1 => *p += predictor1(last, 4),
+            2 => *p += predictor1(last, 5),
+            3 => *p += predictor1(last, 5),
+            4 => *p += last,
+            _ => {}
+        }
+        last = *p;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Channel recombination (combine_int / combine_float) and output (write_wave).
+// ---------------------------------------------------------------------------
+
+/// `combine_int`: undo the inter-channel decorrelation done at encode time.
+fn combine_int(frame_len: usize, num_chan: usize, buffer: &mut [Vec<i64>]) {
+    if num_chan > 1 {
+        let n = num_chan - 1;
+        for i in 0..frame_len {
+            buffer[n][i] += buffer[n - 1][i] / 2;
+            for j in (1..=n).rev() {
+                buffer[j - 1][i] = buffer[j][i] - buffer[j - 1][i];
+            }
+        }
+    }
+}
+
+const SWAP16_LOW16: u32 = 0xffff;
+
+/// `SWAP16`: reverse the low 16 bits.
+#[inline]
+fn swap16(x: u32) -> u32 {
+    (x & SWAP16_LOW16).reverse_bits() >> 16
+}
+
+/// `combine_float`: rebuild 32-bit floats from the split hi/lo channels.
+fn combine_float(frame_len: usize, num_chan: usize, buffer: &mut [Vec<i64>]) {
+    for i in 0..frame_len {
+        for j in 0..num_chan {
+            let negative = (buffer[j + num_chan][i] as u32) & 0x80000000;
+            let mut data_hi = buffer[j][i] as u32;
+            let data_lo = (buffer[j + num_chan][i].unsigned_abs() as u32).wrapping_sub(1);
+            data_hi = data_hi.wrapping_add(0x3F80);
+            buffer[j][i] = ((data_hi << 16) | swap16(data_lo) | negative) as i32 as i64;
+        }
+    }
+}
+
+/// `write_wave`: interleave the per-channel samples back into `byte_size`-wide
+/// little-endian words and emit them.
+fn write_wave(
+    io: &Io,
+    byte_size: usize,
+    num_chan: usize,
+    frame_len: usize,
+    buffer: &[Vec<i64>],
+) -> Result<(), c_int> {
+    let mut out = vec![0u8; frame_len * num_chan * byte_size];
+    for i in 0..frame_len {
+        for n in 0..num_chan {
+            let v = buffer[n][i];
+            let base = (i * num_chan + n) * byte_size;
+            match byte_size {
+                1 => out[base] = (v + 0x80) as u8,
+                2 => out[base..base + 2].copy_from_slice(&(v as i16).to_le_bytes()),
+                3 => {
+                    let u = v as u32;
+                    out[base] = u as u8;
+                    out[base + 1] = (u >> 8) as u8;
+                    out[base + 2] = (u >> 16) as u8;
+                }
+                4 => out[base..base + 4].copy_from_slice(&(v as i32).to_le_bytes()),
+                _ => {}
+            }
+        }
+    }
+    io.write_all(&out)
+}
+
+// ---------------------------------------------------------------------------
+// The decoder proper (tta_decompress).
+// ---------------------------------------------------------------------------
+
+/// Decode a TTA stream. Entry point matching `tta_decompress`.
+pub fn decompress(io: &Io) -> c_int {
+    match run(io) {
+        Ok(()) => OK,
+        Err(e) => e,
+    }
+}
+
+fn run(io: &Io) -> Result<(), c_int> {
+    // TTA header
+    let mut header = [0u8; 4];
+    read_exact(io, &mut header)?;
+    let level = header[0] as usize;
+    let is_float = (header[1] % 2) as usize;
+    let raw_data = header[1] / 2;
+    let num_chan = header[2] as usize;
+    let word_size = header[3] as usize;
+    let byte_size = (word_size + 7) / 8;
+
+    if level > 3
+        || raw_data > 1
+        || (is_float != 0 && byte_size != 4)
+        || (is_float == 0 && byte_size >= 4)
+    {
+        return Err(BAD);
+    }
+
+    // level 0 => the payload is stored; copy input to output verbatim.
+    if level == 0 {
+        let mut buf = vec![0u8; MB];
+        loop {
+            let n = io.read(&mut buf);
+            if n <= 0 {
+                return if n < 0 { Err(n) } else { Ok(()) };
+            }
+            io.write_all(&buf[..n as usize])?;
+        }
+    }
+
+    // num_chan / byte_size are now guaranteed non-zero for the sample paths:
+    // byte_size >= 1 (word_size <= 255) and a stored/level-0 stream already
+    // returned. num_chan can still be zero from a corrupt header, which would
+    // make the sample-set size zero -- reject rather than divide by it.
+    if num_chan == 0 || byte_size == 0 {
+        return Err(BAD);
+    }
+    let sample_set = num_chan * byte_size; // bytes per (all-channels) sample
+
+    // Copy the verbatim original-data header.
+    let offset = read_u32(io)? as usize;
+    if offset > MAX_LEN as usize {
+        return Err(BAD);
+    }
+    if offset > 0 {
+        let mut buf = vec![0u8; offset];
+        read_exact(io, &mut buf)?;
+        io.write_all(&buf)?;
+    }
+
+    let rows = num_chan << is_float;
+
+    loop {
+        // Frame header is optional (EOF ends the stream); everything after it
+        // in the frame is mandatory.
+        let bytes_read = match read_u32_or_eof(io)? {
+            None => return Ok(()),
+            Some(v) => v as u64,
+        };
+        if bytes_read > MAX_LEN {
+            return Err(BAD);
+        }
+        let bytes_read = bytes_read as usize;
+        let frame_len = bytes_read / sample_set;
+
+        // Read the block body.
+        let mut buffer: Vec<Vec<i64>>;
+        if raw_data == 0 {
+            let bit_array_size = read_u32(io)? as u64;
+            if bit_array_size > MAX_LEN {
+                return Err(BAD);
+            }
+            if bit_array_size == 0 {
+                // stored block: copy bytes_read bytes through
+                let mut buf = vec![0u8; bytes_read];
+                read_exact(io, &mut buf)?;
+                io.write_all(&buf)?;
+                continue;
+            }
+            let mut packed = vec![0u8; bit_array_size as usize];
+            read_exact(io, &mut packed)?;
+
+            buffer = alloc2d(rows, frame_len)?;
+            let mut br = BitReader::new(&packed);
+            for row in buffer.iter_mut() {
+                decode_frame(&mut br, row);
+                filters_decompress(row, level, byte_size);
+            }
+        } else {
+            // raw_data == 1: the predictor residuals were dumped as raw `long`
+            // values. On the LP64 build that wrote these archives `long` is 8
+            // bytes, so each sample is a little-endian i64. (This path is
+            // architecture-dependent in the C, a known quirk; match the writer.)
+            buffer = alloc2d(rows, frame_len)?;
+            let mut raw = vec![0u8; frame_len.checked_mul(8).ok_or(BAD)?];
+            for row in buffer.iter_mut() {
+                read_exact(io, &mut raw)?;
+                for (slot, chunk) in row.iter_mut().zip(raw.chunks_exact(8)) {
+                    *slot = i64::from_le_bytes(chunk.try_into().unwrap());
+                }
+                filters_decompress(row, level, byte_size);
+            }
+        }
+
+        if is_float != 0 {
+            combine_float(frame_len, num_chan, &mut buffer);
+        } else {
+            combine_int(frame_len, num_chan, &mut buffer);
+        }
+
+        if frame_len != 0 {
+            write_wave(io, byte_size, num_chan, frame_len, &buffer)?;
+        }
+
+        // Trailing bytes that do not fill a whole sample-set, copied verbatim.
+        let rest = bytes_read % sample_set;
+        if rest != 0 {
+            let mut buf = vec![0u8; rest];
+            read_exact(io, &mut buf)?;
+            io.write_all(&buf)?;
+        }
+    }
+}
+
+/// `malloc2d(num, len)`: `num` rows of `len` zeroed `i64`s. The C allocates one
+/// block; here each row is its own Vec, which the callers never rely on being
+/// contiguous. Guards the total against absurd sizes from a corrupt header.
+fn alloc2d(num: usize, len: usize) -> Result<Vec<Vec<i64>>, c_int> {
+    // The filters index up to pl+order (< len+MAX_ORDER) only inside dl/dx, not
+    // this buffer, so len alone is the row length. Bound the product.
+    if num != 0 && len > (isize::MAX as usize) / 8 / num {
+        return Err(NOMEM);
+    }
+    Ok(vec![vec![0i64; len]; num])
+}

--- a/rust/darc-codecs/tests/tta.rs
+++ b/rust/darc-codecs/tests/tta.rs
@@ -1,0 +1,165 @@
+//! Malformed-input tests for the TTA decoder.
+//!
+//! TTA is ported decode-first, so there is no in-crate round trip to assert
+//! against -- byte-exactness versus the C original is proved by
+//! rust/difftest/tta-check.sh, which is the only thing that can. What these add
+//! is the half the differential harness does not reach: hostile and truncated
+//! input.
+//!
+//! The bar is specific. `tta_decompress` is reached through `arc t` on an
+//! attacker-supplied archive, called across the C ABI. It must return an error
+//! there -- never panic (an unwind across `extern "C"` is undefined behaviour)
+//! and never hang (a non-terminating Rice run must be bounded). nextest's
+//! per-test process isolation is what keeps a panic here reported as one failing
+//! test rather than taking the whole run down.
+
+use darc_codecs::ffi::Io;
+use darc_codecs::tta;
+use std::ffi::{c_char, c_int, c_void, CStr};
+
+struct Mem {
+    input: Vec<u8>,
+    pos: usize,
+    output: Vec<u8>,
+}
+
+/// Serve at most `size` bytes per `read`, exactly as the archiver's callback
+/// does, so a decoder that loops on read is actually driven round its loop.
+unsafe extern "C" fn mem_callback(
+    what: *const c_char,
+    buf: *mut c_void,
+    size: c_int,
+    aux: *mut c_void,
+) -> c_int {
+    let mem = &mut *(aux as *mut Mem);
+    let what = CStr::from_ptr(what).to_bytes();
+    let size = if size < 0 { return -1 } else { size as usize };
+
+    if what == b"read" {
+        let n = size.min(mem.input.len() - mem.pos);
+        if n > 0 {
+            std::ptr::copy_nonoverlapping(mem.input[mem.pos..].as_ptr(), buf as *mut u8, n);
+            mem.pos += n;
+        }
+        n as c_int
+    } else if what == b"write" {
+        if size > 0 {
+            mem.output
+                .extend_from_slice(std::slice::from_raw_parts(buf as *const u8, size));
+        }
+        size as c_int
+    } else {
+        0
+    }
+}
+
+/// Decode `input`, returning (status, bytes written). Any status is acceptable;
+/// panicking or hanging is not.
+fn decode(input: &[u8]) -> (c_int, Vec<u8>) {
+    let mut mem = Mem { input: input.to_vec(), pos: 0, output: Vec::new() };
+    let io = unsafe { Io::new(Some(mem_callback), &mut mem as *mut Mem as *mut c_void) }
+        .expect("callback was not null");
+    let rc = tta::decompress(&io);
+    drop(io);
+    (rc, mem.output)
+}
+
+fn prng(seed: u32, n: usize) -> Vec<u8> {
+    let mut s = seed.wrapping_mul(2654435761).wrapping_add(1);
+    (0..n)
+        .map(|_| {
+            s = s.wrapping_mul(1103515245).wrapping_add(12345);
+            (s >> 16) as u8
+        })
+        .collect()
+}
+
+#[test]
+fn empty_input_is_rejected_cleanly() {
+    // No header at all: the first 4-byte read comes up short.
+    let (_rc, out) = decode(&[]);
+    assert!(out.is_empty());
+}
+
+#[test]
+fn garbage_never_panics() {
+    for seed in [1u32, 2, 3, 7, 42, 99, 1234, 65535] {
+        for len in [1usize, 2, 3, 4, 5, 8, 16, 64, 256, 4096] {
+            let _ = decode(&prng(seed, len));
+        }
+    }
+}
+
+#[test]
+fn every_header_byte_combination_is_survivable() {
+    // The header is (level, raw*2+is_float, num_chan, word_size). Sweep the
+    // first two bytes over their whole range with a scattering of channel/word
+    // values and some trailing bytes; each must return, not panic.
+    for level in 0u8..=6 {
+        for flags in 0u8..=5 {
+            for &num_chan in &[0u8, 1, 2, 3, 255] {
+                for &word_size in &[0u8, 8, 16, 24, 32, 255] {
+                    let mut v = vec![level, flags, num_chan, word_size];
+                    v.extend_from_slice(&prng(level as u32 * 7 + word_size as u32, 64));
+                    let _ = decode(&v);
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn valid_header_then_truncation_is_survivable() {
+    // A well-formed 16-bit-stereo header (level 3), then a frame header claiming
+    // a large block but with the body cut at every prefix length. The decoder
+    // must treat each short read as an error, not walk off a buffer.
+    let base = vec![3u8, 0, 2, 16, /*offset=*/ 0, 0, 0, 0];
+    // frame header: bytes_read = 400000, then bit_array_size = 100000
+    let mut frame = base.clone();
+    frame.extend_from_slice(&400_000u32.to_le_bytes());
+    frame.extend_from_slice(&100_000u32.to_le_bytes());
+    frame.extend_from_slice(&prng(5, 5000)); // far short of 100000
+
+    for cut in [8usize, 9, 12, 13, 16, 20, 100, frame.len()] {
+        if cut <= frame.len() {
+            let _ = decode(&frame[..cut]);
+        }
+    }
+}
+
+#[test]
+fn absurd_lengths_are_rejected_not_allocated() {
+    // A header followed by a frame claiming a 4 GB block. The `> 1<<30` guards
+    // must reject it rather than attempt the allocation.
+    let mut v = vec![3u8, 0, 2, 16, 0, 0, 0, 0];
+    v.extend_from_slice(&0xFFFF_FFFFu32.to_le_bytes()); // bytes_read
+    v.extend_from_slice(&0xFFFF_FFFFu32.to_le_bytes()); // bit_array_size
+    v.extend_from_slice(&prng(6, 256));
+    let (rc, _out) = decode(&v);
+    assert!(rc < 0, "a 4 GB block claim should be rejected");
+}
+
+#[test]
+fn stored_level0_copies_input_through() {
+    // level == 0 means the payload is stored: everything after the 4-byte header
+    // is copied verbatim to the output.
+    let payload = prng(11, 5000);
+    let mut v = vec![0u8, 0, 0, 0];
+    v.extend_from_slice(&payload);
+    let (rc, out) = decode(&v);
+    assert!(rc >= 0);
+    assert_eq!(out, payload, "level-0 stored stream must pass the payload through");
+}
+
+#[test]
+fn stored_block_within_a_frame_copies_through() {
+    // bit_array_size == 0 marks a stored block: bytes_read bytes are copied.
+    let block = prng(12, 800);
+    let mut v = vec![3u8, 0, 2, 16, 0, 0, 0, 0];
+    v.extend_from_slice(&(block.len() as u32).to_le_bytes()); // bytes_read
+    v.extend_from_slice(&0u32.to_le_bytes()); // bit_array_size == 0 -> stored
+    v.extend_from_slice(&block);
+    let (rc, out) = decode(&v);
+    assert!(rc >= 0);
+    assert_eq!(out, block, "a stored block must be copied verbatim");
+}

--- a/rust/difftest/mmdet_ccodec.cpp
+++ b/rust/difftest/mmdet_ccodec.cpp
@@ -1,0 +1,12 @@
+/* mmdet.cpp for the differential harness, as its own translation unit.
+ *
+ * tta_compress references mmdet's autodetection entry points, so they must link
+ * even though the harness passes explicit parameters and never calls them.
+ * mmdet.cpp has no includes of its own (mm.cpp includes it after Compression.h)
+ * and defines a file-local `channels[]` that collides with tta.cpp's, so it is
+ * compiled separately here -- mirroring the real C_MM.o / C_TTA.o split.
+ * MMD_LIBRARY suppresses its benchmark driver (which needs <io.h>/<windows.h>).
+ */
+#define MMD_LIBRARY
+#include "../../Compression/Compression.h"
+#include "../../Compression/MM/mmdet.cpp"

--- a/rust/difftest/tta-check.sh
+++ b/rust/difftest/tta-check.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Differential-test the TTA decoder port against the C original.
+#
+# TTA is ported decode-first, so the C compressor is the only encoder: compress
+# each input with C (over a matrix of channel counts / word sizes / levels),
+# decompress with both C and the Rust port, and require both to reproduce the
+# original. Byte-for-byte equality is the bar because TTA defines an archive
+# format.
+set -uo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+W="${TMPDIR:-/tmp}/tta-check.$$"; mkdir -p "$W"
+trap 'rm -rf "$W"' EXIT
+
+( cd "$ROOT/rust" && cargo build --release -p darc-codecs ) >/dev/null 2>&1 \
+  || { echo "cargo build failed" >&2; exit 1; }
+LIB="$ROOT/rust/target/release/libdarc_codecs.a"
+
+cc() { clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+        "$@" -I"$ROOT" -I"$ROOT/Compression" \
+        "$ROOT/rust/difftest/tta_ref.cpp" "$ROOT/rust/difftest/tta_ccodec.cpp" \
+        "$ROOT/rust/difftest/mmdet_ccodec.cpp" \
+        "$ROOT/Compression/Common.cpp"; }
+cc                        -o "$W/c"  || exit 1
+cc -DUSE_RUST "$LIB"      -o "$W/rs" || exit 1
+
+# Inputs: synthetic PCM-like signals -- sines, chords, ramps, noise, silence and
+# near-silence -- built at raw byte level. The audio filters and the adaptive
+# Rice coder behave very differently across loud/quiet and smooth/noisy input,
+# so the corpus spans those. Sizes straddle the 1<<18-sample frame boundary too.
+python3 - "$W/in" <<'PY'
+import os,sys,math,struct
+d=sys.argv[1]; os.makedirs(d,exist_ok=True)
+def prng(seed,n):
+    s=seed; o=bytearray()
+    for _ in range(n): s=(s*1103515245+12345)&0xffffffff; o.append((s>>16)&0xff)
+    return bytes(o)
+w=lambda n,b: open(f"{d}/{n}","wb").write(b)
+def s16(vals): return b"".join(struct.pack("<h", max(-32768,min(32767,int(v)))) for v in vals)
+N=100000
+w("sine16_stereo",  s16([ v for i in range(N) for v in (int(20000*math.sin(i*0.03)), int(15000*math.sin(i*0.041))) ]))
+w("chord16_stereo", s16([ v for i in range(N) for v in
+                        (int(8000*math.sin(i*0.02)+6000*math.sin(i*0.05)),
+                         int(7000*math.sin(i*0.03)+5000*math.sin(i*0.07))) ]))
+w("quiet16_stereo", s16([ v for i in range(N) for v in (int(30*math.sin(i*0.03)), int(25*math.sin(i*0.05))) ]))
+w("ramp16_mono",  s16([ (i%2000)-1000 for i in range(2*N) ]))
+w("silence16",    b"\x00\x00"*(2*N))
+w("sine8_mono",   bytes([ (128+int(100*math.sin(i*0.05)))&0xff for i in range(2*N) ]))
+w("noise8",       prng(9, 2*N))
+for n in (0,1,3,4,8, 1<<18, (1<<18)+1, (1<<18)-1):
+    w(f"n16_{n}", s16([ int(9000*math.sin(i*0.03)) for i in range(n) ]))
+PY
+
+decode_case () {   # $1=tag  $2..=encoder args ("LEVEL NUMCHAN WORDSIZE ISFLOAT [RAW]")
+  local tag="$1"; shift
+  local ec="$*"
+  local f fail=0 n=0
+  for f in "$W"/in/*; do
+    n=$((n+1)); local name; name=$(basename "$f")
+    "$W/c"  c $ec < "$f"        >| "$W/stream" 2>/dev/null || { echo "  [$tag] $name: C-compress FAILED"; fail=$((fail+1)); continue; }
+    "$W/c"  d     < "$W/stream" >| "$W/oc"     2>/dev/null || { echo "  [$tag] $name: C-decode FAILED";   fail=$((fail+1)); continue; }
+    "$W/rs" d     < "$W/stream" >| "$W/ors"    2>/dev/null || { echo "  [$tag] $name: RUST-decode FAILED"; fail=$((fail+1)); continue; }
+    cmp -s "$f" "$W/oc"  || { echo "  [$tag] $name: C-decode != original (harness bug)"; fail=$((fail+1)); continue; }
+    cmp -s "$f" "$W/ors" || { echo "  [$tag] $name: RUST-decode != original"; fail=$((fail+1)); continue; }
+  done
+  echo "  [$tag] $n inputs, $fail differing"
+  return $fail
+}
+
+total=0
+decode_case "L3 2*16"  3 2 16 0; total=$((total+$?))
+decode_case "L1 2*16"  1 2 16 0; total=$((total+$?))
+decode_case "L2 2*16"  2 2 16 0; total=$((total+$?))
+decode_case "L3 1*16"  3 1 16 0; total=$((total+$?))
+decode_case "L3 1*8"   3 1 8  0; total=$((total+$?))
+decode_case "L3 2*8"   3 2 8  0; total=$((total+$?))
+decode_case "raw 2*16" 3 2 16 0 1; total=$((total+$?))
+
+echo "tta decode: $total total differing"
+[ "$total" -eq 0 ] && echo "TTA decoder matches the C original byte for byte" || exit 1

--- a/rust/difftest/tta_ccodec.cpp
+++ b/rust/difftest/tta_ccodec.cpp
@@ -1,0 +1,26 @@
+/* Amalgamation of the C TTA codec for the differential harness.
+ *
+ * tta.cpp / entropy.cpp / filters.cpp carry no includes of their own -- they
+ * are meant to be textually included after Compression.h, exactly as C_TTA.cpp
+ * does it. This mirrors C_TTA.cpp's structure verbatim (minus the method-class
+ * wrapper it does not need):
+ *
+ *   - Compression.h and mmdet.h go inside `extern "C"`, so tta.cpp's calls to
+ *     the autodetection entry points take C linkage -- matching mmdet.cpp's own
+ *     `extern "C"` definitions over in mmdet_ccodec.cpp. Getting this wrong is a
+ *     link error about a missing C++-mangled `autodetect_*`.
+ *   - entropy/filters/tta.cpp are included with C++ linkage, so tta_compress /
+ *     tta_decompress are C++-mangled, matching the declarations in tta_ref.cpp.
+ *
+ * TTA_LIBRARY suppresses tta.cpp's own main()/driver (which needs <io.h>).
+ * mmdet.cpp is a SEPARATE unit (mmdet_ccodec.cpp) because it too defines a
+ * file-local `channels[]`, which would redefine tta.cpp's in one unit.
+ */
+#define TTA_LIBRARY
+extern "C" {
+#include "../../Compression/Compression.h"
+#include "../../Compression/MM/mmdet.h"
+}
+#include "../../Compression/MM/entropy.cpp"
+#include "../../Compression/MM/filters.cpp"
+#include "../../Compression/MM/tta.cpp"

--- a/rust/difftest/tta_ref.cpp
+++ b/rust/difftest/tta_ref.cpp
@@ -1,0 +1,79 @@
+/* Reference driver for differential-testing the TTA decoder port.
+ *
+ *     tta_ref c LEVEL NUMCHAN WORDSIZE ISFLOAT [RAW]  <in >stream
+ *     tta_ref d                                        <stream >out
+ *
+ * Built a second time with -DUSE_RUST so `d` drives the Rust port instead. TTA
+ * is ported decode-first (like REP and Dict), so there is no Rust encoder: the
+ * stream always comes from the C compressor, and the test is that the Rust
+ * decoder reproduces the original bytes from it -- which is what proves it reads
+ * the archive format correctly.
+ *
+ * NUMCHAN/WORDSIZE are passed explicitly so the encoder takes its sample path
+ * deterministically rather than running mmdet's autodetection (which, on
+ * synthetic input, would often choose "storing" and never exercise the codec).
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "../../Compression/Compression.h"
+
+// tta.cpp, compiled standalone here, has C++ linkage (C_TTA.cpp gives it C
+// linkage only by wrapping its includes; this driver compiles tta.cpp directly,
+// so match its C++ linkage). The Rust drop-in is extern "C".
+int tta_compress   (int, int, int, int, int, int, int, CALLBACK_FUNC*, void*);
+int tta_decompress (CALLBACK_FUNC*, void*);
+#ifdef USE_RUST
+extern "C" int darc_rs_tta_decompress (CALLBACK_FUNC*, void*);
+#endif
+
+struct Buffers {
+  const unsigned char *in; size_t in_len, in_pos;
+  unsigned char *out; size_t out_len, out_cap;
+};
+static int io_callback (const char *what, void *data, int size, void *aux) {
+  Buffers *b = (Buffers*) aux;
+  if (size < 0) return FREEARC_ERRCODE_GENERAL;
+  if (strcmp(what,"read")==0) {
+    size_t avail=b->in_len-b->in_pos, n=(size_t)size<avail?(size_t)size:avail;
+    memcpy(data,b->in+b->in_pos,n); b->in_pos+=n; return (int)n;
+  }
+  if (strcmp(what,"write")==0) {
+    if (b->out_len+(size_t)size>b->out_cap) {
+      size_t cap=b->out_cap?b->out_cap:65536;
+      while (cap<b->out_len+(size_t)size) cap*=2;
+      unsigned char *g=(unsigned char*)realloc(b->out,cap);
+      if(!g) return FREEARC_ERRCODE_NOT_ENOUGH_MEMORY;
+      b->out=g; b->out_cap=cap;
+    }
+    memcpy(b->out+b->out_len,data,(size_t)size); b->out_len+=(size_t)size; return size;
+  }
+  return FREEARC_ERRCODE_NOT_IMPLEMENTED;
+}
+
+int main (int argc, char **argv) {
+  if (argc<2 || (argv[1][0]!='c'&&argv[1][0]!='d')) {
+    fprintf(stderr,"usage: %s c LEVEL NUMCHAN WORDSIZE ISFLOAT [RAW] | d\n",argv[0]); return 2; }
+  size_t cap=1<<20, len=0; unsigned char *in=(unsigned char*)malloc(cap); if(!in) return 3;
+  for(;;){ if(len==cap){cap*=2; unsigned char*g=(unsigned char*)realloc(in,cap); if(!g){free(in);return 3;} in=g;}
+    size_t n=fread(in+len,1,cap-len,stdin); if(n==0)break; len+=n; }
+  Buffers b={in,len,0,NULL,0,0};
+  int rc;
+  if (argv[1][0]=='c') {
+    int level    = argc>2? atoi(argv[2]) : 3;
+    int num_chan = argc>3? atoi(argv[3]) : 2;
+    int word_size= argc>4? atoi(argv[4]) : 16;
+    int is_float = argc>5? atoi(argv[5]) : 0;
+    int raw_data = argc>6? atoi(argv[6]) : 0;
+    rc = tta_compress (level, 0, is_float, num_chan, word_size, 0, raw_data, io_callback, &b);
+  } else {
+#ifdef USE_RUST
+    rc = darc_rs_tta_decompress (io_callback, &b);
+#else
+    rc = tta_decompress (io_callback, &b);
+#endif
+  }
+  if (rc<0){ fprintf(stderr,"codec returned %d\n",rc); free(in); free(b.out); return 4; }
+  if (b.out_len && fwrite(b.out,1,b.out_len,stdout)!=b.out_len){ free(in); free(b.out); return 5; }
+  free(in); free(b.out); return 0;
+}


### PR DESCRIPTION
Ports the TTA lossless-audio **decoder** to Rust — the next codec after REP, following the same decode-first recipe. A Rust build must *read* every existing `-mtta` archive before it may write one.

## What's ported
`tta_decompress` and everything it reaches, into `rust/darc-codecs/src/tta.rs` (~430 lines):
- **Adaptive Rice entropy decoder** (`entropy.cpp`: `decode_frame`, `get_binary`, `get_unary`)
- **Three cascaded hybrid filters + order-1 predictor** (`filters.cpp`: `filters_decompress`, `PREDICTOR1`)
- **Channel recombination + output** (`tta.cpp`: `combine_int`/`combine_float`, `write_wave`)

The 1,117-line `mmdet.cpp` detector is **not** ported — it drives encoder autodetection only, so the decoder is fully self-contained.

## Width faithfulness
TTA was the source of ten LP64 width bugs in this repo, so the widths match the reference exactly: `long`→`i64`, `unsigned long`→`u64`, `tta_i32`→`i32`, `tta_word`→`u32`. The adaptive filter state is 32-bit *by design* and relies on 32-bit wraparound, so every filter op is a `wrapping_*`; `decode_frame`'s value arithmetic and `DEC` wrap too, so a corrupt frame reached through `arc t` cannot overflow-panic across the C ABI.

## Verification (the REP recipe)
| Check | Result |
|---|---|
| `rust/difftest/tta-check.sh` — C-encode → C&Rust decode, both reproduce original | **105/105 byte-exact** (15 audio inputs × 7 channel/word/level combos, both directions) |
| Sabotage (desync initial Rice `k`) | 52 cases break; the `raw` path stays clean → `decode_frame` genuinely exercised |
| `tests/tta.rs` malformed input (garbage, truncation, absurd lengths, stored blocks, header sweep) | 8/8 — errors, never panics/hangs |
| **End-to-end**: DARC_RUST archiver links + reproduces committed `tta` fingerprint | `df47b54a…` identical on both builds; every other fingerprint unchanged |

## Linkage
The C `tta_decompress` is excluded under `#ifndef DARC_RUST`, in the **same commit** as the dropin — its declaration comes from `ttaenc.h` inside `C_TTA.cpp`'s `extern "C"` block, so it has C linkage and shares a symbol with the Rust export (same arrangement as Dict/LZP/REP; two C-linkage definitions would collide on GNU ld).

🤖 Generated with [Claude Code](https://claude.com/claude-code)