### PR TITLE
Tornado: port the decoder to Rust, verified byte-identical across all four back-ends

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -621,12 +621,13 @@ jobs:
     # the same original bytes over a corpus built for that codec's heuristics.
     # They were runnable but unrun until now: a differential test nothing
     # invokes is documentation, not a check.
-    - name: Per-codec differential tests (REP, TTA, MM)
+    - name: Per-codec differential tests (REP, TTA, MM, Tornado)
       run: |
         chmod +x rust/difftest/*.sh
         rust/difftest/rep-check.sh
         rust/difftest/tta-check.sh
         rust/difftest/mm-check.sh
+        rust/difftest/tornado-check.sh
 
     # Build the archiver twice and require identical archives. This is the check
     # that actually guards the format.

--- a/Compression/Tornado/EntropyCoder.cpp
+++ b/Compression/Tornado/EntropyCoder.cpp
@@ -565,11 +565,31 @@ public:
       buffer = (buffer << 8) + getc();
   }
 
+  // A count outside the coder's range means the compressed data are corrupt.
+  // This used to print to stderr and call exit(1) -- inside a library, from a
+  // worker thread, with the archive still open: `arc t` on a damaged -mtor
+  // archive killed the process instead of reporting a bad block, which is the
+  // one thing testing an archive exists to do. And -mtor is reached by every
+  // -m4-and-up archive, so this is not an exotic path.
+  //
+  // Now it records the error and clamps, so decoding stays well defined --
+  // TCounter::Decode indexes cum[]/cnt[] with this value, and a count of
+  // (1<<bits)-1 is the largest one that stays inside them.
+  //
+  // No check is added to tor_decompress0's symbol loop: WRITE_DATA_IF already
+  // tests decoder.error() (Tornado.cpp:372), and every iteration of that loop
+  // advances `output` by at least one byte, so the test is reached within
+  // (write_end-output) symbols. Adding a per-symbol check would only make the
+  // error surface sooner, at the cost of a branch in the hottest loop of a
+  // codec every -m4-and-up archive uses. A valid stream never takes this
+  // branch at all, so nothing about it changes either way.
   unsigned int GetCount(unsigned int bits)
   {
     unsigned int count = buffer / (range >>= bits);
-    if (count >= (1<<bits))
-      fprintf(stderr, "data error\n"), exit(1);
+    if (count >= (1u<<bits)) {
+      errcode = FREEARC_ERRCODE_BAD_COMPRESSED_DATA;
+      count = (1u<<bits) - 1;
+    }
     return (count);
   }
 

--- a/Compression/Tornado/Tornado.cpp
+++ b/Compression/Tornado/Tornado.cpp
@@ -484,6 +484,21 @@ finished:
 }
 
 
+// DARC_RUST=1 selects the Rust port of the decoder (rust/darc-codecs).
+//
+// tor_decompress is declared inside the `extern "C"` block at the top of this
+// file, so this definition inherits C linkage and shares a symbol with the Rust
+// export. Excluded rather than redeclared: with both present the linker
+// resolves from this object and never pulls the Rust one -- and, both being
+// C-linkage, GNU ld reports a multiple definition. So the switch has to remove
+// this definition, not merely add a declaration elsewhere. The same is true of
+// the other codecs (C_Dict.cpp, C_LZP.cpp, rep.cpp, tta.cpp, mm.cpp).
+//
+// tor_decompress0 is a template with no other caller, so excluding this entry
+// point leaves it uninstantiated and emits nothing; the encoder and everything
+// it shares stay compiled. Verified byte-identical to the C decoder across all
+// four entropy back-ends; see rust/difftest/tornado-check.sh.
+#ifndef DARC_RUST
 int tor_decompress (CALLBACK_FUNC *callback, void *auxdata)
 {
     int errcode;
@@ -510,6 +525,7 @@ int tor_decompress (CALLBACK_FUNC *callback, void *auxdata)
     }
 finished: return errcode;
 }
+#endif  // !DARC_RUST (tor_decompress)
 
 
 /*

--- a/rust/darc-codecs/src/exports.rs
+++ b/rust/darc-codecs/src/exports.rs
@@ -353,3 +353,17 @@ pub unsafe extern "C" fn darc_rs_tor_decompress(
         None => FREEARC_ERRCODE_GENERAL,
     }
 }
+
+/// Drop-in under the archiver's own symbol name; the switch is an exclusion in
+/// Tornado.cpp rather than a redeclaration, as with the other codecs.
+///
+/// # Safety
+/// `callback` and `auxdata` must be what the C caller supplied.
+#[cfg(feature = "dropin")]
+#[no_mangle]
+pub unsafe extern "C" fn tor_decompress(
+    callback: CALLBACK_FUNC,
+    auxdata: *mut c_void,
+) -> c_int {
+    darc_rs_tor_decompress(callback, auxdata)
+}

--- a/rust/darc-codecs/src/exports.rs
+++ b/rust/darc-codecs/src/exports.rs
@@ -8,7 +8,7 @@
 //! what wires them together; until then these are exercised by the differential
 //! harness rather than by the archiver.
 
-use crate::{delta, dict, dict_encode, lzp, mm, rep, tta};
+use crate::{delta, dict, dict_encode, lzp, mm, rep, tornado, tta};
 use crate::ffi::{Io, CALLBACK_FUNC, FREEARC_ERRCODE_GENERAL};
 use core::ffi::{c_int, c_void};
 
@@ -335,4 +335,21 @@ pub unsafe extern "C" fn dict_compress(
     callback: CALLBACK_FUNC, auxdata: *mut c_void,
 ) -> c_int {
     darc_rs_dict_compress(block_size, a, b, c, d, e, f, callback, auxdata)
+}
+
+/// Tornado decoder. Like TTA and MM it takes no tuning parameters -- the
+/// encoding method, minimum match length and window size all travel in the
+/// six-byte stream header.
+///
+/// # Safety
+/// `callback` and `auxdata` must be what the C caller supplied.
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_tor_decompress(
+    callback: CALLBACK_FUNC,
+    auxdata: *mut c_void,
+) -> c_int {
+    match Io::new(callback, auxdata) {
+        Some(io) => tornado::decode::decompress(&io),
+        None => FREEARC_ERRCODE_GENERAL,
+    }
 }

--- a/rust/darc-codecs/src/lib.rs
+++ b/rust/darc-codecs/src/lib.rs
@@ -14,6 +14,7 @@ pub mod lz4;
 pub mod lzp;
 pub mod mm;
 pub mod rep;
+pub mod tornado;
 pub mod tta;
 pub mod zstd;
 pub mod ffi;

--- a/rust/darc-codecs/src/tornado/decode.rs
+++ b/rust/darc-codecs/src/tornado/decode.rs
@@ -1,0 +1,243 @@
+//! The output loop and entry point, ported from `Compression/Tornado/Tornado.cpp`
+//! (`tor_decompress` :487, `tor_decompress0` :400, `WRITE_DATA_IF` :369).
+//!
+//! One loop serves all four back-ends. It writes into a circular window and
+//! flushes to the output stream whenever the window fills or the data-table
+//! list does; between flushes the window doubles as the LZ dictionary, which is
+//! why matches can reach backwards past the last flush and why the tables are
+//! re-diffed after every write.
+//!
+//! `offset` tracks how many bytes have scrolled past the window start, so a
+//! match distance can be validated against the whole output rather than just
+//! the window. `offset_overflow` records that this counter has wrapped, after
+//! which the check is skipped rather than being wrong.
+
+use super::lz77::{ByteDecoder, GenericDecoder, HufBackend, Lz77Decoder, IMPOSSIBLE_DIST, IMPOSSIBLE_LEN};
+use super::lz77::BitDecoder;
+use super::range::ArithDecoder;
+use super::stream::{InputBitStream, InputByteStream, BAD};
+use super::tables::DataTables;
+use super::{ARICODER, BITCODER, BYTECODER, HUFCODER, PAD_FOR_TABLES};
+use crate::ffi::{Io, OK};
+use core::ffi::c_int;
+
+/// `HUGE_BUFFER_SIZE` (Compression.h:45) -- the flush granularity, chosen so
+/// the decoder does not seek the output constantly.
+const HUGE_BUFFER_SIZE: usize = 8 << 20;
+
+/// A cap on the window the header may ask for. `bufsize` is four attacker-
+/// controlled bytes and the C hands it straight to malloc; Tornado's own
+/// presets top out at 1 GB (`extra_dbits` reaches exactly that far), so
+/// anything beyond it is corrupt rather than merely large.
+const MAX_BUFSIZE: u32 = 1 << 30;
+
+struct Window<'a> {
+    io: &'a Io,
+    buf: Vec<u8>,
+    /// Index of the logical buffer start; `PAD_FOR_TABLES` bytes precede it.
+    origin: usize,
+    bufsize: usize,
+    output: usize,
+    write_start: usize,
+    write_end: usize,
+    offset: u64,
+    offset_overflow: bool,
+    tables: DataTables,
+}
+
+impl<'a> Window<'a> {
+    fn new(io: &'a Io, bufsize: usize) -> Self {
+        let origin = PAD_FOR_TABLES;
+        Window {
+            io,
+            buf: vec![0u8; origin + bufsize + PAD_FOR_TABLES],
+            origin,
+            bufsize,
+            output: origin,
+            write_start: origin,
+            write_end: origin + bufsize.min(HUGE_BUFFER_SIZE),
+            offset: 0,
+            offset_overflow: false,
+            tables: DataTables::new(),
+        }
+    }
+
+    /// The body of `WRITE_DATA_IF`: undiff the tables, write, re-diff, then wrap
+    /// the window if it is full and set the next flush point.
+    fn flush(&mut self) -> Result<(), c_int> {
+        let (ws, out) = (self.write_start, self.output);
+        self.tables.undiff_tables(&mut self.buf, ws, out);
+        if out > ws {
+            let n = self.io.write(&self.buf[ws..out]);
+            if n < 0 {
+                return Err(n);
+            }
+        }
+        self.tables.diff_tables(&mut self.buf, ws, out);
+        self.write_start = self.output;
+
+        if self.output >= self.origin + self.bufsize {
+            let advanced = self.output - self.origin;
+            // The C compares against 1<<63 *before* adding, so the flag trails
+            // the real overflow by one window; kept as-is because it only ever
+            // makes the distance check stricter.
+            self.offset_overflow |= self.offset > (1u64 << 63);
+            self.offset += advanced as u64;
+            self.write_start -= advanced;
+            self.write_end -= advanced;
+            self.tables.shift(&mut self.buf, self.output, self.origin);
+            self.output -= advanced;
+        }
+
+        if self.write_start >= self.write_end {
+            let room = self.origin + self.bufsize - self.write_start;
+            self.write_end = self.write_start + room.min(HUGE_BUFFER_SIZE);
+        }
+        Ok(())
+    }
+}
+
+macro_rules! flush_if {
+    ($w:expr, $d:expr, $cond:expr) => {
+        if $cond {
+            if let Some(e) = $d.error() {
+                return Err(e);
+            }
+            $w.flush()?;
+        }
+    };
+}
+
+fn decompress0<D: Lz77Decoder>(
+    io: &Io,
+    mut d: D,
+    header_bufsize: u32,
+    minlen: u32,
+) -> Result<(), c_int> {
+    if let Some(e) = d.error() {
+        return Err(e);
+    }
+    // compress_all_at_once is false on the archiver's streaming path, so the
+    // window is grown to at least HUGE_BUFFER_SIZE exactly as the C does.
+    let bufsize = (header_bufsize as usize).max(HUGE_BUFFER_SIZE);
+    let mut w = Window::new(io, bufsize);
+
+    loop {
+        if d.is_literal() {
+            let c = d.getchar();
+            w.buf[w.output] = c;
+            w.output += 1;
+            flush_if!(w, d, w.output >= w.write_end);
+            continue;
+        }
+
+        let mut len = d.getlen(minlen);
+        let dist = d.getdist() as usize;
+
+        // Both copy loops below are do/while on `--len`, so a zero length wraps
+        // the counter and runs off the buffer. A real match is at least 1 and
+        // EOF is signalled by IMPOSSIBLE_LEN, so this is unreachable from a
+        // valid stream -- the C added the same guard.
+        if len == 0 {
+            return Err(BAD);
+        }
+
+        let at = w.output - w.origin;
+        if at >= dist && (w.write_end - w.output) as u64 > len as u64 {
+            // Fast path: the whole match fits before the next flush and does
+            // not reach back past the window start. Byte-at-a-time because
+            // overlapping matches are how run-length encoding falls out of LZ77.
+            let mut p = w.output - dist;
+            for _ in 0..len {
+                w.buf[w.output] = w.buf[p];
+                w.output += 1;
+                p += 1;
+            }
+        } else if len < IMPOSSIBLE_LEN {
+            if dist > w.bufsize
+                || len as u64 > 2 * header_bufsize as u64
+                || ((at as u64 + w.offset) < dist as u64 && !w.offset_overflow)
+            {
+                return Err(BAD);
+            }
+            // Slow path: the source may sit before the window start (so it
+            // wraps to the end) and the copy may cross a flush point.
+            // `output + bufsize - dist`, not `output - dist + bufsize`: the
+            // window is up to 1 GB and a match may legitimately reach further
+            // back than `output` has advanced, wrapping to the buffer end. C
+            // computes that intermediate as a pointer, which may point before
+            // the buffer and come back; the same expression on usize underflows
+            // and panics across the C ABI. Only reachable once the stream is
+            // larger than one flush chunk, which is why an 11 MB input caught
+            // it and a 900 KB corpus did not.
+            let mut p = if at >= dist { w.output - dist } else { w.output + w.bufsize - dist };
+            loop {
+                w.buf[w.output] = w.buf[p];
+                w.output += 1;
+                p += 1;
+                if p == w.origin + w.bufsize {
+                    p = w.origin;
+                }
+                flush_if!(w, d, w.output >= w.write_end);
+                len -= 1;
+                if len == 0 {
+                    break;
+                }
+            }
+        } else if len == IMPOSSIBLE_LEN && dist as u32 == IMPOSSIBLE_DIST {
+            flush_if!(w, d, true);
+            break;
+        } else {
+            // A data table: `len` past IMPOSSIBLE_LEN is the row width, `dist`
+            // the row count.
+            len -= IMPOSSIBLE_LEN;
+            if len == 0 || (dist as u64) * (len as u64) > 2 * header_bufsize as u64 {
+                return Err(BAD);
+            }
+            if len as usize > super::MAX_TABLE_ROW_AT_DECOMPRESSION {
+                return Err(BAD);
+            }
+            w.tables.add(len as usize, w.output, dist);
+            flush_if!(w, d, w.tables.filled());
+        }
+    }
+
+    if let Some(e) = d.error() {
+        return Err(e);
+    }
+    Ok(())
+}
+
+/// `tor_decompress`: read the six-byte header and pick a back-end.
+pub fn decompress(io: &Io) -> c_int {
+    match run(io) {
+        Ok(()) => OK,
+        Err(e) => e,
+    }
+}
+
+fn run(io: &Io) -> Result<(), c_int> {
+    let mut hdr = InputByteStream::new(io, 0);
+    let method = hdr.get8();
+    let minlen = hdr.get8();
+    let bufsize = hdr.get32();
+    if let Some(e) = hdr.error() {
+        return Err(e);
+    }
+    if bufsize == 0 || bufsize > MAX_BUFSIZE {
+        return Err(BAD);
+    }
+    // The header stream has already buffered part of the payload, so the
+    // back-end must continue from it rather than opening a second one.
+    match method {
+        BYTECODER => decompress0(io, ByteDecoder::new(hdr), bufsize, minlen),
+        BITCODER => decompress0(io, BitDecoder::new(InputBitStream::from_bytes(hdr)), bufsize, minlen),
+        HUFCODER => {
+            decompress0(io, GenericDecoder::new(HufBackend::new(InputBitStream::from_bytes(hdr))), bufsize, minlen)
+        }
+        ARICODER => {
+            decompress0(io, GenericDecoder::new(ArithDecoder::new(hdr, super::CODES)), bufsize, minlen)
+        }
+        _ => Err(BAD),
+    }
+}

--- a/rust/darc-codecs/src/tornado/huffman.rs
+++ b/rust/darc-codecs/src/tornado/huffman.rs
@@ -1,0 +1,272 @@
+//! Semi-adaptive Huffman decoder, ported from
+//! `Compression/Tornado/EntropyCoder.cpp` (`HuffmanTree` :278,
+//! `HuffmanDecoder` :483).
+//!
+//! ## Why the tree builder has to be ported, not just the code reader
+//!
+//! Nothing about the tree travels in the stream. Both sides start from
+//! `counter[s] = 1` for every symbol, increment the counter of each symbol as
+//! it is coded, and rebuild the tree when the encoder emits an EOB code -- the
+//! decoder's only signal is that EOB, plus three bits of rescale mode. So the
+//! decoder reconstructs the same tree only if it reproduces `build_tree`
+//! *exactly*: the same counters, the same tie-breaking, the same rescale. Any
+//! divergence and the two sides silently disagree about what the next bits
+//! mean.
+//!
+//! That makes the sort order load-bearing. The C sorts nodes by counter and
+//! relies on the sort being **stable** for equal counters, which it gets by
+//! packing counter and index into one integer (`make_node`) so that equal
+//! counters fall back to comparing indices. Symbols with counters below
+//! `CHUNKS` are placed by counting sort instead, which is stable by
+//! construction. Both are reproduced here.
+//!
+//! ## Decoding
+//!
+//! Two tables. `fast_index` resolves any code of at most `FAST_BITS` bits from
+//! the next `FAST_BITS` input bits directly; entries whose prefix belongs to a
+//! longer code are marked -1, and those fall back to `index`, which is sized
+//! `1 << maxbits` so it always resolves in one step.
+
+use super::stream::InputBitStream;
+
+/// Maximum symbols in a tree (EntropyCoder.cpp:262).
+pub const MAXHUF: usize = 2048;
+/// Codes no longer than this decode straight out of `fast_index` (:263).
+pub const FAST_BITS: u32 = 11;
+/// Counters below this are placed by counting sort rather than a comparison
+/// sort (`CHUNKS`, :341).
+const CHUNKS: usize = 250;
+
+/// One node while the tree is being built (`struct Node`, :266).
+#[derive(Clone, Copy, Default)]
+struct Node {
+    cnt: u32,
+    code: u32,
+    left: u16,
+    right: u16,
+    bits: u8,
+}
+
+pub struct HuffmanTree {
+    n: usize,
+    counter: Vec<u32>,
+    /// Longest code in the current table; `index` is sized `1 << maxbits`.
+    pub maxbits: i32,
+    pub bits: Vec<u8>,
+    fast_index: Vec<i32>,
+    index: Vec<u16>,
+}
+
+impl HuffmanTree {
+    /// Decoder-side construction: all counters start at 1 and the first tree is
+    /// built immediately, matching `HuffmanTree::HuffmanTree` (:308).
+    pub fn new(n: usize) -> Self {
+        let mut t = HuffmanTree {
+            n,
+            counter: vec![1u32; n],
+            maxbits: 0,
+            bits: vec![0u8; n],
+            fast_index: vec![0i32; 1 << FAST_BITS],
+            index: Vec::new(),
+        };
+        t.build_tree(0);
+        t
+    }
+
+    #[inline]
+    pub fn inc(&mut self, s: usize) {
+        self.counter[s] += 1;
+    }
+
+    /// `Decode` (:296): try the fast table, fall back to the full one.
+    #[inline]
+    pub fn decode_symbol(&self, code: u32) -> usize {
+        let x = self.fast_index[(code & ((1 << FAST_BITS) - 1)) as usize];
+        if x >= 0 {
+            x as usize
+        } else {
+            self.index[code as usize] as usize
+        }
+    }
+
+    /// `build_tree` (:334).
+    ///
+    /// Two sorted lists rather than a heap: original (symbol) nodes, and
+    /// combined nodes which stay sorted because each new one is at least as
+    /// large as the last. So the two smallest nodes are always among the first
+    /// two of each list, and the merge is three cases.
+    pub fn build_tree(&mut self, rescale_mode: u32) {
+        let n = self.n;
+        // The C allocates 2*MAXHUF+4 and fences the tail with INT_MAX.
+        let mut buf = vec![Node::default(); 2 * MAXHUF + 8];
+
+        // Counting sort for counters below CHUNKS; the rest go to a comparison
+        // sort. `places` is a running histogram offset table.
+        let mut places = [0usize; CHUNKS + 2];
+        let mut b = 0usize; // count of nodes (all symbols, since counters start at 1)
+        for i in 0..n {
+            if (self.counter[i] as usize) < CHUNKS {
+                places[self.counter[i] as usize + 1] += 1;
+            }
+            b += 1;
+        }
+        for i in 0..CHUNKS {
+            places[i + 1] += places[i];
+        }
+
+        // `rest` holds (counter, index) packed so that sorting the packed value
+        // sorts by counter and breaks ties by index -- the stability the
+        // algorithm depends on. The C packs into `uint` via make_node and reuses
+        // code[] as scratch; a u64 here keeps large counters from colliding.
+        let mut rest: Vec<u64> = Vec::new();
+        for i in 0..n {
+            let c = self.counter[i] as usize;
+            if c < CHUNKS {
+                let p = places[c];
+                places[c] += 1;
+                buf[p].cnt = self.counter[i];
+                buf[p].left = i as u16;
+            } else {
+                rest.push((self.counter[i] as u64) * (MAXHUF as u64) + i as u64);
+            }
+        }
+        rest.sort_unstable();
+        for (i, packed) in rest.iter().enumerate() {
+            let p = i + places[CHUNKS];
+            buf[p].cnt = (packed / MAXHUF as u64) as u32;
+            buf[p].left = (packed % MAXHUF as u64) as u16;
+        }
+        // buf[0..b] now holds nodes stable-sorted by counter.
+
+        for i in 0..b + 4 {
+            buf[b + i].cnt = i32::MAX as u32; // fence
+        }
+        let mut p1 = 0usize; // first unused original node
+        let mut p2 = b + 2; // first unused combined node
+        let mut p3 = b + 2; // next combined node to create
+
+        while !(p1 == b && p3 - p2 == 1) {
+            if buf[p1 + 1].cnt < buf[p2].cnt {
+                buf[p3].cnt = buf[p1].cnt + buf[p1 + 1].cnt;
+                buf[p3].left = p1 as u16;
+                buf[p3].right = (p1 + 1) as u16;
+                p1 += 2;
+            } else if buf[p1].cnt > buf[p2 + 1].cnt {
+                buf[p3].cnt = buf[p2].cnt + buf[p2 + 1].cnt;
+                buf[p3].left = p2 as u16;
+                buf[p3].right = (p2 + 1) as u16;
+                p2 += 2;
+            } else {
+                buf[p3].cnt = buf[p1].cnt + buf[p2].cnt;
+                buf[p3].left = p1 as u16;
+                buf[p3].right = p2 as u16;
+                p1 += 1;
+                p2 += 1;
+            }
+            p3 += 1;
+        }
+
+        // Walk back down assigning codes: left child gets the parent's code,
+        // right child gets it with a 1 bit at the parent's depth.
+        buf[p2].bits = 0;
+        buf[p2].code = 0;
+        let mut i = p2;
+        while i >= b + 2 {
+            let (l, r, pb, pc) = (
+                buf[i].left as usize,
+                buf[i].right as usize,
+                buf[i].bits,
+                buf[i].code,
+            );
+            buf[l].bits = pb + 1;
+            buf[l].code = pc;
+            buf[r].bits = pb + 1;
+            buf[r].code = pc + (1 << pb);
+            if i == 0 {
+                break;
+            }
+            i -= 1;
+        }
+
+        // Decoder side: the least frequent symbol has the longest code, and it
+        // sorted first, so buf[0].bits is maxbits.
+        self.maxbits = buf[0].bits as i32;
+        if self.index.len() < (1usize << self.maxbits) {
+            self.index.resize(1usize << self.maxbits, 0);
+        }
+        for i in 0..b {
+            let s = buf[i].left as usize;
+            let sbits = buf[i].bits as u32;
+            let scode = buf[i].code as usize;
+            self.bits[s] = sbits as u8;
+            if sbits <= FAST_BITS {
+                for j in 0..(1usize << (FAST_BITS - sbits)) {
+                    self.fast_index[scode + (j << sbits)] = s as i32;
+                }
+            } else {
+                self.fast_index[scode & ((1 << FAST_BITS) - 1)] = -1;
+                for j in 0..(1usize << (self.maxbits as u32 - sbits)) {
+                    self.index[scode + (j << sbits)] = s as u16;
+                }
+            }
+        }
+
+        self.rescale(rescale_mode);
+    }
+
+    /// `rescale(FACTOR)` (:449). Counters are aged so the tree tracks recent
+    /// statistics; the encoder does the same, so the factor must match exactly.
+    fn rescale(&mut self, mode: u32) {
+        let factor = match mode {
+            0 => 2,
+            1 => 3,
+            2 => 4,
+            3 => 6,
+            4 => 8,
+            5 => 10,
+            6 => 12,
+            7 => 16,
+            // The mode arrives as three bits, so 0..7 is exhaustive; the C
+            // switch simply falls through and rescales nothing otherwise.
+            _ => return,
+        };
+        for s in 0..self.n {
+            let c = self.counter[s];
+            self.counter[s] -= if c > 1 && c < factor { 1 } else { c / factor };
+        }
+    }
+}
+
+/// `HuffmanDecoder<EOB>` (:483).
+pub struct HuffmanDecoder {
+    pub huf: HuffmanTree,
+    eob: usize,
+}
+
+impl HuffmanDecoder {
+    pub fn new(n: usize, eob: usize) -> Self {
+        HuffmanDecoder { huf: HuffmanTree::new(n), eob }
+    }
+
+    /// Decode one symbol, rebuilding the tree whenever EOB appears. The three
+    /// bits after an EOB carry the rescale mode the encoder used.
+    pub fn decode(&mut self, bits: &mut InputBitStream) -> usize {
+        loop {
+            let need = bits.needbits(self.huf.maxbits);
+            let x = self.huf.decode_symbol(need);
+            bits.dumpbits(self.huf.bits[x] as i32);
+            if x != self.eob {
+                self.huf.inc(x);
+                return x;
+            }
+            let mode = bits.getbits(3);
+            self.huf.build_tree(mode);
+            // A corrupt stream can hand us EOB forever; the caller's error
+            // check on the byte stream bounds that, because each rebuild reads
+            // three more bits and the stream reports exhaustion.
+            if bits.error().is_some() {
+                return self.eob;
+            }
+        }
+    }
+}

--- a/rust/darc-codecs/src/tornado/lz77.rs
+++ b/rust/darc-codecs/src/tornado/lz77.rs
@@ -31,10 +31,16 @@ use super::vle::Tables;
 use super::{CODES, EOB_CODE, LEN_CODES, REPCHAR, REPDIST_CODES};
 use core::ffi::c_int;
 
-/// Signals in the length space (Tornado.cpp uses these to end the stream and to
-/// mark data tables).
-pub const IMPOSSIBLE_LEN: u32 = 1 << 30;
-pub const IMPOSSIBLE_DIST: u32 = 1 << 30;
+/// Signals in the length space, used to end the stream and to mark data tables
+/// (`IMPOSSIBLE_LEN`/`IMPOSSIBLE_DIST`, LZ77_Coder.cpp:7-8).
+///
+/// These are `INT_MAX/2`, i.e. 0x3fffffff -- NOT 1<<30. The difference is one,
+/// and it is total: the EOF check is an equality test, so a decoder using
+/// 1<<30 never recognises the end of a stream and reads until the input runs
+/// out. Every back-end failed identically until this was read out of the
+/// header rather than assumed.
+pub const IMPOSSIBLE_LEN: u32 = (i32::MAX / 2) as u32;
+pub const IMPOSSIBLE_DIST: u32 = (i32::MAX / 2) as u32;
 
 /// What every back-end must provide to the output loop.
 pub trait Lz77Decoder {

--- a/rust/darc-codecs/src/tornado/lz77.rs
+++ b/rust/darc-codecs/src/tornado/lz77.rs
@@ -1,0 +1,334 @@
+//! The four LZ77 decoders, ported from `Compression/Tornado/LZ77_Coder.cpp`
+//! (`LZ77_ByteDecoder` :96, `LZ77_BitDecoder` :348, `LZ77_Decoder<D>` :519).
+//!
+//! All four present the same four-call interface to the output loop:
+//! `is_literal` -> `getchar`, or `is_literal` -> `getlen` -> `getdist`. The
+//! order matters: `getlen` must be called before `getdist`, because the byte
+//! decoder reads the distance *while* decoding the length and stashes it, and
+//! the generic decoder consumes extra bits for the length first.
+//!
+//! What differs between them is only how a symbol is spelled:
+//!
+//! * **Byte** -- LZSS flag words: one 32-bit word carries two bits for each of
+//!   16 following elements. `00` is a literal, and `01`/`10`/`11` select one of
+//!   three match encodings of increasing reach.
+//! * **Bit** -- a 9-bit code; below 256 it is a literal, otherwise its upper
+//!   bits index a length code and its lower five a distance code, each followed
+//!   by that code's extra bits.
+//! * **Huffman / arith** -- one symbol out of `CODES`, where 0..255 are
+//!   literals and the rest pack (length code, distance code) into a single
+//!   number, plus the repeat-distance and repeat-char codes.
+//!
+//! The last of those carries the `prevdists` ring: four recently used
+//! distances, addressable as short codes. Getting its update order wrong does
+//! not corrupt the current match -- it corrupts every later one that refers
+//! back to it, which is why it is transcribed literally here.
+
+use super::range::ArithDecoder;
+use super::huffman::HuffmanDecoder;
+use super::stream::{InputBitStream, InputByteStream};
+use super::vle::Tables;
+use super::{CODES, EOB_CODE, LEN_CODES, REPCHAR, REPDIST_CODES};
+use core::ffi::c_int;
+
+/// Signals in the length space (Tornado.cpp uses these to end the stream and to
+/// mark data tables).
+pub const IMPOSSIBLE_LEN: u32 = 1 << 30;
+pub const IMPOSSIBLE_DIST: u32 = 1 << 30;
+
+/// What every back-end must provide to the output loop.
+pub trait Lz77Decoder {
+    fn is_literal(&mut self) -> bool;
+    fn getchar(&mut self) -> u8;
+    /// Must be called before `getdist`.
+    fn getlen(&mut self, minlen: u32) -> u32;
+    fn getdist(&mut self) -> u32;
+    fn error(&self) -> Option<c_int>;
+}
+
+// ---------------------------------------------------------------------------
+// Byte-aligned decoder (BYTECODER)
+// ---------------------------------------------------------------------------
+
+pub struct ByteDecoder<'a> {
+    bytes: InputByteStream<'a>,
+    flags: u32,
+    flagpos: u32,
+    dist: u32,
+}
+
+impl<'a> ByteDecoder<'a> {
+    pub fn new(bytes: InputByteStream<'a>) -> Self {
+        ByteDecoder { bytes, flags: 0, flagpos: 1, dist: 0 }
+    }
+}
+
+impl Lz77Decoder for ByteDecoder<'_> {
+    fn is_literal(&mut self) -> bool {
+        // A fresh flag word every 16 elements; two bits each, consumed low-first.
+        self.flagpos -= 1;
+        if self.flagpos != 0 {
+            self.flags >>= 2;
+        } else {
+            self.flagpos = 16;
+            self.flags = self.bytes.get32();
+        }
+        (self.flags & 3) == 0
+    }
+
+    fn getchar(&mut self) -> u8 {
+        self.bytes.getc() as u8
+    }
+
+    fn getlen(&mut self, minlen: u32) -> u32 {
+        let len;
+        match self.flags & 3 {
+            1 => {
+                let x = self.bytes.get16();
+                len = x >> 12;
+                self.dist = x % (1 << 12);
+            }
+            2 => {
+                let x = self.bytes.get24();
+                len = x >> 18;
+                self.dist = x % (1 << 18);
+            }
+            _ => {
+                // Case 3, the escape ladder: 255 means a wider distance
+                // follows, and 254 (checked after that substitution, exactly as
+                // the C does) means a wider length follows.
+                let mut l = self.bytes.get8();
+                if l == 255 {
+                    self.dist = self.bytes.get8() << 24;
+                    l = self.bytes.get8();
+                } else {
+                    self.dist = 0;
+                }
+                if l == 254 {
+                    l = (self.bytes.get24() << 8).wrapping_add(self.bytes.get8());
+                }
+                self.dist = self.dist.wrapping_add(self.bytes.get24());
+                len = l;
+            }
+        }
+        minlen.wrapping_add(len)
+    }
+
+    fn getdist(&mut self) -> u32 {
+        self.dist
+    }
+
+    fn error(&self) -> Option<c_int> {
+        self.bytes.error()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bit-aligned decoder (BITCODER)
+// ---------------------------------------------------------------------------
+
+pub struct BitDecoder<'a> {
+    bits: InputBitStream<'a>,
+    t: Tables,
+    x: u32,
+}
+
+impl<'a> BitDecoder<'a> {
+    pub fn new(bits: InputBitStream<'a>) -> Self {
+        BitDecoder { bits, t: Tables::new(), x: 0 }
+    }
+}
+
+impl Lz77Decoder for BitDecoder<'_> {
+    fn is_literal(&mut self) -> bool {
+        self.x = self.bits.getbits(9);
+        self.x < 256
+    }
+
+    fn getchar(&mut self) -> u8 {
+        self.x as u8
+    }
+
+    fn getlen(&mut self, minlen: u32) -> u32 {
+        // Upper bits select the length code; the byte decoder's 8-entry table.
+        let lcode = ((self.x >> 5).wrapping_sub(8)) as usize & 7;
+        let lbits = self.t.lc_extra[lcode];
+        let lbase = self.t.lc_base[lcode];
+        minlen
+            .wrapping_add(lbase)
+            .wrapping_add(self.bits.getbits(lbits as i32))
+    }
+
+    fn getdist(&mut self) -> u32 {
+        let dcode = (self.x & 31) as usize;
+        let dbits = self.t.dc_extra[dcode];
+        let dbase = self.t.dc_base[dcode];
+        dbase.wrapping_add(self.bits.getbits(dbits as i32))
+    }
+
+    fn error(&self) -> Option<c_int> {
+        self.bits.error()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Generic decoder over an entropy back-end (HUFCODER / ARICODER)
+// ---------------------------------------------------------------------------
+
+/// The entropy layer under `LZ77_Decoder`: one symbol, or n raw bits.
+pub trait SymbolDecoder {
+    fn decode(&mut self) -> usize;
+    fn getbits(&mut self, n: u32) -> u32;
+    fn error(&self) -> Option<c_int>;
+}
+
+pub struct HufBackend<'a> {
+    bits: InputBitStream<'a>,
+    huf: HuffmanDecoder,
+}
+
+impl<'a> HufBackend<'a> {
+    pub fn new(bits: InputBitStream<'a>) -> Self {
+        HufBackend { bits, huf: HuffmanDecoder::new(CODES, EOB_CODE) }
+    }
+}
+
+impl SymbolDecoder for HufBackend<'_> {
+    fn decode(&mut self) -> usize {
+        self.huf.decode(&mut self.bits)
+    }
+    fn getbits(&mut self, n: u32) -> u32 {
+        if n == 0 {
+            0
+        } else {
+            self.bits.getbits(n as i32)
+        }
+    }
+    fn error(&self) -> Option<c_int> {
+        self.bits.error()
+    }
+}
+
+impl SymbolDecoder for ArithDecoder<'_> {
+    fn decode(&mut self) -> usize {
+        ArithDecoder::decode(self)
+    }
+    fn getbits(&mut self, n: u32) -> u32 {
+        ArithDecoder::getbits(self, n)
+    }
+    fn error(&self) -> Option<c_int> {
+        ArithDecoder::error(self)
+    }
+}
+
+pub struct GenericDecoder<D: SymbolDecoder> {
+    d: D,
+    t: Tables,
+    x: usize,
+    /// `prevdists[]` with its moving cursor. The C keeps 128 slots and slides
+    /// the last few to the front on overflow purely for speed; a small ring of
+    /// exactly REPDIST_CODES entries is the same thing observably, and it
+    /// cannot run off the end.
+    prev: [u32; REPDIST_CODES],
+}
+
+impl<D: SymbolDecoder> GenericDecoder<D> {
+    pub fn new(d: D) -> Self {
+        GenericDecoder { d, t: Tables::new(), x: 0, prev: [0; REPDIST_CODES] }
+    }
+
+    /// `prevdist[-1]` is the most recent distance; `[-2]` the one before it.
+    #[inline]
+    fn recent(&self, back: usize) -> u32 {
+        self.prev[REPDIST_CODES - back]
+    }
+
+    /// Move the entry `back` places from the end to the end, sliding the ones
+    /// after it down -- the C's explicit swap chains in `getdist`.
+    #[inline]
+    fn promote(&mut self, back: usize) -> u32 {
+        let idx = REPDIST_CODES - back;
+        let d = self.prev[idx];
+        for i in idx..REPDIST_CODES - 1 {
+            self.prev[i] = self.prev[i + 1];
+        }
+        self.prev[REPDIST_CODES - 1] = d;
+        d
+    }
+
+    #[inline]
+    fn push(&mut self, dist: u32) {
+        for i in 0..REPDIST_CODES - 1 {
+            self.prev[i] = self.prev[i + 1];
+        }
+        self.prev[REPDIST_CODES - 1] = dist;
+    }
+}
+
+impl<D: SymbolDecoder> Lz77Decoder for GenericDecoder<D> {
+    fn is_literal(&mut self) -> bool {
+        self.x = self.d.decode();
+        self.x < 256
+    }
+
+    fn getchar(&mut self) -> u8 {
+        self.x as u8
+    }
+
+    fn getlen(&mut self, minlen: u32) -> u32 {
+        if self.x == REPCHAR {
+            return 1;
+        }
+        let lcode = self.x % LEN_CODES;
+        let lbits = self.t.lc2_extra[lcode];
+        let lbase = self.t.lc2_base[lcode];
+        let len = lbase.wrapping_add(self.d.getbits(lbits));
+        // Lengths above 100 are the escape window: 101..104 encode the four
+        // table/EOF signals, anything higher is a real length shifted by 4.
+        if len > 100 {
+            if len <= 104 {
+                len - 100 + IMPOSSIBLE_LEN
+            } else {
+                len - 4 + minlen
+            }
+        } else {
+            len + minlen
+        }
+    }
+
+    fn getdist(&mut self) -> u32 {
+        if self.x == REPCHAR {
+            return self.recent(1);
+        }
+        let dcode = (self.x - 256) / LEN_CODES;
+        // The first REPDIST_CODES distance codes are "reuse a recent distance";
+        // the C reaches them by letting dcode go negative.
+        if dcode < REPDIST_CODES {
+            return match dcode {
+                0 => self.recent(1),
+                1 => self.promote(2),
+                2 => self.promote(3),
+                _ => self.promote(4),
+            };
+        }
+        let dcode = dcode - REPDIST_CODES;
+        // Only 0..31 are real distance codes. A symbol at or above REPBOTH
+        // yields 32, and the C reads `xextra_bits[32]` -- past the part its
+        // constructor ever fills, so uninitialised. That is unreachable from a
+        // valid stream: REPBOTH and the seven spare codes are declared but the
+        // encoder never emits them, and EOB and REPCHAR are handled before
+        // this. Clamping keeps a corrupt stream deterministic; the resulting
+        // distance is then rejected by the output loop's `dist > bufsize` check
+        // rather than silently copying from nowhere.
+        let dcode = dcode.min(31);
+        let dbits = self.t.dc_extra[dcode];
+        let dbase = self.t.dc_base[dcode];
+        let dist = dbase.wrapping_add(self.d.getbits(dbits)).wrapping_add(1);
+        self.push(dist);
+        dist
+    }
+
+    fn error(&self) -> Option<c_int> {
+        self.d.error()
+    }
+}

--- a/rust/darc-codecs/src/tornado/mod.rs
+++ b/rust/darc-codecs/src/tornado/mod.rs
@@ -36,6 +36,9 @@
 
 #![allow(dead_code)] // WIP: layers land before the entry point that uses them
 
+pub mod huffman;
+pub mod lz77;
+pub mod range;
 pub mod stream;
 pub mod vle;
 

--- a/rust/darc-codecs/src/tornado/mod.rs
+++ b/rust/darc-codecs/src/tornado/mod.rs
@@ -36,10 +36,12 @@
 
 #![allow(dead_code)] // WIP: layers land before the entry point that uses them
 
+pub mod decode;
 pub mod huffman;
 pub mod lz77;
 pub mod range;
 pub mod stream;
+pub mod tables;
 pub mod vle;
 
 /// Encoding methods (`enum {STORING..ARICODER}`, Tornado.cpp:34).

--- a/rust/darc-codecs/src/tornado/mod.rs
+++ b/rust/darc-codecs/src/tornado/mod.rs
@@ -1,0 +1,108 @@
+//! Tornado LZ77 decoder, ported from `Compression/Tornado/`.
+//!
+//! **Work in progress.** The stream and table layers are ported; the four
+//! entropy back-ends, the data-table undiffer and the output loop are not, so
+//! nothing here is wired to `tor_decompress` yet and the C decoder is still the
+//! one that runs. Nothing is excluded C-side until the port is complete and
+//! verified byte-exact, the same order used for REP, Dict, LZP, TTA and MM.
+//!
+//! Tornado is the highest-value target left: `tor` is a default method, so
+//! every `-m4`-and-up archive contains Tornado streams.
+//!
+//! ## Shape of the thing
+//!
+//! `tor_decompress` (Tornado.cpp:487) reads a six-byte header --
+//! `encoding_method`, `minlen`, then a 4-byte `bufsize` -- and dispatches to
+//! `tor_decompress0<Decoder>` (:400) with one of four back-ends:
+//!
+//! | method | back-end | entropy layer |
+//! |---|---|---|
+//! | 1 BYTECODER | `LZ77_ByteDecoder` | none, byte-aligned with LZSS flag words |
+//! | 2 BITCODER  | `LZ77_BitDecoder`  | none, bit-aligned with VLE codes |
+//! | 3 HUFCODER  | `LZ77_Decoder<HuffmanDecoder>` | semi-adaptive Huffman |
+//! | 4 ARICODER  | `LZ77_Decoder<ArithDecoder>`   | semi-adaptive range coder |
+//!
+//! 0 (STORING) never reaches the decoder loop. Only the entropy layer differs;
+//! all four feed the same `is_literal` / `getchar` / `getlen` / `getdist`
+//! interface to one output loop over a circular buffer.
+//!
+//! The Huffman and arithmetic back-ends are *semi-adaptive*: both sides update
+//! symbol counters as they go and rebuild their tables on the same schedule, so
+//! the decoder has to reproduce the tree builder and the rescale exactly, not
+//! merely read the codes. That is the bulk of the remaining work.
+//!
+//! Encoder-only files are not in scope: `MatchFinder.cpp` (956 lines) and
+//! `OptimalParsing.cpp` (44) are reached only from `tor_compress`.
+
+#![allow(dead_code)] // WIP: layers land before the entry point that uses them
+
+pub mod stream;
+pub mod vle;
+
+/// Encoding methods (`enum {STORING..ARICODER}`, Tornado.cpp:34).
+pub const STORING: u32 = 0;
+pub const BYTECODER: u32 = 1;
+pub const BITCODER: u32 = 2;
+pub const HUFCODER: u32 = 3;
+pub const ARICODER: u32 = 4;
+
+/// Code-space layout for the Huffman/arith back-ends (LZ77_Coder.cpp:388-398).
+pub const REPDIST_CODES: usize = 4;
+pub const DIST_CODES: usize = vle::EXTRA_DBITS.len() + REPDIST_CODES; // 36
+pub const LEN_CODES: usize = vle::EXTRA_LBITS2.len(); // 16
+/// End of block -- also the signal to rebuild the Huffman tree.
+pub const EOB_CODE: usize = 256 + LEN_CODES * DIST_CODES; // 832
+/// Copy one char at the last distance.
+pub const REPCHAR: usize = EOB_CODE + 1;
+/// Repeat both the previous length and distance.
+pub const REPBOTH: usize = EOB_CODE + 2;
+/// Total alphabet, including seven spare codes.
+pub const CODES: usize = EOB_CODE + 10; // 842
+
+/// `PAD_FOR_TABLES` (DataTables.cpp:13): slack required both before and after
+/// the output buffer so table undiffing can reach across its edges.
+pub const MAX_TABLE_ROW_AT_DECOMPRESSION: usize = 256;
+pub const PAD_FOR_TABLES: usize = MAX_TABLE_ROW_AT_DECOMPRESSION * 2;
+
+#[cfg(test)]
+mod tests {
+    use super::vle::*;
+
+    /// The distance base values are the one table where an off-by-one is
+    /// invisible until archives decode to subtly wrong bytes, so they are
+    /// pinned against the three-range construction in LZ77_Coder.cpp:233.
+    #[test]
+    fn distance_bases_follow_the_three_ranges() {
+        let base = distance_bases();
+        // First range counts distances one at a time from zero.
+        assert_eq!(base[0], 0);
+        assert_eq!(base[1], 16); // 1<<4
+        assert_eq!(base[2], 32); // +1<<4
+        assert_eq!(base[3], 64); // +1<<5
+        // Ranges are monotonically increasing across all three regimes.
+        for w in base.windows(2) {
+            assert!(w[1] > w[0], "distance bases must increase: {w:?}");
+        }
+        // The last code reaches the 1 GB ceiling the coder documents.
+        assert!(base[31] >= 1 << 20, "top distance base too small: {}", base[31]);
+    }
+
+    #[test]
+    fn length_bases_are_running_sums_of_their_extra_bits() {
+        let base = length_bases(&EXTRA_LBITS);
+        assert_eq!(base[0], 0);
+        assert_eq!(base[1], 1);
+        assert_eq!(base[2], 2);
+        assert_eq!(base[3], 3); // codes 0..2 carry no extra bits
+        assert_eq!(base[4], 5); // +1<<1
+        assert_eq!(base[5], 9); // +1<<2
+
+        let base2 = length_bases(&EXTRA_LBITS2);
+        // Seven zero-extra-bit codes, so the first seven bases are 0..6.
+        for (i, b) in base2.iter().take(7).enumerate() {
+            assert_eq!(*b, i as u32);
+        }
+        assert_eq!(base2[7], 7);
+        assert_eq!(base2[8], 9); // +1<<1
+    }
+}

--- a/rust/darc-codecs/src/tornado/range.rs
+++ b/rust/darc-codecs/src/tornado/range.rs
@@ -1,0 +1,223 @@
+//! Shindler range decoder and its semi-adaptive counter, ported from
+//! `Compression/Tornado/EntropyCoder.cpp` (`TRangeDecoder` :555, `TCounter`
+//! :602, `ArithDecoder` :703).
+//!
+//! Like the Huffman back-end this is semi-adaptive: nothing about the model
+//! travels in the stream. Both sides start from an even split of `RANGE` points
+//! across the alphabet, count every symbol as it is coded, and recompute the
+//! coding table whenever `RANGE` new points have accumulated -- so the decoder
+//! reproduces `Rescale` exactly or the two sides drift apart silently.
+//!
+//! The aging step is the subtle part: `livecnt[s] -= (livecnt[s]>1 &&
+//! livecnt[s]<6)? 1 : livecnt[s]/6`, i.e. each block starts from roughly 5/6 of
+//! the previous counts, with small counts decremented rather than divided so
+//! they do not collapse to zero. `remainder` is then how many increments it
+//! takes to bring the total back up to `RANGE`.
+//!
+//! All the arithmetic wraps at 32 bits in C; every operation here is an
+//! explicit `wrapping_*` for the same reason it is in `tta.rs` -- Rust would
+//! panic in debug on values the format produces routinely.
+
+use super::stream::{InputByteStream, BAD};
+use core::ffi::c_int;
+
+/// `RANGE_BITS` / `RANGE` (EntropyCoder.cpp:599-600).
+pub const RANGE_BITS: u32 = 14;
+pub const RANGE: u32 = 1 << RANGE_BITS;
+/// `INDEXES` -- entries in the fast symbol-lookup table (:598).
+pub const INDEXES: usize = 2048;
+/// `NUM` -- maximum alphabet (:597).
+pub const NUM: usize = 2048;
+/// Points per index slot; 8 with the constants above.
+const PER_INDEX: u32 = RANGE / INDEXES as u32;
+
+pub struct RangeDecoder<'a> {
+    pub bytes: InputByteStream<'a>,
+    range: u32,
+    buffer: u32,
+    /// Sticky corrupt-data flag. The C printed to stderr and called `exit(1)`
+    /// here, which killed `arc t` on a damaged archive instead of reporting a
+    /// bad block; the C has since been fixed to record an error the same way.
+    err: Option<c_int>,
+}
+
+impl<'a> RangeDecoder<'a> {
+    pub fn new(bytes: InputByteStream<'a>) -> Self {
+        let mut d = RangeDecoder { bytes, range: 0xffff_ffff, buffer: 0, err: None };
+        // Five bytes primed. The C leaves `buffer` uninitialised before this
+        // loop, but forty bits of shifting evict every original bit, so
+        // starting from zero is identical rather than merely close.
+        for _ in 0..5 {
+            d.buffer = (d.buffer << 8).wrapping_add(d.bytes.getc());
+        }
+        d
+    }
+
+    /// `GetCount` (:568).
+    pub fn get_count(&mut self, bits: u32) -> u32 {
+        self.range >>= bits;
+        let mut count = if self.range == 0 { 0 } else { self.buffer / self.range };
+        if count >= (1u32 << bits) {
+            self.err = Some(BAD);
+            count = (1u32 << bits) - 1;
+        }
+        count
+    }
+
+    /// `Update` (:576).
+    pub fn update(&mut self, cum: u32, cnt: u32) {
+        self.buffer = self.buffer.wrapping_sub(cum.wrapping_mul(self.range));
+        self.range = self.range.wrapping_mul(cnt);
+        while self.range < (1 << 24) {
+            self.range <<= 8;
+            self.buffer = (self.buffer << 8).wrapping_add(self.bytes.getc());
+        }
+    }
+
+    pub fn error(&self) -> Option<c_int> {
+        self.err.or_else(|| self.bytes.error())
+    }
+}
+
+/// `TCounter<Decoder>` (:602).
+pub struct Counter {
+    n: usize,
+    remainder: u32,
+    cnt: Vec<u32>,
+    cum: Vec<u32>,
+    livecnt: Vec<u32>,
+    index: Vec<u16>,
+}
+
+impl Counter {
+    pub fn new(n: usize) -> Self {
+        let mut c = Counter {
+            n,
+            remainder: 0,
+            cnt: vec![0; n],
+            cum: vec![0; n],
+            livecnt: vec![0; n],
+            index: vec![0; INDEXES + 1],
+        };
+        // RANGE points split evenly, remainder handed to the first symbols.
+        let share = RANGE / n as u32;
+        let extra = RANGE - share * n as u32;
+        for s in 0..n {
+            c.livecnt[s] = share + if (s as u32) < extra { 1 } else { 0 };
+        }
+        c.rescale();
+        c
+    }
+
+    #[inline]
+    pub fn cum(&self, s: usize) -> u32 {
+        self.cum[s]
+    }
+
+    #[inline]
+    pub fn cnt(&self, s: usize) -> u32 {
+        self.cnt[s]
+    }
+
+    /// `Inc` (:613).
+    #[inline]
+    pub fn inc(&mut self, s: usize) {
+        self.livecnt[s] += 1;
+        // Rescale leaves remainder > 0 (the aged counts always sum to less than
+        // RANGE), so this cannot underflow on a well-formed model; saturating
+        // rather than wrapping keeps a corrupt one from panicking across the
+        // C ABI instead of just rescaling early.
+        self.remainder = self.remainder.saturating_sub(1);
+        if self.remainder == 0 {
+            self.rescale();
+        }
+    }
+
+    /// `Rescale` (:646).
+    fn rescale(&mut self) {
+        self.remainder = RANGE;
+        let mut total: u32 = 0;
+        let mut ind: usize = 0;
+        for s in 0..self.n {
+            self.cnt[s] = self.livecnt[s];
+            self.cum[s] = total;
+            total += self.cnt[s];
+            let lc = self.livecnt[s];
+            self.livecnt[s] -= if lc > 1 && lc < 6 { 1 } else { lc / 6 };
+            self.remainder = self.remainder.wrapping_sub(self.livecnt[s]);
+            // index[k] ends up holding the first symbol whose range can cover
+            // code k*PER_INDEX, which is what makes Decode's search short.
+            while ind < INDEXES && self.cum[s] + self.cnt[s] >= PER_INDEX * ind as u32 + 1 {
+                self.index[ind] = s as u16;
+                ind += 1;
+            }
+        }
+        // A well-formed table has total == RANGE and fills every index slot; if
+        // it somehow did not, point the tail at the last symbol rather than
+        // leaving stale entries behind.
+        while ind < INDEXES {
+            self.index[ind] = (self.n - 1) as u16;
+            ind += 1;
+        }
+    }
+
+    /// `Decode` (:624): jump to the index hint, then walk forward to the first
+    /// symbol whose range end reaches `count`. Bounded here -- the C walk has
+    /// no upper limit and a corrupt count would run it off the end of `cum[]`.
+    #[inline]
+    pub fn decode(&self, count: u32) -> usize {
+        let mut s = self.index[(count / PER_INDEX) as usize] as usize;
+        while s < self.n && self.cum[s] + self.cnt[s] < count + 1 {
+            s += 1;
+        }
+        if s >= self.n {
+            self.n - 1
+        } else {
+            s
+        }
+    }
+}
+
+/// `ArithDecoder<EOB>` (:703).
+pub struct ArithDecoder<'a> {
+    pub rc: RangeDecoder<'a>,
+    c: Counter,
+}
+
+impl<'a> ArithDecoder<'a> {
+    pub fn new(bytes: InputByteStream<'a>, elements: usize) -> Self {
+        ArithDecoder { rc: RangeDecoder::new(bytes), c: Counter::new(elements) }
+    }
+
+    /// Decode one symbol and count it.
+    pub fn decode(&mut self) -> usize {
+        let count = self.rc.get_count(RANGE_BITS);
+        let x = self.c.decode(count);
+        self.rc.update(self.c.cum(x), self.c.cnt(x));
+        self.c.inc(x);
+        x
+    }
+
+    /// `getbits` (:722): raw bits ride the same coder with a flat count of 1,
+    /// split into two pieces past 24 bits so the range never underflows.
+    pub fn getbits(&mut self, n: u32) -> u32 {
+        if n == 0 {
+            return 0;
+        }
+        if n <= 24 {
+            let x = self.rc.get_count(n);
+            self.rc.update(x, 1);
+            x
+        } else {
+            let x1 = self.rc.get_count(15);
+            self.rc.update(x1, 1);
+            let x2 = self.rc.get_count(n - 15);
+            self.rc.update(x2, 1);
+            (x2 << 15) + x1
+        }
+    }
+
+    pub fn error(&self) -> Option<c_int> {
+        self.rc.error()
+    }
+}

--- a/rust/darc-codecs/src/tornado/stream.rs
+++ b/rust/darc-codecs/src/tornado/stream.rs
@@ -1,0 +1,216 @@
+//! Input byte and bit streams, ported from `Compression/Tornado/EntropyCoder.cpp`
+//! (`InputByteStream` :105, `InputBitStream` :223).
+//!
+//! All four Tornado back-ends read through one of these, so this is the layer
+//! that decides what a truncated stream does.
+//!
+//! ## The C has no end-of-data bound, and this does
+//!
+//! `InputByteStream` keeps a `bufsize` buffer with `MAXELEM` bytes of slack at
+//! the front, refilled whenever the read pointer passes `read_point`. It
+//! records the callback's return value in `errcode` but never compares it to
+//! what it asked for -- the `dataend` field that would have tracked it is
+//! commented out at EntropyCoder.cpp:113. So once the input is exhausted the
+//! callback returns 0 and the decoder keeps reading whatever those bytes
+//! happened to be: the previous chunk's data, or uninitialised heap on the
+//! first read. A truncated `-mtor` stream therefore decodes stale memory
+//! rather than failing, and a corrupt one can spin emitting literals forever.
+//!
+//! Here the buffer past the valid data reads as zero, and running off the end
+//! is an error rather than a silent success. That is deliberately *not*
+//! bug-compatible, and it cannot change a valid stream: the only reads past
+//! real data are the bit buffer's 4-byte lookahead and `get64`'s slack, and a
+//! valid stream stops at its EOB code before any of those bits reach the
+//! output. `EXHAUSTED_SLACK` is what keeps that lookahead legal.
+
+use crate::ffi::{Io, FREEARC_ERRCODE_BAD_COMPRESSED_DATA};
+use core::ffi::c_int;
+
+pub const BAD: c_int = FREEARC_ERRCODE_BAD_COMPRESSED_DATA as c_int;
+
+/// `MAXELEM` (EntropyCoder.cpp:22) -- the largest element `get64` can pull, and
+/// the slack the C keeps at the buffer front so a read never straddles a chunk.
+const MAXELEM: usize = 8;
+
+/// `LARGE_BUFFER_SIZE` (Compression.h:41), the refill granularity. Not part of
+/// the format -- it only decides how often the callback is asked for more.
+const LARGE_BUFFER_SIZE: usize = 256 << 10;
+
+/// How far past the last real byte a read may go before it is an error. The bit
+/// buffer refills 32 bits at a time through `get32`, and `get64` reads 8, so a
+/// stream that ends mid-lookahead is still valid; one that keeps asking well
+/// past the end is not.
+const EXHAUSTED_SLACK: usize = 64;
+
+pub struct InputByteStream<'a> {
+    io: &'a Io,
+    buf: Vec<u8>,
+    /// Read cursor within `buf`.
+    pos: usize,
+    /// One past the last byte the callback actually delivered.
+    valid: usize,
+    /// Refill fence: `buf.len() - MAXELEM` in the C layout.
+    read_point: usize,
+    /// Bytes served from beyond `valid`; past `EXHAUSTED_SLACK` this is a
+    /// truncated stream rather than end-of-stream lookahead.
+    overrun: usize,
+    /// Sticky negative error from the callback.
+    err: Option<c_int>,
+}
+
+impl<'a> InputByteStream<'a> {
+    pub fn new(io: &'a Io, bufsize: usize) -> Self {
+        // compress_all_at_once is false for the archiver's streaming path, so
+        // the C picks LARGE_BUFFER_SIZE regardless of the header's bufsize.
+        let _ = bufsize;
+        let size = LARGE_BUFFER_SIZE;
+        let mut s = InputByteStream {
+            io,
+            buf: vec![0u8; MAXELEM + size],
+            pos: MAXELEM,
+            valid: MAXELEM,
+            read_point: MAXELEM + size,
+            overrun: 0,
+            err: None,
+        };
+        s.refill();
+        s
+    }
+
+    fn refill(&mut self) {
+        let start = MAXELEM;
+        let end = self.buf.len();
+        // Anything the callback does not deliver must read as zero rather than
+        // as the previous chunk, so the result never depends on stale bytes.
+        self.buf[start..end].fill(0);
+        match self.io.read(&mut self.buf[start..end]) {
+            n if n < 0 => {
+                self.err = Some(n);
+                self.valid = start;
+            }
+            n => self.valid = start + n as usize,
+        }
+    }
+
+    /// `fill()` (EntropyCoder.cpp:136): once the cursor passes the fence, carry
+    /// the last MAXELEM bytes to the front and read the next chunk.
+    #[inline]
+    fn fill(&mut self) {
+        if self.pos >= self.read_point {
+            let tail = self.buf.len() - MAXELEM;
+            self.buf.copy_within(tail.., 0);
+            let consumed_valid = self.valid;
+            self.refill();
+            self.pos -= self.buf.len() - MAXELEM;
+            // Carry forward how far past real data we had already gone.
+            if consumed_valid < tail {
+                self.overrun += tail - consumed_valid;
+            }
+        }
+    }
+
+    #[inline]
+    fn take(&mut self, n: usize) -> &[u8] {
+        self.fill();
+        if self.pos + n > self.valid {
+            self.overrun += (self.pos + n).saturating_sub(self.valid.max(self.pos));
+        }
+        let at = self.pos;
+        self.pos += n;
+        &self.buf[at..at + n]
+    }
+
+    /// Any hard error seen so far: a negative callback return, or reading so far
+    /// past the end of the data that the stream must be truncated.
+    pub fn error(&self) -> Option<c_int> {
+        if let Some(e) = self.err {
+            return Some(e);
+        }
+        if self.overrun > EXHAUSTED_SLACK {
+            return Some(BAD);
+        }
+        None
+    }
+
+    #[inline]
+    pub fn getc(&mut self) -> u32 {
+        self.take(1)[0] as u32
+    }
+
+    #[inline]
+    pub fn get8(&mut self) -> u32 {
+        self.getc()
+    }
+
+    #[inline]
+    pub fn get16(&mut self) -> u32 {
+        let b = self.take(2);
+        u16::from_le_bytes([b[0], b[1]]) as u32
+    }
+
+    #[inline]
+    pub fn get24(&mut self) -> u32 {
+        let b = self.take(3);
+        u32::from_le_bytes([b[0], b[1], b[2], 0])
+    }
+
+    #[inline]
+    pub fn get32(&mut self) -> u32 {
+        let b = self.take(4);
+        u32::from_le_bytes([b[0], b[1], b[2], b[3]])
+    }
+}
+
+/// `InputBitStream` (EntropyCoder.cpp:223). The bit buffer is filled 32 bits at
+/// a time from the low end and consumed from the low end, so `bitcount` is how
+/// many valid bits sit in `bitbuf`.
+pub struct InputBitStream<'a> {
+    pub bytes: InputByteStream<'a>,
+    bitbuf: u64,
+    bitcount: i32,
+}
+
+impl<'a> InputBitStream<'a> {
+    pub fn new(io: &'a Io, bufsize: usize) -> Self {
+        InputBitStream { bytes: InputByteStream::new(io, bufsize), bitbuf: 0, bitcount: 0 }
+    }
+
+    /// `needbits` -- top up to at least `n` valid bits (n <= 32) and return them.
+    #[inline]
+    pub fn needbits(&mut self, n: i32) -> u32 {
+        if self.bitcount <= 32 {
+            self.bitbuf |= (self.bytes.get32() as u64) << self.bitcount;
+            self.bitcount += 32;
+        }
+        mask64(self.bitbuf, n)
+    }
+
+    #[inline]
+    pub fn dumpbits(&mut self, n: i32) {
+        self.bitbuf >>= n;
+        self.bitcount -= n;
+    }
+
+    #[inline]
+    pub fn getbits(&mut self, n: i32) -> u32 {
+        let x = self.needbits(n);
+        self.dumpbits(n);
+        x
+    }
+
+    pub fn error(&self) -> Option<c_int> {
+        self.bytes.error()
+    }
+}
+
+/// `mask(x,n)` (EntropyCoder.cpp:17). C computes `(1<<n)-1` in `int`, so n==32
+/// would be undefined there; it is only ever called with n<=32 and the shift is
+/// done here at 64 bits so the n==32 case is well defined.
+#[inline]
+pub fn mask64(x: u64, n: i32) -> u32 {
+    if n >= 32 {
+        x as u32
+    } else {
+        (x & ((1u64 << n) - 1)) as u32
+    }
+}

--- a/rust/darc-codecs/src/tornado/stream.rs
+++ b/rust/darc-codecs/src/tornado/stream.rs
@@ -69,7 +69,9 @@ impl<'a> InputByteStream<'a> {
             buf: vec![0u8; MAXELEM + size],
             pos: MAXELEM,
             valid: MAXELEM,
-            read_point: MAXELEM + size,
+            // C: read_point = buf + bufsize, i.e. MAXELEM short of the end,
+            // leaving room for a get64 that straddles the fence.
+            read_point: size,
             overrun: 0,
             err: None,
         };
@@ -172,7 +174,14 @@ pub struct InputBitStream<'a> {
 
 impl<'a> InputBitStream<'a> {
     pub fn new(io: &'a Io, bufsize: usize) -> Self {
-        InputBitStream { bytes: InputByteStream::new(io, bufsize), bitbuf: 0, bitcount: 0 }
+        Self::from_bytes(InputByteStream::new(io, bufsize))
+    }
+
+    /// Continue from an already-open byte stream. The six-byte header is read
+    /// through one of these, and it has buffered payload behind it, so the
+    /// back-end must inherit that buffer rather than open a second stream.
+    pub fn from_bytes(bytes: InputByteStream<'a>) -> Self {
+        InputBitStream { bytes, bitbuf: 0, bitcount: 0 }
     }
 
     /// `needbits` -- top up to at least `n` valid bits (n <= 32) and return them.

--- a/rust/darc-codecs/src/tornado/tables.rs
+++ b/rust/darc-codecs/src/tornado/tables.rs
@@ -1,0 +1,243 @@
+//! Data-table diffing, ported from `Compression/Tornado/DataTables.cpp`
+//! (`undiff_table` :46, `diff_table` :20, `DataTables` :128).
+//!
+//! Tornado's encoder spots tables of fixed-width numbers and subtracts each row
+//! from the next, which the LZ stage then compresses far better. The decoder
+//! has to add them back -- but only just before the bytes leave for the output
+//! stream, because until then those same bytes are still the LZ window that
+//! later matches copy from. So each table is undiffed, written, and then
+//! **diffed again in place** to restore the window. That round trip is what
+//! `undiff_tables` / `diff_tables` are for, and it is why a table straddling
+//! two write chunks needs its base row saved and restored.
+//!
+//! Positions here are absolute indices into the decoder's buffer rather than
+//! raw pointers. The buffer carries `PAD_FOR_TABLES` of slack at both ends, so
+//! a table start may legitimately sit *before* the logical origin after the
+//! window wraps -- which is exactly what that padding is reserved for.
+
+use super::MAX_TABLE_ROW_AT_DECOMPRESSION as MAX_ROW;
+
+/// Entries before the list forces a flush (`ENTRIES`, DataTables.cpp:166).
+const ENTRIES: usize = 10000;
+
+#[derive(Clone, Copy)]
+pub struct TableEntry {
+    /// Bytes per row (`table_type`).
+    pub row: usize,
+    /// Absolute index of the table's first byte.
+    pub start: usize,
+    /// Number of rows.
+    pub len: usize,
+}
+
+/// Add each row to the previous one. Byte-wise with carry for widths other than
+/// 2 and 4, which is what makes this exactly reversible by `diff_table`.
+pub fn undiff_table(buf: &mut [u8], n: usize, start: usize, len: usize) {
+    if len == 0 || n == 0 {
+        return;
+    }
+    let end = start + n * len;
+    match n {
+        2 => {
+            let mut v = u16::from_le_bytes([buf[start], buf[start + 1]]);
+            let mut r = start + 2;
+            while r < end {
+                v = v.wrapping_add(u16::from_le_bytes([buf[r], buf[r + 1]]));
+                buf[r..r + 2].copy_from_slice(&v.to_le_bytes());
+                r += 2;
+            }
+        }
+        4 => {
+            let mut v = u32::from_le_bytes([buf[start], buf[start + 1], buf[start + 2], buf[start + 3]]);
+            let mut r = start + 4;
+            while r < end {
+                v = v.wrapping_add(u32::from_le_bytes([buf[r], buf[r + 1], buf[r + 2], buf[r + 3]]));
+                buf[r..r + 4].copy_from_slice(&v.to_le_bytes());
+                r += 4;
+            }
+        }
+        _ => {
+            let mut r = start + n;
+            while r < end {
+                let mut carry = 0u32;
+                for i in 0..n {
+                    let t = buf[r + i] as u32 + buf[r + i - n] as u32 + carry;
+                    buf[r + i] = t as u8;
+                    carry = t >> 8;
+                }
+                r += n;
+            }
+        }
+    }
+}
+
+/// The inverse: subtract each row from the next, restoring the LZ window after
+/// a write. Walks backwards so each row still sees its undiffed predecessor.
+pub fn diff_table(buf: &mut [u8], n: usize, start: usize, len: usize) {
+    if len == 0 || n == 0 {
+        return;
+    }
+    let end = start + n * len;
+    match n {
+        2 => {
+            let mut prev = u16::from_le_bytes([buf[start], buf[start + 1]]);
+            let mut r = start + 2;
+            while r < end {
+                let v = u16::from_le_bytes([buf[r], buf[r + 1]]);
+                buf[r..r + 2].copy_from_slice(&v.wrapping_sub(prev).to_le_bytes());
+                prev = v;
+                r += 2;
+            }
+        }
+        4 => {
+            let mut prev =
+                u32::from_le_bytes([buf[start], buf[start + 1], buf[start + 2], buf[start + 3]]);
+            let mut r = start + 4;
+            while r < end {
+                let v = u32::from_le_bytes([buf[r], buf[r + 1], buf[r + 2], buf[r + 3]]);
+                buf[r..r + 4].copy_from_slice(&v.wrapping_sub(prev).to_le_bytes());
+                prev = v;
+                r += 4;
+            }
+        }
+        _ => {
+            let mut r = end;
+            while r > start + n {
+                r -= n;
+                let mut carry = 0u32;
+                for i in 0..n {
+                    let sub = buf[r + i - n] as u32 + carry;
+                    let newcarry = ((buf[r + i] as u32) < sub) as u32;
+                    buf[r + i] = (buf[r + i] as u32).wrapping_sub(sub) as u8;
+                    carry = newcarry;
+                }
+            }
+        }
+    }
+}
+
+pub struct DataTables {
+    tables: Vec<TableEntry>,
+    /// Base row of a table split across two write chunks, saved before the
+    /// re-diff so the next chunk can undiff from it.
+    base_data: [u8; MAX_ROW],
+    /// The bytes `undiff_tables` temporarily overwrote with `base_data`.
+    original: [u8; MAX_ROW],
+    original_bytes: usize,
+}
+
+impl DataTables {
+    pub fn new() -> Self {
+        DataTables {
+            tables: Vec::with_capacity(64),
+            base_data: [0; MAX_ROW],
+            original: [0; MAX_ROW],
+            original_bytes: 0,
+        }
+    }
+
+    pub fn add(&mut self, row: usize, start: usize, len: usize) {
+        self.tables.push(TableEntry { row, start, len });
+    }
+
+    pub fn filled(&self) -> bool {
+        self.tables.len() >= ENTRIES
+    }
+
+    /// Rows of `e` that lie at or before `write_end`. The C lets this go
+    /// negative for a table starting past the write point, where every loop
+    /// body is then skipped; the saturating form here has the same effect.
+    fn rows_until(e: &TableEntry, write_end: usize) -> usize {
+        if e.row == 0 || write_end < e.start {
+            return 0;
+        }
+        let fit = 1 + (write_end - e.start) / e.row;
+        fit.min(e.len)
+    }
+
+    fn process(&mut self, buf: &mut [u8], write_end: usize, undiff: bool) {
+        for e in &self.tables {
+            let len = Self::rows_until(e, write_end);
+            if undiff {
+                undiff_table(buf, e.row, e.start, len);
+            } else {
+                diff_table(buf, e.row, e.start, len);
+            }
+        }
+    }
+
+    /// Undiff everything up to `write_end`, ready for the bytes to be written.
+    pub fn undiff_tables(&mut self, buf: &mut [u8], write_start: usize, write_end: usize) {
+        self.original_bytes = 0;
+        if let Some(first) = self.tables.first().copied() {
+            if first.start < write_start {
+                // This table began in the previous chunk. Its first row on disk
+                // is a difference, so swap in the base row saved back then, and
+                // remember what was there to put back afterwards.
+                let n = first.row.min(write_start - first.start).min(MAX_ROW);
+                self.original[..n].copy_from_slice(&buf[first.start..first.start + n]);
+                buf[first.start..first.start + n].copy_from_slice(&self.base_data[..n]);
+                self.original_bytes = n;
+            }
+        }
+        self.process(buf, write_end, true);
+    }
+
+    /// Re-diff so the written bytes go back to being a valid LZ window, and
+    /// clear the list -- keeping the tail of a table that runs past `write_end`.
+    pub fn diff_tables(&mut self, buf: &mut [u8], write_start: usize, write_end: usize) {
+        let mut carry_over: Option<TableEntry> = None;
+        if let Some(&last) = self.tables.last() {
+            if last.row != 0 && write_end >= last.start {
+                let processed = (write_end - last.start) / last.row;
+                if processed < last.len {
+                    // Keep two extra rows: one as the undiff base for the next
+                    // chunk, and one because a row can straddle the boundary.
+                    let processed = processed.saturating_sub(2);
+                    let mut tail = last;
+                    tail.start += processed * last.row;
+                    tail.len -= processed;
+                    let n = tail.row.min(MAX_ROW);
+                    self.base_data[..n].copy_from_slice(&buf[tail.start..tail.start + n]);
+                    carry_over = Some(tail);
+                }
+            }
+        }
+        self.process(buf, write_end, false);
+        // Put back the bytes undiff_tables borrowed for the base row.
+        if self.original_bytes > 0 {
+            if let Some(first) = self.tables.first().copied() {
+                if first.start < write_start {
+                    let n = self.original_bytes;
+                    buf[first.start..first.start + n].copy_from_slice(&self.original[..n]);
+                }
+            }
+        }
+        self.original_bytes = 0;
+        self.tables.clear();
+        if let Some(t) = carry_over {
+            self.tables.push(t);
+        }
+    }
+
+    /// The window wrapped: move table positions back with it, and carry the few
+    /// leading bytes that now sit before the origin -- undiffing the next chunk
+    /// needs them, which is what `PAD_FOR_TABLES` reserves room for.
+    pub fn shift(&mut self, buf: &mut [u8], old_pos: usize, new_pos: usize) {
+        let delta = old_pos - new_pos;
+        for e in self.tables.iter_mut() {
+            let old = e.start;
+            e.start -= delta;
+            if new_pos > e.start {
+                let n = new_pos - e.start;
+                buf.copy_within(old..old + n, e.start);
+            }
+        }
+    }
+}
+
+impl Default for DataTables {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/rust/darc-codecs/src/tornado/vle.rs
+++ b/rust/darc-codecs/src/tornado/vle.rs
@@ -1,0 +1,99 @@
+//! Variable-length length/distance code tables, ported from
+//! `Compression/Tornado/LZ77_Coder.cpp` (`VLE` :147, `LengthCoder` :195,
+//! `DistanceCoder` :217).
+//!
+//! These are pure lookup tables derived from the `extra_bits` arrays. The
+//! decoder needs only `extra_bits(code)` and `base_value(code)` -- the
+//! `value -> code` direction (`xcode`) is the encoder's, so it is not built
+//! here. What matters for decoding is that `xbase_value` comes out identical,
+//! including `DistanceCoder`'s three-range construction, because a base value
+//! off by one silently shifts every match distance.
+
+/// Extra bits per length code, bitcoder (`extra_lbits`, LZ77_Coder.cpp:189).
+pub const EXTRA_LBITS: [u32; 8] = [0, 0, 0, 1, 2, 4, 8, 30];
+
+/// Extra bits per length code, huffman/arith (`extra_lbits2`, :190).
+pub const EXTRA_LBITS2: [u32; 16] = [0, 0, 0, 0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 8, 30];
+
+/// Extra bits per distance code (`extra_dbits`, :211).
+pub const EXTRA_DBITS: [u32; 32] = [
+    4, 4, 5, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15, 16, 17,
+    18, 19, 21, 23, 30,
+];
+
+/// Base value for each length code: the running sum of `1 << extra_bits`, which
+/// is what `VLE`'s constructor accumulates in `value`.
+pub fn length_bases<const N: usize>(extra: &[u32; N]) -> [u32; N] {
+    let mut base = [0u32; N];
+    let mut value: u64 = 0;
+    for code in 0..N {
+        base[code] = value as u32;
+        // The C stops filling xcode[] at VLE_SIZE but keeps advancing `value`
+        // only while it writes, so the base values follow the unclamped sum for
+        // every code that fits -- and the last code (30 extra bits) is never
+        // used as a base for anything the decoder reads back.
+        value += 1u64 << extra[code];
+    }
+    base
+}
+
+/// `DistanceCoder`'s base values (LZ77_Coder.cpp:233). Three ranges: distances
+/// below 512 are counted one by one, then in units of 256, then of 65536 --
+/// hence `dist << 8` and `dist << 16` rather than a plain running sum.
+pub fn distance_bases() -> [u32; 32] {
+    let extra = &EXTRA_DBITS;
+    let mut base = [0u32; 32];
+    let mut dist: u64 = 0;
+    let mut code = 0usize;
+
+    while dist < 512 && code < 32 {
+        base[code] = dist as u32;
+        dist += 1u64 << extra[code];
+        code += 1;
+    }
+    dist >>= 8; // from here on distances are counted in units of 256
+    while dist < 512 && code < 32 {
+        base[code] = (dist << 8) as u32;
+        dist += 1u64 << (extra[code] - 8);
+        code += 1;
+    }
+    dist >>= 8; // and from here in units of 65536
+    while code < 32 {
+        base[code] = (dist << 16) as u32;
+        dist += 1u64 << (extra[code] - 16);
+        code += 1;
+    }
+    base
+}
+
+/// The three tables the decoders index, built once per decode call. They are a
+/// few hundred bytes and building them is a handful of shifts, so there is no
+/// reason to reach for a global the way the C does (`lc`, `lc2`, `dc` are
+/// file-scope objects with static constructors there).
+pub struct Tables {
+    pub lc_extra: [u32; 8],
+    pub lc_base: [u32; 8],
+    pub lc2_extra: [u32; 16],
+    pub lc2_base: [u32; 16],
+    pub dc_extra: [u32; 32],
+    pub dc_base: [u32; 32],
+}
+
+impl Tables {
+    pub fn new() -> Self {
+        Tables {
+            lc_extra: EXTRA_LBITS,
+            lc_base: length_bases(&EXTRA_LBITS),
+            lc2_extra: EXTRA_LBITS2,
+            lc2_base: length_bases(&EXTRA_LBITS2),
+            dc_extra: EXTRA_DBITS,
+            dc_base: distance_bases(),
+        }
+    }
+}
+
+impl Default for Tables {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/rust/darc-codecs/tests/tornado.rs
+++ b/rust/darc-codecs/tests/tornado.rs
@@ -1,0 +1,176 @@
+//! Malformed-input tests for the Tornado decoder.
+//!
+//! Byte-exactness against the C original is proved by
+//! rust/difftest/tornado-check.sh, which is the only thing that can. What these
+//! add is the half the differential harness does not reach: hostile and
+//! truncated input.
+//!
+//! The bar is specific. `tor_decompress` is reached through `arc t` on an
+//! attacker-supplied archive -- and `tor` is a default method, so this is the
+//! codec most likely to meet one. It must return an error there: never panic
+//! (an unwind across `extern "C"` is undefined behaviour) and never hang. Both
+//! failure modes are live concerns here rather than hypothetical. The C decoder
+//! reads past the end of its own buffer on a truncated stream because
+//! `InputByteStream` never checks how much the read callback delivered, and the
+//! port's own slow match path panicked on a `usize` underflow until an 11 MB
+//! input exposed it.
+
+use darc_codecs::ffi::Io;
+use darc_codecs::tornado::decode;
+use std::ffi::{c_char, c_int, c_void, CStr};
+
+struct Mem {
+    input: Vec<u8>,
+    pos: usize,
+    output: Vec<u8>,
+    /// Cap on emitted bytes: a decoder that fails to terminate would otherwise
+    /// grow this until the machine gives up, which reads as a hang rather than
+    /// a failure.
+    limit: usize,
+}
+
+unsafe extern "C" fn mem_callback(
+    what: *const c_char,
+    buf: *mut c_void,
+    size: c_int,
+    aux: *mut c_void,
+) -> c_int {
+    let mem = &mut *(aux as *mut Mem);
+    let what = CStr::from_ptr(what).to_bytes();
+    let size = if size < 0 { return -1 } else { size as usize };
+
+    if what == b"read" {
+        let n = size.min(mem.input.len() - mem.pos);
+        if n > 0 {
+            std::ptr::copy_nonoverlapping(mem.input[mem.pos..].as_ptr(), buf as *mut u8, n);
+            mem.pos += n;
+        }
+        n as c_int
+    } else if what == b"write" {
+        if mem.output.len() + size > mem.limit {
+            return -1; // refuse rather than let a runaway decoder allocate
+        }
+        if size > 0 {
+            mem.output
+                .extend_from_slice(std::slice::from_raw_parts(buf as *const u8, size));
+        }
+        size as c_int
+    } else {
+        0
+    }
+}
+
+fn decode_with(input: &[u8], limit: usize) -> (c_int, usize) {
+    let mut mem = Mem { input: input.to_vec(), pos: 0, output: Vec::new(), limit };
+    let io = unsafe { Io::new(Some(mem_callback), &mut mem as *mut Mem as *mut c_void) }
+        .expect("callback was not null");
+    let rc = decode::decompress(&io);
+    drop(io);
+    (rc, mem.output.len())
+}
+
+fn decode(input: &[u8]) -> (c_int, usize) {
+    decode_with(input, 64 << 20)
+}
+
+fn prng(seed: u32, n: usize) -> Vec<u8> {
+    let mut s = seed.wrapping_mul(2654435761).wrapping_add(1);
+    (0..n)
+        .map(|_| {
+            s = s.wrapping_mul(1103515245).wrapping_add(12345);
+            (s >> 16) as u8
+        })
+        .collect()
+}
+
+/// A six-byte header: method, minlen, then a little-endian window size.
+fn header(method: u8, minlen: u8, bufsize: u32) -> Vec<u8> {
+    let mut v = vec![method, minlen];
+    v.extend_from_slice(&bufsize.to_le_bytes());
+    v
+}
+
+#[test]
+fn empty_input_is_rejected_cleanly() {
+    let (rc, out) = decode(&[]);
+    assert!(rc < 0, "empty input must be an error, got {rc}");
+    assert_eq!(out, 0);
+}
+
+#[test]
+fn unknown_encoding_method_is_rejected() {
+    // 0 is STORING, which never reaches the decoder loop; 5..=255 are undefined.
+    for method in [0u8, 5, 6, 100, 255] {
+        let mut input = header(method, 4, 1 << 20);
+        input.extend_from_slice(&prng(1, 4096));
+        let (rc, out) = decode(&input);
+        assert!(rc < 0, "method {method} must be rejected, got {rc}");
+        assert_eq!(out, 0, "method {method} emitted data before failing");
+    }
+}
+
+#[test]
+fn absurd_window_size_is_rejected_not_allocated() {
+    // bufsize is four attacker-controlled bytes that the C hands to malloc.
+    for bufsize in [0u32, 0x4000_0001, 0x7fff_ffff, 0x8000_0000, 0xffff_ffff] {
+        let mut input = header(1, 4, bufsize);
+        input.extend_from_slice(&prng(2, 4096));
+        let (rc, out) = decode(&input);
+        assert!(rc < 0, "bufsize {bufsize:#x} must be rejected, got {rc}");
+        assert_eq!(out, 0);
+    }
+}
+
+#[test]
+fn truncation_at_every_header_position_is_survivable() {
+    let full = {
+        let mut v = header(3, 4, 1 << 20);
+        v.extend_from_slice(&prng(3, 256));
+        v
+    };
+    for cut in 0..full.len() {
+        let (rc, _) = decode(&full[..cut]);
+        let _ = rc; // any status is fine; not panicking or hanging is the test
+    }
+}
+
+#[test]
+fn garbage_never_panics_on_any_back_end() {
+    // All four back-ends over random payloads. The bit, huffman and arithmetic
+    // decoders each build adaptive state from whatever they read, so garbage
+    // drives them into states a valid stream never produces.
+    for method in 1u8..=4 {
+        for seed in 0..24u32 {
+            for len in [8usize, 64, 1000, 40_000] {
+                let mut input = header(method, 4, 1 << 20);
+                input.extend_from_slice(&prng(seed, len));
+                let (rc, _) = decode_with(&input, 4 << 20);
+                let _ = rc;
+            }
+        }
+    }
+}
+
+#[test]
+fn zero_minlen_is_survivable() {
+    // minlen is a header byte and feeds the match length directly; the output
+    // loop rejects a zero length because both copy loops decrement first.
+    for method in 1u8..=4 {
+        let mut input = header(method, 0, 1 << 20);
+        input.extend_from_slice(&prng(5, 8192));
+        let (rc, _) = decode_with(&input, 4 << 20);
+        let _ = rc;
+    }
+}
+
+#[test]
+fn a_write_error_is_propagated_not_ignored() {
+    // The limit makes the write callback fail partway through. A decoder that
+    // ignores that would keep going and report success.
+    for method in 1u8..=4 {
+        let mut input = header(method, 4, 1 << 20);
+        input.extend_from_slice(&prng(9, 200_000));
+        let (rc, _) = decode_with(&input, 16);
+        let _ = rc;
+    }
+}

--- a/rust/difftest/tornado-check.sh
+++ b/rust/difftest/tornado-check.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Differential-test the Tornado decoder port against the C original.
+#
+# Tornado is ported decode-first, so the C compressor is the only encoder:
+# compress each input with C at every preset, decompress with both C and the
+# Rust port, and require both to reproduce the original. Byte-for-byte equality
+# is the bar because Tornado defines an archive format -- and `tor` is a default
+# method, so these are the streams inside every -m4-and-up archive.
+#
+# The presets are not interchangeable: 1 selects the byte coder, 2 the bit
+# coder, 3-4 huffman and 5+ the range coder. All four share one output loop and
+# nothing else, so a corpus that skips any of them proves little.
+set -uo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+W="${TMPDIR:-/tmp}/tornado-check.$$"; mkdir -p "$W"
+trap 'rm -rf "$W"' EXIT
+
+( cd "$ROOT/rust" && cargo build --release -p darc-codecs ) >/dev/null 2>&1 \
+  || { echo "cargo build failed" >&2; exit 1; }
+LIB="$ROOT/rust/target/release/libdarc_codecs.a"
+
+# Trailing arguments land after the sources: GNU ld resolves an archive against
+# only the objects already seen, so a library placed first is silently dropped.
+cc() { local out="$1"; shift
+  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+    -I"$ROOT" -I"$ROOT/Compression" \
+    "$ROOT/rust/difftest/tornado_ref.cpp" "$ROOT/rust/difftest/tornado_ccodec.cpp" \
+    "$ROOT/Compression/Common.cpp" "$@" -o "$out"; }
+cc "$W/c"                    || exit 1
+cc "$W/rs" -DUSE_RUST "$LIB" || exit 1
+
+# Inputs chosen for the LZ and entropy layers both: long repeats (deep matches
+# and the repeat-distance codes), text (skewed symbol statistics, so the
+# huffman tree rebuilds often), incompressible noise (literal-heavy), tables of
+# fixed-width numbers (the data-table diffing path), and sizes around the
+# buffer and flag-word boundaries.
+python3 - "$W/in" <<'PY'
+import os,sys,struct
+d=sys.argv[1]; os.makedirs(d,exist_ok=True)
+def prng(seed,n):
+    s=seed; o=bytearray()
+    for _ in range(n): s=(s*1103515245+12345)&0xffffffff; o.append((s>>16)&0xff)
+    return bytes(o)
+w=lambda n,b: open(f"{d}/{n}","wb").write(b)
+w("text",      b"the quick brown fox jumps over the lazy dog. "*20000)
+w("repeats",   (b"ABCDEFGHIJKLMNOP"*64 + prng(1,256))*400)
+w("noise",     prng(7, 900000))
+w("zeros",     b"\x00"*700000)
+w("mixed",     b"".join((prng(i,1000) + b"pattern"*200) for i in range(300)))
+# Tables of 4- and 2-byte little-endian counters: what the data-table
+# detector is built to find.
+w("table4",    b"".join(struct.pack("<I", i*7+3) for i in range(200000)))
+w("table2",    b"".join(struct.pack("<H", (i*11)&0xffff) for i in range(400000)))
+w("table_mixed", b"".join(struct.pack("<I", i) for i in range(50000))
+               + prng(3,200000)
+               + b"".join(struct.pack("<H", i&0xffff) for i in range(100000)))
+# Larger than HUGE_BUFFER_SIZE (8 MB), so the output window actually wraps and
+# flushes mid-stream. Everything below that size sees exactly one flush, at the
+# very end, which leaves the window-wrap path, the cross-chunk data-table
+# bookkeeping and any match reaching back further than `output` has advanced
+# entirely unexercised. A corpus without this passed while the port still had a
+# panic in it.
+w("big_table",  b"".join(struct.pack("<I", i*7+3) for i in range(2600000)))
+for n in (0,1,15,16,17,63,64,65,4095,4096,65535,65536,65537):
+    w(f"n_{n}", (b"the quick brown fox "*10000)[:n])
+PY
+
+total=0
+for preset in 1 2 3 4 5 7 9 11; do
+  fail=0; n=0
+  for f in "$W"/in/*; do
+    n=$((n+1)); name=$(basename "$f")
+    "$W/c"  c "$preset" < "$f"    >| "$W/s"  2>/dev/null || { echo "  [p$preset] $name: C-compress FAILED"; fail=$((fail+1)); continue; }
+    "$W/c"  d           < "$W/s"  >| "$W/oc" 2>/dev/null || { echo "  [p$preset] $name: C-decode FAILED";   fail=$((fail+1)); continue; }
+    "$W/rs" d           < "$W/s"  >| "$W/or" 2>/dev/null || { echo "  [p$preset] $name: RUST-decode FAILED"; fail=$((fail+1)); continue; }
+    cmp -s "$f" "$W/oc" || { echo "  [p$preset] $name: C-decode != original (harness bug)"; fail=$((fail+1)); continue; }
+    cmp -s "$f" "$W/or" || { echo "  [p$preset] $name: RUST-decode != original"; fail=$((fail+1)); continue; }
+  done
+  m=$("$W/c" c "$preset" < "$W/in/text" 2>/dev/null | head -c1 | od -An -tu1 | tr -d ' ')
+  echo "  [preset $preset, coder $m] $n inputs, $fail differing"
+  total=$((total+fail))
+done
+
+echo "tornado decode: $total total differing"
+[ "$total" -eq 0 ] && echo "Tornado decoder matches the C original byte for byte" || exit 1

--- a/rust/difftest/tornado_ccodec.cpp
+++ b/rust/difftest/tornado_ccodec.cpp
@@ -1,0 +1,20 @@
+/* The C Tornado codec for the differential harness.
+ *
+ * Tornado.cpp includes Compression.h and its four component files itself, the
+ * same way C_Tornado.cpp compiles it, so no amalgamation is needed here.
+ * TORNADO_LIBRARY suppresses anything driver-shaped.
+ *
+ * tor_compress/tor_decompress are declared inside an `extern "C"` block in
+ * Tornado.cpp itself (:27-31), so they have C linkage here as well as in the
+ * real build -- which is also why the Rust drop-in needs the C definition
+ * excluded rather than merely shadowed.
+ */
+#define TORNADO_LIBRARY
+#include "../../Compression/Tornado/Tornado.cpp"
+
+// Thin shim so the driver can select a preset without seeing PackMethod's
+// definition (it lives inside Tornado.cpp, which only this unit includes).
+int tor_compress_preset (int preset, CALLBACK_FUNC *callback, void *auxdata)
+{
+    return tor_compress (std_Tornado_method[preset], callback, auxdata);
+}

--- a/rust/difftest/tornado_ref.cpp
+++ b/rust/difftest/tornado_ref.cpp
@@ -1,0 +1,74 @@
+/* Reference driver for differential-testing the Tornado decoder port.
+ *
+ *     tornado_ref c PRESET  <in >stream
+ *     tornado_ref d         <stream >out
+ *
+ * Built a second time with -DUSE_RUST so `d` drives the Rust port. Tornado is
+ * ported decode-first, so the C compressor is the only encoder and the test is
+ * that the Rust decoder reproduces the original bytes from its output.
+ *
+ * PRESET indexes std_Tornado_method[], which is what -mtor:N selects. The
+ * presets span all four entropy back-ends, which is the point: the byte, bit,
+ * huffman and arithmetic decoders share one output loop but nothing else.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "../../Compression/Compression.h"
+
+extern "C" {
+int tor_decompress (CALLBACK_FUNC *callback, void *auxdata);
+#ifdef USE_RUST
+int darc_rs_tor_decompress (CALLBACK_FUNC *callback, void *auxdata);
+#endif
+}
+struct PackMethod;
+extern PackMethod std_Tornado_method[];
+int tor_compress_preset (int preset, CALLBACK_FUNC *callback, void *auxdata);
+
+struct Buffers {
+  const unsigned char *in; size_t in_len, in_pos;
+  unsigned char *out; size_t out_len, out_cap;
+};
+static int io_callback (const char *what, void *data, int size, void *aux) {
+  Buffers *b = (Buffers*) aux;
+  if (size < 0) return FREEARC_ERRCODE_GENERAL;
+  if (strcmp(what,"read")==0) {
+    size_t avail=b->in_len-b->in_pos, n=(size_t)size<avail?(size_t)size:avail;
+    memcpy(data,b->in+b->in_pos,n); b->in_pos+=n; return (int)n;
+  }
+  if (strcmp(what,"write")==0) {
+    if (b->out_len+(size_t)size>b->out_cap) {
+      size_t cap=b->out_cap?b->out_cap:65536;
+      while (cap<b->out_len+(size_t)size) cap*=2;
+      unsigned char *g=(unsigned char*)realloc(b->out,cap);
+      if(!g) return FREEARC_ERRCODE_NOT_ENOUGH_MEMORY;
+      b->out=g; b->out_cap=cap;
+    }
+    memcpy(b->out+b->out_len,data,(size_t)size); b->out_len+=(size_t)size; return size;
+  }
+  if (strcmp(what,"quasiwrite")==0)  return 0;
+  return FREEARC_ERRCODE_NOT_IMPLEMENTED;
+}
+
+int main (int argc, char **argv) {
+  if (argc<2 || (argv[1][0]!='c'&&argv[1][0]!='d')) {
+    fprintf(stderr,"usage: %s c PRESET | d\n",argv[0]); return 2; }
+  size_t cap=1<<20, len=0; unsigned char *in=(unsigned char*)malloc(cap); if(!in) return 3;
+  for(;;){ if(len==cap){cap*=2; unsigned char*g=(unsigned char*)realloc(in,cap); if(!g){free(in);return 3;} in=g;}
+    size_t n=fread(in+len,1,cap-len,stdin); if(n==0)break; len+=n; }
+  Buffers b={in,len,0,NULL,0,0};
+  int rc;
+  if (argv[1][0]=='c') {
+    rc = tor_compress_preset (argc>2? atoi(argv[2]) : 4, io_callback, &b);
+  } else {
+#ifdef USE_RUST
+    rc = darc_rs_tor_decompress (io_callback, &b);
+#else
+    rc = tor_decompress (io_callback, &b);
+#endif
+  }
+  if (rc<0){ fprintf(stderr,"codec returned %d\n",rc); free(in); free(b.out); return 4; }
+  if (b.out_len && fwrite(b.out,1,b.out_len,stdout)!=b.out_len){ free(in); free(b.out); return 5; }
+  free(in); free(b.out); return 0;
+}


### PR DESCRIPTION
Ports `tor_decompress` and everything it reaches to `rust/darc-codecs/src/tornado/`, selected by `DARC_RUST=1`. Decode-first, as with REP, Dict, LZP, TTA and MM — and the highest-value target so far: **`tor` is a default method**, so every `-m4`-and-up archive contains Tornado streams.

Four interchangeable entropy back-ends behind one output loop, all ported:

| method | back-end | entropy layer |
|---|---|---|
| 1 BYTECODER | `ByteDecoder` | none — byte-aligned, LZSS flag words |
| 2 BITCODER | `BitDecoder` | none — bit-aligned VLE codes |
| 3 HUFCODER | `GenericDecoder<HufBackend>` | semi-adaptive Huffman |
| 4 ARICODER | `GenericDecoder<ArithDecoder>` | semi-adaptive range coder |

The two adaptive ones carry no model in the stream: both sides start from a fixed state, count every symbol, and rebuild on the same schedule. So the decoder had to reproduce `build_tree` and `Rescale` exactly — including the sort stability the Huffman builder depends on, which the C obtains by packing `(counter, index)` into one integer.

Encoder-only files are untouched: `MatchFinder.cpp` (956 lines) and `OptimalParsing.cpp` (44) are reached only from `tor_compress`.

## Verification

| | |
|---|---|
| Differential vs C | **176/176 byte-identical** — 22 inputs × 8 presets, all four back-ends |
| Sabotage | 6 sabotages break **4–21** cases each |
| Malformed input | 7 nextest cases; suite **52/52** |
| Archive format | stock and `DARC_RUST` both 22/22, **identical fingerprints**, `tor` still `a9519783eb5917ce` |
| Really linked | `C_Tornado.o` carries `U _tor_decompress` |

## Two bugs the harness caught that reading had not

1. **`IMPOSSIBLE_LEN` is `INT_MAX/2` (`0x3fffffff`), not `1<<30`.** I assumed the round number. The EOF check is an equality test, so all four back-ends failed identically — the decoder never recognised the end of a stream.
2. **The slow match path underflowed on `usize`.** `output - dist + bufsize` is legal C pointer arithmetic where the intermediate may sit before the buffer and come back; on `usize` it panics across the C ABI.

## The sabotage that wasn't caught, and why that mattered

The data-table sabotage first came back **0 differing**. That was not the port being right — my corpus topped out under 900 KB against an 8 MB flush granularity, so every input saw exactly one flush, at the very end. The window never wrapped, the cross-chunk table bookkeeping never ran, and no match ever reached back further than `output` had advanced.

An 11 MB input broke the port immediately; that is where bug 2 came from. The corpus now carries one, the data-table sabotage is caught (6 cases), and a new window-wrap sabotage is caught too (4). A sabotage that isn't caught is a claim about the test, not the code.

## C-side fix included

`TRangeDecoder::GetCount` called **`exit(1)`** on a corrupt count — inside a library, from a worker thread, with the archive still open. `arc t` on a damaged `-mtor` archive killed the process rather than reporting a bad block. It now records `FREEARC_ERRCODE_BAD_COMPRESSED_DATA` and clamps so decoding stays well defined.

No check was added to the symbol loop: `WRITE_DATA_IF` already tests `decoder.error()` (Tornado.cpp:372) and every iteration advances `output` by at least one byte, so termination was already guaranteed. I wrote one before noticing that, and removed it — it would only have made the error surface sooner, at the price of a branch in the hottest loop of a default codec.

## One deliberate divergence

`InputByteStream` records the read callback's return value but never compares it to what it asked for (the `dataend` field is commented out at EntropyCoder.cpp:113), so a truncated stream decodes stale buffer contents — previous-chunk data, or uninitialised heap on the first read. The port reads zero past the end and treats running off it as an error. This cannot change a valid stream: the only over-reads are the bit buffer's 4-byte lookahead and `get64`'s slack, and a valid stream hits its EOB code first.

`tornado-check.sh` joins the per-codec differential step in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)