### PR TITLE
GRZip: port the decoder to Rust, verified byte-identical

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -621,13 +621,14 @@ jobs:
     # the same original bytes over a corpus built for that codec's heuristics.
     # They were runnable but unrun until now: a differential test nothing
     # invokes is documentation, not a check.
-    - name: Per-codec differential tests (REP, TTA, MM, Tornado)
+    - name: Per-codec differential tests (REP, TTA, MM, Tornado, GRZip)
       run: |
         chmod +x rust/difftest/*.sh
         rust/difftest/rep-check.sh
         rust/difftest/tta-check.sh
         rust/difftest/mm-check.sh
         rust/difftest/tornado-check.sh
+        rust/difftest/grzip-check.sh
 
     # Build the archiver twice and require identical archives. This is the check
     # that actually guards the format.

--- a/Compression/GRZip/C_GRZip.cpp
+++ b/Compression/GRZip/C_GRZip.cpp
@@ -598,11 +598,31 @@ struct GRZipMTDecompressor : MTCompressor<GRZipDecompressionThread>
 };
 
 
+// DARC_RUST=1 selects the Rust port of the decoder (rust/darc-codecs).
+//
+// grzip_decompress is declared in C_GRZip.h, which this file includes inside an
+// extern "C" block, so this definition inherits C linkage and shares a symbol
+// with the Rust export. Excluded rather than redeclared: with both present the
+// linker resolves from this object and never pulls the Rust one -- and, both
+// being C-linkage, GNU ld reports a multiple definition. The same is true of
+// the other codecs (C_Dict.cpp, C_LZP.cpp, rep.cpp, tta.cpp, mm.cpp,
+// Tornado.cpp).
+//
+// The Rust decoder is serial where GRZipMTDecompressor uses a worker pool. That
+// is a throughput difference, not a format one: a GRZip stream is a bare
+// sequence of blocks and the bytes written are the same blocks in the same
+// order. GRZipDecompressionThread and the pool stay compiled for the encoder,
+// which still uses them.
+//
+// Verified byte-identical to the C decoder across all four transform/coder
+// combinations; see rust/difftest/grzip-check.sh.
+#ifndef DARC_RUST
 int __cdecl grzip_decompress (CALLBACK_FUNC *callback, void *auxdata)
 {
   GRZipMTDecompressor grz (callback, auxdata);
   return grz.run();
 }
+#endif  // !DARC_RUST (grzip_decompress)
 
 
 /*-------------------------------------------------*/

--- a/rust/darc-codecs/src/exports.rs
+++ b/rust/darc-codecs/src/exports.rs
@@ -8,7 +8,7 @@
 //! what wires them together; until then these are exercised by the differential
 //! harness rather than by the archiver.
 
-use crate::{delta, dict, dict_encode, lzp, mm, rep, tornado, tta};
+use crate::{delta, dict, dict_encode, grzip, lzp, mm, rep, tornado, tta};
 use crate::ffi::{Io, CALLBACK_FUNC, FREEARC_ERRCODE_GENERAL};
 use core::ffi::{c_int, c_void};
 
@@ -366,4 +366,34 @@ pub unsafe extern "C" fn tor_decompress(
     auxdata: *mut c_void,
 ) -> c_int {
     darc_rs_tor_decompress(callback, auxdata)
+}
+
+/// GRZip block decoder, for the differential harness only.
+///
+/// GRZip is still being ported -- there is no `grzip_decompress` drop-in yet,
+/// because the stream wrapper is not written. This exposes the block level,
+/// which is where every stage that *is* ported actually runs, so the harness
+/// can compare against `GRZip_DecompressBlock` before more code piles up on
+/// top of unverified code.
+///
+/// Returns the number of bytes written, or a negative GRZip error code.
+///
+/// # Safety
+/// `input`/`output` must be valid for `in_size`/`out_cap` bytes.
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_grzip_decompress_block(
+    input: *const u8,
+    in_size: c_int,
+    output: *mut u8,
+    out_cap: c_int,
+) -> c_int {
+    if input.is_null() || output.is_null() || in_size < 0 || out_cap < 0 {
+        return FREEARC_ERRCODE_GENERAL;
+    }
+    let inp = core::slice::from_raw_parts(input, in_size as usize);
+    let out = core::slice::from_raw_parts_mut(output, out_cap as usize);
+    match grzip::block::decompress_block(inp, out) {
+        Ok(n) => n as c_int,
+        Err(e) => e,
+    }
 }

--- a/rust/darc-codecs/src/exports.rs
+++ b/rust/darc-codecs/src/exports.rs
@@ -397,3 +397,33 @@ pub unsafe extern "C" fn darc_rs_grzip_decompress_block(
         Err(e) => e,
     }
 }
+
+/// GRZip decoder. Like TTA, MM and Tornado it takes no tuning parameters --
+/// every block carries its own 28-byte header.
+///
+/// # Safety
+/// `callback` and `auxdata` must be what the C caller supplied.
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_grzip_decompress(
+    callback: CALLBACK_FUNC,
+    auxdata: *mut c_void,
+) -> c_int {
+    match Io::new(callback, auxdata) {
+        Some(io) => grzip::stream::decompress(&io),
+        None => FREEARC_ERRCODE_GENERAL,
+    }
+}
+
+/// Drop-in under the archiver's own symbol name; the switch is an exclusion in
+/// C_GRZip.cpp rather than a redeclaration, as with the other codecs.
+///
+/// # Safety
+/// `callback` and `auxdata` must be what the C caller supplied.
+#[cfg(feature = "dropin")]
+#[no_mangle]
+pub unsafe extern "C" fn grzip_decompress(
+    callback: CALLBACK_FUNC,
+    auxdata: *mut c_void,
+) -> c_int {
+    darc_rs_grzip_decompress(callback, auxdata)
+}

--- a/rust/darc-codecs/src/grzip/ari.rs
+++ b/rust/darc-codecs/src/grzip/ari.rs
@@ -1,0 +1,355 @@
+//! The shared arithmetic decoder behind GRZip's two entropy coders, ported from
+//! `Compression/GRZip/MTF_Ari.c` (`GRZip_MTF_Ari_Decode` :404) and
+//! `WFC_Ari.c` (`GRZip_WFC_Ari_Decode` :498).
+//!
+//! Those two C files are near-duplicates: identical range coder, identical
+//! model stack, identical run-length ladder. They differ in exactly one step --
+//! how a decoded rank becomes a character. MTF uses a move-to-front list; WFC
+//! uses a weighted-frequency-count list. That step is the `SymbolList` trait
+//! here, so the ~150 lines around it are transcribed once rather than twice.
+//!
+//! This is the entropy stage that follows the BWT or ST4. It decodes a
+//! move-to-front rank, then a run length for that symbol, both through a binary
+//! arithmetic coder driven by a stack of adaptive context models.
+//!
+//! ## How a symbol is spelled
+//!
+//! 1. **Rank 0-3** from a quaternary model that mixes three tables: a global
+//!    one, one keyed on the previous character, and one keyed on the recent
+//!    rank and run-length history.
+//! 2. If the rank is 3, the real rank is **escaped**: a unary group number
+//!    (0-6) then a binary position within that group, which together index
+//!    `GRNUM_TO_GRBEGIN`. Group 6 with position 127 is the **end marker** --
+//!    the only exit from the loop.
+//! 3. The rank drives a **move-to-front list**, giving the character.
+//! 4. A **log2 run length**, again unary, then that many bits of the run's
+//!    remainder, offset by `LOG2_RLE_SIZE`.
+//!
+//! Every model is a frequency in `[0, MODEL_MAX_FREQ]` updated by shifting
+//! toward or away from the maximum -- `x += (MAX-x)>>k` on a zero bit,
+//! `x -= x>>k` on a one. The shift constants differ per model and are what tune
+//! adaptation speed; they must match exactly or the two sides diverge.
+//!
+//! ## Bounds
+//!
+//! The C gained several bounds in an earlier hardening pass, all reproduced
+//! here: an over-read counter so a truncated block stops instead of spinning on
+//! zero bytes, a rank-search limit so a corrupt frequency cannot walk past the
+//! five-entry models, a `Log2RunSize` ceiling, and a run length checked against
+//! the remaining output. The one exit is the end marker, so without them a
+//! corrupt block never terminates.
+
+use super::{GrzError, GRZ_UNEXPECTED_EOF};
+
+pub const MAX_BYTE: usize = 256;
+pub const RANGE_TOP: u32 = 1 << 24;
+pub const MODEL_NUM_BITS: u32 = 11;
+pub const MODEL_MAX_FREQ: u32 = 1 << MODEL_NUM_BITS;
+
+const M_LOG2RLE_SHIFT_0: u32 = 6;
+const M_LOG2RLE_SHIFT_1: u32 = 3;
+const M_LOG2RLE_SHIFT_2: u32 = 6;
+const M_L1_SHIFT_0: u32 = 4;
+const M_L1_SHIFT_1: u32 = 6;
+const M_L2_SHIFT: u32 = 7;
+
+const MODEL_L0_0_MAX_FREQ: u32 = 58;
+const MODEL_L0_1_MAX_FREQ: u32 = 62;
+const MODEL_L0_2_MAX_FREQ: u32 = 204;
+
+/// `GRZ_Log2MaxBlockSize` (libGRZip.h:55).
+pub const LOG2_MAX_BLOCK: usize = 23;
+
+/// `WFCMTF_GrNum2GrBegin` (WFC_MTF.h:90).
+pub const GRNUM_TO_GRBEGIN: [u32; 7] = [3, 5, 9, 17, 33, 65, 129];
+
+/// `WFCMTF_Log2RLESize` (WFC_MTF.h:92) -- the base run length for each log2
+/// bucket.
+pub const LOG2_RLE_SIZE: [u32; LOG2_MAX_BLOCK + 1] = [
+    1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072,
+    262144, 524288, 1048576, 2097152, 4194304, 8388608,
+];
+
+/// How far past the compressed data the decoder may read before giving up.
+/// The C counts the same and checks it at the top of the symbol loop.
+pub const MAX_OVERREAD: u32 = 64;
+
+struct Rc<'a> {
+    input: &'a [u8],
+    pos: usize,
+    code: u32,
+    range: u32,
+    overread: u32,
+}
+
+impl<'a> Rc<'a> {
+    /// `ARI_InTgtByte`: past the end, yield zero and count it.
+    #[inline]
+    fn byte(&mut self) -> u32 {
+        if self.pos < self.input.len() {
+            let b = self.input[self.pos] as u32;
+            self.pos += 1;
+            b
+        } else {
+            self.overread += 1;
+            0
+        }
+    }
+
+    fn new(input: &'a [u8]) -> Self {
+        let mut rc = Rc { input, pos: 0, code: 0, range: u32::MAX, overread: 0 };
+        // Five bytes, four of them followed by a shift.
+        for _ in 0..4 {
+            rc.code |= rc.byte();
+            rc.code <<= 8;
+        }
+        rc.code |= rc.byte();
+        rc
+    }
+
+    /// `ARI_GetFreq`: divides `range` in place, then scales the code by it.
+    #[inline]
+    fn get_freq(&mut self, tot: u32) -> u32 {
+        self.range /= tot.max(1);
+        if self.range == 0 {
+            0
+        } else {
+            self.code / self.range
+        }
+    }
+
+    /// `ARI_Decode`. The `TotFreq` argument the C takes is assigned and never
+    /// used -- the division already happened in `get_freq` -- so it is absent.
+    #[inline]
+    fn decode(&mut self, freq: u32, cum: u32) {
+        self.code = self.code.wrapping_sub(cum.wrapping_mul(self.range));
+        self.range = self.range.wrapping_mul(freq);
+        while self.range < RANGE_TOP {
+            let b = self.byte();
+            self.code = (self.code << 8) | b;
+            self.range <<= 8;
+        }
+    }
+
+    #[inline]
+    fn decode_0(&mut self, f: u32) {
+        self.decode(f, 0);
+    }
+
+    #[inline]
+    fn decode_1(&mut self, f: u32) {
+        self.decode(MODEL_MAX_FREQ - f, f);
+    }
+}
+
+#[inline]
+fn up0(v: &mut u32, k: u32) {
+    *v += (MODEL_MAX_FREQ - *v) >> k;
+}
+
+#[inline]
+fn up1(v: &mut u32, k: u32) {
+    *v -= *v >> k;
+}
+
+/// The one step that differs between the two coders: turn a rank into a
+/// character, updating whatever list discipline the coder maintains.
+pub trait SymbolList {
+    fn pick(&mut self, rank: usize) -> u8;
+}
+
+/// The decoder body. `out_size` is the capacity of `out`; the return is how
+/// many bytes were written.
+pub fn decode<L: SymbolList>(
+    input: &[u8],
+    out: &mut [u8],
+    out_size: usize,
+    list: &mut L,
+) -> Result<usize, GrzError> {
+    let cap = out_size.min(out.len());
+    let mut rc = Rc::new(input);
+
+    let mut m_l0_0 = [1u32, 1, 1, 1, 4];
+    let mut m_l0_1 = vec![0u32; MAX_BYTE * 5];
+    let mut m_l0_2 = vec![0u32; 4 * MAX_BYTE * 5];
+    let half = MODEL_MAX_FREQ >> 1;
+    let mut m_l1_0 = [half; 8];
+    // The C initialises only rows 0..6 (`for (i=0;i<7;i++)`), leaving row 7 as
+    // uninitialised stack. CtxL1 is a group number in 0..6, so row 7 is never
+    // read; initialising it too is unreachable rather than divergent.
+    let mut m_l1_1 = [[half; 8]; 8];
+    let mut m_l2_0 = [[half; 128]; 8];
+    let mut m_rle_0 = [[half; LOG2_MAX_BLOCK + 1]; 64];
+    let mut m_rle_2 = [[half; LOG2_MAX_BLOCK + 1]; LOG2_MAX_BLOCK + 1];
+    let mut m_rle_1 = vec![half; MAX_BYTE * (LOG2_MAX_BLOCK + 1)];
+
+    let mut ctx_rle: usize = 0;
+    let mut ctx_l0: usize = 0;
+    let mut ctx_l1: usize = 0;
+    let mut ch: usize = 0;
+    let mut op = 0usize;
+
+    loop {
+        // The only exit is the end marker, so a corrupt stream would otherwise
+        // spin forever on zero bytes.
+        if rc.overread > MAX_OVERREAD {
+            return Err(GRZ_UNEXPECTED_EOF);
+        }
+
+        let pred = ch;
+        let v = pred * 5; // Model_L0_1[PredChar]
+        let u = (4 * ctx_l0 + (ctx_rle & 3)) * 5; // Model_L0_2[...]
+
+        let total = m_l0_0[4] + m_l0_2[u + 4] + m_l0_1[v + 4];
+        let frq = rc.get_freq(total);
+        // Bounded at 4: a corrupt frequency could otherwise walk past the
+        // five-entry models. A valid stream always stops by rank 4.
+        let mut cum = 0u32;
+        let mut rank = 0usize;
+        while frq >= cum && rank < 4 {
+            cum += m_l0_0[rank] + m_l0_2[u + rank] + m_l0_1[v + rank];
+            rank += 1;
+        }
+        rank -= 1;
+        cum -= m_l0_0[rank] + m_l0_2[u + rank] + m_l0_1[v + rank];
+
+        rc.decode(m_l0_0[rank] + m_l0_2[u + rank] + m_l0_1[v + rank], cum);
+
+        m_l0_0[rank] += 2;
+        m_l0_2[u + rank] += 2;
+        m_l0_1[v + rank] += 2;
+        m_l0_0[4] += 2;
+        m_l0_2[u + 4] += 2;
+        m_l0_1[v + 4] += 2;
+
+        // Update_Model_L0: halve each model that has outgrown its ceiling. Note
+        // the global one rounds up, the two context ones do not.
+        if m_l0_0[4] > MODEL_L0_0_MAX_FREQ {
+            let mut sum = 0;
+            for i in 0..4 {
+                m_l0_0[i] = (m_l0_0[i] + 1) >> 1;
+                sum += m_l0_0[i];
+            }
+            m_l0_0[4] = sum;
+        }
+        if m_l0_1[v + 4] > MODEL_L0_1_MAX_FREQ {
+            let mut sum = 0;
+            for i in 0..4 {
+                m_l0_1[v + i] >>= 1;
+                sum += m_l0_1[v + i];
+            }
+            m_l0_1[v + 4] = sum;
+        }
+        if m_l0_2[u + 4] > MODEL_L0_2_MAX_FREQ {
+            let mut sum = 0;
+            for i in 0..4 {
+                m_l0_2[u + i] >>= 1;
+                sum += m_l0_2[u + i];
+            }
+            m_l0_2[u + 4] = sum;
+        }
+
+        let mut wrank = rank;
+        if rank == 3 {
+            // Escape: a unary group number, then a binary position inside it.
+            let mut grnum = 0usize;
+            let mut grpos = 0u32;
+            while grnum != 6 {
+                let p = (m_l1_0[grnum] + m_l1_1[ctx_l1][grnum]) >> 1;
+                if rc.get_freq(MODEL_MAX_FREQ) < p {
+                    rc.decode_0(p);
+                    up0(&mut m_l1_0[grnum], M_L1_SHIFT_0);
+                    up0(&mut m_l1_1[ctx_l1][grnum], M_L1_SHIFT_1);
+                    break;
+                }
+                rc.decode_1(p);
+                up1(&mut m_l1_0[grnum], M_L1_SHIFT_0);
+                up1(&mut m_l1_1[ctx_l1][grnum], M_L1_SHIFT_1);
+                grnum += 1;
+            }
+            ctx_l1 = grnum;
+
+            let mut ctx_l2 = 1usize;
+            for _ in 0..=grnum {
+                let p = m_l2_0[grnum][ctx_l2];
+                if rc.get_freq(MODEL_MAX_FREQ) < p {
+                    rc.decode_0(p);
+                    up0(&mut m_l2_0[grnum][ctx_l2], M_L2_SHIFT);
+                    ctx_l2 <<= 1;
+                    grpos <<= 1;
+                } else {
+                    rc.decode_1(p);
+                    up1(&mut m_l2_0[grnum][ctx_l2], M_L2_SHIFT);
+                    ctx_l2 = (ctx_l2 << 1) | 1;
+                    grpos = (grpos << 1) | 1;
+                }
+            }
+            // The end marker, and the loop's only exit.
+            if grnum == 6 && grpos == 127 {
+                break;
+            }
+            wrank = (GRNUM_TO_GRBEGIN[grnum] + grpos) as usize;
+        }
+
+        wrank = (wrank + 1) & 0xFF;
+        ch = list.pick(wrank) as usize;
+        wrank = wrank.wrapping_sub(1) & 0xFF;
+
+        let clamped = wrank.min(3);
+        ctx_l0 = ((ctx_l0 << 2) | clamped) & 0xFF;
+
+        // Log2 of the run length, unary.
+        let rle0_row = ctx_rle + 16 * clamped;
+        let u1 = ch * (LOG2_MAX_BLOCK + 1);
+        let mut log2_run = 0usize;
+        loop {
+            let p = (m_rle_0[rle0_row][log2_run] + m_rle_1[u1 + log2_run]) >> 1;
+            if rc.get_freq(MODEL_MAX_FREQ) < p {
+                rc.decode_0(p);
+                up0(&mut m_rle_0[rle0_row][log2_run], M_LOG2RLE_SHIFT_0);
+                up0(&mut m_rle_1[u1 + log2_run], M_LOG2RLE_SHIFT_1);
+                break;
+            }
+            rc.decode_1(p);
+            up1(&mut m_rle_0[rle0_row][log2_run], M_LOG2RLE_SHIFT_0);
+            up1(&mut m_rle_1[u1 + log2_run], M_LOG2RLE_SHIFT_1);
+            log2_run += 1;
+            // A run cannot outlast the block, so a valid stream never gets here.
+            if log2_run > LOG2_MAX_BLOCK {
+                return Err(GRZ_UNEXPECTED_EOF);
+            }
+        }
+
+        ctx_rle = if log2_run < 2 {
+            (ctx_rle << 1) & 0xF
+        } else {
+            ((ctx_rle << 1) | 1) & 0xF
+        };
+
+        // The run's remaining bits, most significant first.
+        let mut run: u32 = 0;
+        for i in 0..log2_run {
+            let p = m_rle_2[log2_run][i];
+            if rc.get_freq(MODEL_MAX_FREQ) < p {
+                rc.decode_0(p);
+                up0(&mut m_rle_2[log2_run][i], M_LOG2RLE_SHIFT_2);
+                run <<= 1;
+            } else {
+                rc.decode_1(p);
+                up1(&mut m_rle_2[log2_run][i], M_LOG2RLE_SHIFT_2);
+                run = (run << 1) | 1;
+            }
+        }
+        run += LOG2_RLE_SIZE[log2_run];
+
+        if run as usize > cap - op {
+            return Err(GRZ_UNEXPECTED_EOF);
+        }
+        for _ in 0..run {
+            out[op] = ch as u8;
+            op += 1;
+        }
+    }
+
+    Ok(op)
+}

--- a/rust/darc-codecs/src/grzip/block.rs
+++ b/rust/darc-codecs/src/grzip/block.rs
@@ -25,7 +25,7 @@
 //! Real blocks nest exactly once: the encoder emits `Mode == -2` only from
 //! `GRZip_CompressBlock`'s record-filter path, which then emits plain blocks.
 
-use super::{bwt, lzp, rec, st4, GrzError, GRZ_CRC_ERROR, GRZ_MAX_BLOCK_SIZE, GRZ_UNEXPECTED_EOF};
+use super::{bwt, lzp, mtf_ari, rec, st4, GrzError, GRZ_CRC_ERROR, GRZ_MAX_BLOCK_SIZE, GRZ_UNEXPECTED_EOF};
 
 /// `RESERVED` -- the constant stored in two header words as an integrity check.
 const RESERVED: i32 = 0;
@@ -185,17 +185,18 @@ fn decompress_block_at(input: &[u8], out: &mut [u8], depth: u32) -> Result<usize
 
 /// The entropy stage: MTF-arith or WFC-arith per `GRZ_Compression_MTF`.
 ///
-/// NOT YET PORTED -- `MTF_Ari.c` (620 lines) and `WFC_Ari.c` (759) are the last
-/// and largest pieces of GRZip, both heavily macro-driven with large context
-/// models. Until they land, every block that reaches the main pipeline is
-/// rejected, which is why nothing here is wired to `grzip_decompress` and the C
-/// decoder still runs. The stages after this point are ported and exercised by
-/// their own tests; this is the only hole.
+/// The WFC half (`WFC_Ari.c`, 759 lines) is not ported yet, so a block that
+/// selects it is rejected. That is the last remaining hole, and it is why
+/// nothing here is wired to `grzip_decompress` and the C decoder still runs.
 fn entropy_decode(
-    _body: &[u8],
-    _work: &mut [u8],
-    _out_size: usize,
-    _mode: i32,
+    body: &[u8],
+    work: &mut [u8],
+    out_size: usize,
+    mode: i32,
 ) -> Result<usize, GrzError> {
-    Err(GRZ_CRC_ERROR)
+    if mode & COMPRESSION_MTF != 0 {
+        mtf_ari::decode(body, work, out_size)
+    } else {
+        Err(GRZ_CRC_ERROR)
+    }
 }

--- a/rust/darc-codecs/src/grzip/block.rs
+++ b/rust/darc-codecs/src/grzip/block.rs
@@ -1,0 +1,201 @@
+//! The block dispatcher, ported from `Compression/GRZip/C_GRZip.cpp`
+//! (`GRZip_DecompressBlock` :233).
+//!
+//! Every GRZip block carries a 28-byte header of seven little-endian 32-bit
+//! words. Two of them are fixed constants used as a weak integrity check; the
+//! rest are the decompressed size, the mode, an intermediate size, the inverse
+//! transform's first-byte position, and the compressed length.
+//!
+//! `Mode` selects the pipeline:
+//!
+//! | `Mode` | meaning |
+//! |---|---|
+//! | `-1` | the payload is stored, or LZP-only |
+//! | `-2` | **recursive**: 2 or 4 nested blocks, recombined by `rec::decode` |
+//! | else | arithmetic decode, then inverse BWT or ST4, then optionally LZP |
+//!
+//! ## The recursion needs a bound the C does not have
+//!
+//! A `Mode == -2` block contains whole blocks, each decoded by calling straight
+//! back into this function, and nothing in the C limits how deep that goes --
+//! the nesting comes entirely from attacker-controlled header bytes. In C the
+//! consequence is stack exhaustion; here it would be the same, and a stack
+//! overflow is not something a `Result` can catch. `MAX_DEPTH` bounds it.
+//!
+//! Real blocks nest exactly once: the encoder emits `Mode == -2` only from
+//! `GRZip_CompressBlock`'s record-filter path, which then emits plain blocks.
+
+use super::{bwt, lzp, rec, st4, GrzError, GRZ_CRC_ERROR, GRZ_MAX_BLOCK_SIZE, GRZ_UNEXPECTED_EOF};
+
+/// `RESERVED` -- the constant stored in two header words as an integrity check.
+const RESERVED: i32 = 0;
+
+/// Block header layout, in bytes.
+const HDR: usize = 28;
+
+/// Mode bits (`libGRZip.h:61-77`).
+const COMPRESSION_ST4: i32 = 0x2;
+const COMPRESSION_MTF: i32 = 0x4;
+
+/// How deeply `Mode == -2` may nest. The encoder produces exactly one level;
+/// anything past a handful is a malformed block rather than a deep one.
+const MAX_DEPTH: u32 = 8;
+
+fn word(b: &[u8], at: usize) -> i32 {
+    i32::from_le_bytes([b[at], b[at + 1], b[at + 2], b[at + 3]])
+}
+
+/// `LZP_Enabled` / `Get_LZP_MinMatchLen` / `Get_LZP_HT_Size` (:75-77). Note
+/// these are plain division rather than shifts, and `Mode` is signed -- so a
+/// negative mode would divide toward zero. Only non-negative modes reach here.
+fn lzp_enabled(mode: i32) -> bool {
+    mode / 256 != 0
+}
+fn lzp_min_match_len(mode: i32) -> u32 {
+    (mode / 65536 % 32767) as u32
+}
+fn lzp_ht_size(mode: i32) -> u32 {
+    (1u32 << (mode / 256 % 256)).wrapping_sub(1)
+}
+
+/// `GRZip_DecompressBlock`. Returns the number of bytes written to `out`.
+pub fn decompress_block(input: &[u8], out: &mut [u8]) -> Result<usize, GrzError> {
+    decompress_block_at(input, out, 0)
+}
+
+fn decompress_block_at(input: &[u8], out: &mut [u8], depth: u32) -> Result<usize, GrzError> {
+    if depth > MAX_DEPTH {
+        return Err(GRZ_CRC_ERROR);
+    }
+    if input.len() < HDR {
+        return Err(GRZ_UNEXPECTED_EOF);
+    }
+    if word(input, 24) != RESERVED || word(input, 20) != RESERVED {
+        return Err(GRZ_CRC_ERROR);
+    }
+    let packed = word(input, 16);
+    if packed < 0 || (packed as usize) + HDR > input.len() {
+        return Err(GRZ_UNEXPECTED_EOF);
+    }
+    // Sizes feed allocations and bound the decode; unchecked they produced wild
+    // allocations in the C until an earlier hardening pass.
+    let raw_size = word(input, 0);
+    let mid_size = word(input, 8);
+    if raw_size < 0 || raw_size as usize > GRZ_MAX_BLOCK_SIZE {
+        return Err(GRZ_CRC_ERROR);
+    }
+    if mid_size < 0 || mid_size as usize > GRZ_MAX_BLOCK_SIZE {
+        return Err(GRZ_CRC_ERROR);
+    }
+
+    let mode = word(input, 4);
+    let body = &input[HDR..HDR + packed as usize];
+
+    if mode == -1 {
+        // Stored, or LZP alone.
+        let inner = mid_size;
+        if inner == 0 {
+            let n = packed as usize;
+            if out.len() < n {
+                return Err(GRZ_UNEXPECTED_EOF);
+            }
+            out[..n].copy_from_slice(body);
+            return Ok(n);
+        }
+        let n = raw_size as usize;
+        if out.len() < n {
+            return Err(GRZ_UNEXPECTED_EOF);
+        }
+        return lzp::decode(body, &mut out[..n], lzp_min_match_len(inner), lzp_ht_size(inner));
+    }
+
+    if mode == -2 {
+        // Recursive: `RecMode` decides 2 or 4 sub-blocks laid end to end, each
+        // a complete block with its own header.
+        let rec_mode = mid_size;
+        let size = raw_size as usize;
+        let parts = if rec_mode & 1 == 1 { 2 } else { 4 };
+        let mut buf = vec![0u8; size + 1024];
+        let mut at = 0usize; // offset within `body`
+        let mut written = 0usize;
+        for _ in 0..parts {
+            if at + HDR > body.len() {
+                return Err(GRZ_UNEXPECTED_EOF);
+            }
+            let sub_packed = word(body, at + 16);
+            if sub_packed < 0 {
+                return Err(GRZ_CRC_ERROR);
+            }
+            let sub_len = sub_packed as usize + HDR;
+            if at + sub_len > body.len() {
+                return Err(GRZ_UNEXPECTED_EOF);
+            }
+            if written > buf.len() {
+                return Err(GRZ_CRC_ERROR);
+            }
+            let n = decompress_block_at(&body[at..at + sub_len], &mut buf[written..], depth + 1)?;
+            written += n;
+            at += sub_len;
+        }
+        if out.len() < size {
+            return Err(GRZ_UNEXPECTED_EOF);
+        }
+        rec::decode(&buf, size, &mut out[..size], rec_mode);
+        return Ok(size);
+    }
+
+    // The main pipeline. The compressor rounds the block up to a multiple of 8
+    // before the transform and entropy stages but stores the *unrounded* length,
+    // so the arithmetic decoder legitimately produces up to 7 bytes more.
+    let ari_out_size = ((mid_size as usize) + 7) & !7;
+    let mut work = vec![0u8; ari_out_size + 1024];
+
+    let t_size = entropy_decode(body, &mut work, ari_out_size, mode)?;
+
+    let fbp = word(input, 12);
+    if mode & COMPRESSION_ST4 != 0 {
+        st4::decode(&mut work, t_size, fbp)?;
+    } else {
+        bwt::decode(&mut work, t_size, fbp)?;
+    }
+
+    let n = mid_size as usize;
+    if work.len() < n {
+        return Err(GRZ_UNEXPECTED_EOF);
+    }
+    if lzp_enabled(mode) {
+        let want = raw_size as usize;
+        if out.len() < want {
+            return Err(GRZ_UNEXPECTED_EOF);
+        }
+        lzp::decode(
+            &work[..n],
+            &mut out[..want],
+            lzp_min_match_len(mode),
+            lzp_ht_size(mode),
+        )?;
+    } else {
+        if out.len() < n {
+            return Err(GRZ_UNEXPECTED_EOF);
+        }
+        out[..n].copy_from_slice(&work[..n]);
+    }
+    Ok(raw_size as usize)
+}
+
+/// The entropy stage: MTF-arith or WFC-arith per `GRZ_Compression_MTF`.
+///
+/// NOT YET PORTED -- `MTF_Ari.c` (620 lines) and `WFC_Ari.c` (759) are the last
+/// and largest pieces of GRZip, both heavily macro-driven with large context
+/// models. Until they land, every block that reaches the main pipeline is
+/// rejected, which is why nothing here is wired to `grzip_decompress` and the C
+/// decoder still runs. The stages after this point are ported and exercised by
+/// their own tests; this is the only hole.
+fn entropy_decode(
+    _body: &[u8],
+    _work: &mut [u8],
+    _out_size: usize,
+    _mode: i32,
+) -> Result<usize, GrzError> {
+    Err(GRZ_CRC_ERROR)
+}

--- a/rust/darc-codecs/src/grzip/block.rs
+++ b/rust/darc-codecs/src/grzip/block.rs
@@ -25,7 +25,7 @@
 //! Real blocks nest exactly once: the encoder emits `Mode == -2` only from
 //! `GRZip_CompressBlock`'s record-filter path, which then emits plain blocks.
 
-use super::{bwt, lzp, mtf_ari, rec, st4, GrzError, GRZ_CRC_ERROR, GRZ_MAX_BLOCK_SIZE, GRZ_UNEXPECTED_EOF};
+use super::{bwt, lzp, mtf_ari, rec, st4, wfc_ari, GrzError, GRZ_CRC_ERROR, GRZ_MAX_BLOCK_SIZE, GRZ_UNEXPECTED_EOF};
 
 /// `RESERVED` -- the constant stored in two header words as an integrity check.
 const RESERVED: i32 = 0;
@@ -184,10 +184,6 @@ fn decompress_block_at(input: &[u8], out: &mut [u8], depth: u32) -> Result<usize
 }
 
 /// The entropy stage: MTF-arith or WFC-arith per `GRZ_Compression_MTF`.
-///
-/// The WFC half (`WFC_Ari.c`, 759 lines) is not ported yet, so a block that
-/// selects it is rejected. That is the last remaining hole, and it is why
-/// nothing here is wired to `grzip_decompress` and the C decoder still runs.
 fn entropy_decode(
     body: &[u8],
     work: &mut [u8],
@@ -197,6 +193,6 @@ fn entropy_decode(
     if mode & COMPRESSION_MTF != 0 {
         mtf_ari::decode(body, work, out_size)
     } else {
-        Err(GRZ_CRC_ERROR)
+        wfc_ari::decode(body, work, out_size)
     }
 }

--- a/rust/darc-codecs/src/grzip/bwt.rs
+++ b/rust/darc-codecs/src/grzip/bwt.rs
@@ -1,18 +1,22 @@
 //! Inverse Burrows-Wheeler transform, ported from `Compression/GRZip/BWT.c`
 //! (`GRZip_BWT_Decode` :1052, `GRZip_FastBWT_Decode` :952).
 //!
-//! The encoder picks between two forward transforms and records which by
-//! setting `StrongBWT_Flag` in the stored first-byte position. Both produce the
-//! same permutation of the input, so a single inverse serves both -- the flag
-//! only selects how `FBP` is interpreted, and the C's two `_Decode` functions
-//! differ solely in their bounds. (`GRZip_StrongBWT_Decode` builds a Size+1
-//! entry table and so accepts `FBP == Size`; the fast one indexes a Size-entry
-//! table and does not.)
+//! (`GRZip_StrongBWT_Decode` :403, `GRZip_FastBWT_Decode` :952.)
 //!
-//! The inverse itself is the standard LF-mapping walk, written backwards: pair
-//! every byte with its occurrence index, take the cumulative counts as the
-//! first-column offsets, then follow the chain from `FBP` filling the output
-//! from the end.
+//! The encoder picks between two forward transforms and records which by
+//! setting `StrongBWT_Flag` in the stored first-byte position. **They are
+//! different transforms and each needs its own inverse.** Both walk the same
+//! LF mapping -- pair every byte with its occurrence index, take cumulative
+//! counts as first-column offsets, follow the chain filling the output
+//! backwards -- but the strong variant carries a sentinel row, so its table has
+//! `Size+1` entries with a gap at `FBP`, its prefix sum starts at 1, and its
+//! walk is anchored at 0 rather than at the stored position.
+//!
+//! An earlier version of this file ran one inverse for both, on the assumption
+//! that the flag only reinterpreted `FBP`. Every BWT block decoded to garbage
+//! while every ST4 block passed, which is precisely the signal that located it
+//! -- and it survived a local round-trip test, because that test exercised this
+//! file's own forward transform rather than the C's.
 //!
 //! `FBP` arrives from the block header and was never checked in the C until an
 //! earlier hardening pass; out of range it indexed off the end of the table.
@@ -20,42 +24,46 @@
 
 use super::{GrzError, GRZ_CRC_ERROR};
 
-/// `StrongBWT_Flag` -- set in the stored FBP to select the strong variant.
-const STRONG_BWT_FLAG: i32 = 1 << 30;
+/// `StrongBWT_Flag` (BWT.c:70), set in the stored FBP to select the strong
+/// variant.
+const STRONG_BWT_FLAG: i32 = 0x4000_0000;
 
-/// `GRZip_BWT_Decode`: validate `fbp`, then invert in place.
+/// `GRZip_BWT_Decode` (:1052): the flag picks which inverse runs.
+///
+/// These are **not** the same transform with different bounds, which is what an
+/// earlier version of this file assumed -- it ran one inverse for both and
+/// decoded every BWT block to garbage while the ST4 blocks passed, which is
+/// exactly the signal that found it. The strong variant carries a sentinel:
+/// its table has Size+1 entries with a gap at FBP, its prefix sum starts at 1
+/// rather than 0, and its walk starts from 0 rather than from the stored
+/// position.
 pub fn decode(buf: &mut [u8], size: usize, fbp: i32) -> Result<(), GrzError> {
     if size == 0 || buf.len() < size {
         return Err(GRZ_CRC_ERROR);
     }
-    let real = if (fbp & STRONG_BWT_FLAG) == 0 {
+    if (fbp & STRONG_BWT_FLAG) == 0 {
         // Fast variant: FBP indexes a table of exactly `size` entries.
         if fbp < 0 || fbp as usize >= size {
             return Err(GRZ_CRC_ERROR);
         }
-        fbp as usize
+        invert_fast(buf, size, fbp as usize);
     } else {
-        // Strong variant: FBP only splits fill loops over a size+1 table, so
-        // FBP == size is legitimate there.
         let real = fbp & !STRONG_BWT_FLAG;
-        if real < 0 || real as usize > size {
+        // The C accepts FBP == Size here (the table has Size+1 entries), but
+        // FBP == 0 leaves T[0] unwritten and the walk starts by reading it, so
+        // only 1..=Size is actually decodable.
+        if real < 1 || real as usize > size {
             return Err(GRZ_CRC_ERROR);
         }
-        // A strong FBP equal to `size` cannot start the walk below; the C's
-        // strong decoder handles it structurally rather than by indexing.
-        if real as usize >= size {
-            return Err(GRZ_CRC_ERROR);
-        }
-        real as usize
-    };
-    invert(buf, size, real);
+        invert_strong(buf, size, real as usize);
+    }
     Ok(())
 }
 
-/// The LF-mapping walk. `T[i]` packs the occurrence index of `buf[i]` among
-/// equal bytes into the high bits and the byte itself into the low eight, which
-/// is why a block is capped well below 2^24 bytes.
-fn invert(buf: &mut [u8], size: usize, mut fbp: usize) {
+/// `GRZip_FastBWT_Decode` (:952). The standard LF-mapping walk: pair each byte
+/// with its occurrence index, take cumulative counts as first-column offsets,
+/// then follow the chain from `fbp`, filling the output backwards.
+fn invert_fast(buf: &mut [u8], size: usize, mut fbp: usize) {
     let mut count = [0u32; 256];
     let mut t = vec![0u32; size];
 
@@ -64,7 +72,6 @@ fn invert(buf: &mut [u8], size: usize, mut fbp: usize) {
         t[i] = (count[c] << 8) | c as u32;
         count[c] += 1;
     }
-    // Exclusive prefix sums: the first row offset of each byte value.
     let mut sum: u32 = 0;
     for c in count.iter_mut() {
         sum += *c;
@@ -77,9 +84,44 @@ fn invert(buf: &mut [u8], size: usize, mut fbp: usize) {
         fbp = ((u >> 8) + count[c as usize]) as usize;
         buf[i] = c;
         if fbp >= size {
-            // Only reachable if the permutation is inconsistent, i.e. the block
-            // is corrupt. The remaining output is whatever was decoded so far;
-            // the caller's CRC rejects it. Stopping beats panicking on an index.
+            // Inconsistent permutation, i.e. a corrupt block. The caller's CRC
+            // rejects the partial output; stopping beats panicking on an index.
+            break;
+        }
+    }
+}
+
+/// `GRZip_StrongBWT_Decode` (:403). Same walk, but over a Size+1 table whose
+/// slot `fbp` is deliberately skipped -- the sentinel row -- with the prefix sum
+/// biased by one to account for it, and the walk anchored at 0.
+fn invert_strong(buf: &mut [u8], size: usize, fbp: usize) {
+    let mut count = [0u32; 256];
+    let mut t = vec![0u32; size + 1];
+
+    for i in 0..fbp {
+        let c = buf[i] as usize;
+        t[i] = (count[c] << 8) | c as u32;
+        count[c] += 1;
+    }
+    for i in fbp..size {
+        let c = buf[i] as usize;
+        t[i + 1] = (count[c] << 8) | c as u32;
+        count[c] += 1;
+    }
+    // Sum starts at 1, not 0: the sentinel occupies the first row.
+    let mut sum: u32 = 1;
+    for c in count.iter_mut() {
+        sum += *c;
+        *c = sum - *c;
+    }
+
+    let mut at = 0usize;
+    for i in (0..size).rev() {
+        let u = t[at];
+        let c = (u & 0xFF) as u8;
+        at = ((u >> 8) + count[c as usize]) as usize;
+        buf[i] = c;
+        if at > size {
             break;
         }
     }
@@ -122,7 +164,7 @@ mod tests {
         ] {
             let (mut last, fbp) = forward(case);
             let n = last.len();
-            invert(&mut last, n, fbp);
+            invert_fast(&mut last, n, fbp);
             assert_eq!(&last[..], case, "inverse BWT mismatch for {case:?}");
         }
     }
@@ -133,8 +175,11 @@ mod tests {
         assert!(decode(&mut buf, 4, -1).is_err());
         assert!(decode(&mut buf, 4, 4).is_err());
         assert!(decode(&mut buf, 4, i32::MAX).is_err());
-        // Strong flag with an in-range position is accepted.
+        // Strong flag with an in-range position is accepted; 0 is not, because
+        // it would leave the walk's first table slot unwritten.
         assert!(decode(&mut buf, 4, STRONG_BWT_FLAG | 2).is_ok());
+        assert!(decode(&mut buf, 4, STRONG_BWT_FLAG).is_err());
+        assert!(decode(&mut buf, 4, STRONG_BWT_FLAG | 5).is_err());
     }
 
     #[test]

--- a/rust/darc-codecs/src/grzip/bwt.rs
+++ b/rust/darc-codecs/src/grzip/bwt.rs
@@ -1,0 +1,146 @@
+//! Inverse Burrows-Wheeler transform, ported from `Compression/GRZip/BWT.c`
+//! (`GRZip_BWT_Decode` :1052, `GRZip_FastBWT_Decode` :952).
+//!
+//! The encoder picks between two forward transforms and records which by
+//! setting `StrongBWT_Flag` in the stored first-byte position. Both produce the
+//! same permutation of the input, so a single inverse serves both -- the flag
+//! only selects how `FBP` is interpreted, and the C's two `_Decode` functions
+//! differ solely in their bounds. (`GRZip_StrongBWT_Decode` builds a Size+1
+//! entry table and so accepts `FBP == Size`; the fast one indexes a Size-entry
+//! table and does not.)
+//!
+//! The inverse itself is the standard LF-mapping walk, written backwards: pair
+//! every byte with its occurrence index, take the cumulative counts as the
+//! first-column offsets, then follow the chain from `FBP` filling the output
+//! from the end.
+//!
+//! `FBP` arrives from the block header and was never checked in the C until an
+//! earlier hardening pass; out of range it indexed off the end of the table.
+//! The bounds here are that pass's, not new.
+
+use super::{GrzError, GRZ_CRC_ERROR};
+
+/// `StrongBWT_Flag` -- set in the stored FBP to select the strong variant.
+const STRONG_BWT_FLAG: i32 = 1 << 30;
+
+/// `GRZip_BWT_Decode`: validate `fbp`, then invert in place.
+pub fn decode(buf: &mut [u8], size: usize, fbp: i32) -> Result<(), GrzError> {
+    if size == 0 || buf.len() < size {
+        return Err(GRZ_CRC_ERROR);
+    }
+    let real = if (fbp & STRONG_BWT_FLAG) == 0 {
+        // Fast variant: FBP indexes a table of exactly `size` entries.
+        if fbp < 0 || fbp as usize >= size {
+            return Err(GRZ_CRC_ERROR);
+        }
+        fbp as usize
+    } else {
+        // Strong variant: FBP only splits fill loops over a size+1 table, so
+        // FBP == size is legitimate there.
+        let real = fbp & !STRONG_BWT_FLAG;
+        if real < 0 || real as usize > size {
+            return Err(GRZ_CRC_ERROR);
+        }
+        // A strong FBP equal to `size` cannot start the walk below; the C's
+        // strong decoder handles it structurally rather than by indexing.
+        if real as usize >= size {
+            return Err(GRZ_CRC_ERROR);
+        }
+        real as usize
+    };
+    invert(buf, size, real);
+    Ok(())
+}
+
+/// The LF-mapping walk. `T[i]` packs the occurrence index of `buf[i]` among
+/// equal bytes into the high bits and the byte itself into the low eight, which
+/// is why a block is capped well below 2^24 bytes.
+fn invert(buf: &mut [u8], size: usize, mut fbp: usize) {
+    let mut count = [0u32; 256];
+    let mut t = vec![0u32; size];
+
+    for i in 0..size {
+        let c = buf[i] as usize;
+        t[i] = (count[c] << 8) | c as u32;
+        count[c] += 1;
+    }
+    // Exclusive prefix sums: the first row offset of each byte value.
+    let mut sum: u32 = 0;
+    for c in count.iter_mut() {
+        sum += *c;
+        *c = sum - *c;
+    }
+
+    for i in (0..size).rev() {
+        let u = t[fbp];
+        let c = (u & 0xFF) as u8;
+        fbp = ((u >> 8) + count[c as usize]) as usize;
+        buf[i] = c;
+        if fbp >= size {
+            // Only reachable if the permutation is inconsistent, i.e. the block
+            // is corrupt. The remaining output is whatever was decoded so far;
+            // the caller's CRC rejects it. Stopping beats panicking on an index.
+            break;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A forward BWT is easy to write directly, so the inverse can be pinned
+    /// without the C: build every rotation, sort, take the last column and the
+    /// row index of the original, then invert and require the original back.
+    fn forward(data: &[u8]) -> (Vec<u8>, usize) {
+        let n = data.len();
+        let mut rows: Vec<usize> = (0..n).collect();
+        rows.sort_by(|&a, &b| {
+            for k in 0..n {
+                let x = data[(a + k) % n];
+                let y = data[(b + k) % n];
+                if x != y {
+                    return x.cmp(&y);
+                }
+            }
+            a.cmp(&b)
+        });
+        let last: Vec<u8> = rows.iter().map(|&r| data[(r + n - 1) % n]).collect();
+        let fbp = rows.iter().position(|&r| r == 0).unwrap();
+        (last, fbp)
+    }
+
+    #[test]
+    fn inverse_undoes_a_forward_transform() {
+        for case in [
+            &b"banana"[..],
+            &b"the quick brown fox jumps over the lazy dog"[..],
+            &b"aaaaaaaaaaaaaaaa"[..],
+            &b"ab"[..],
+            &b"a"[..],
+            &b"mississippi river"[..],
+        ] {
+            let (mut last, fbp) = forward(case);
+            let n = last.len();
+            invert(&mut last, n, fbp);
+            assert_eq!(&last[..], case, "inverse BWT mismatch for {case:?}");
+        }
+    }
+
+    #[test]
+    fn out_of_range_fbp_is_rejected() {
+        let mut buf = vec![1u8, 2, 3, 4];
+        assert!(decode(&mut buf, 4, -1).is_err());
+        assert!(decode(&mut buf, 4, 4).is_err());
+        assert!(decode(&mut buf, 4, i32::MAX).is_err());
+        // Strong flag with an in-range position is accepted.
+        assert!(decode(&mut buf, 4, STRONG_BWT_FLAG | 2).is_ok());
+    }
+
+    #[test]
+    fn empty_or_oversized_size_is_rejected() {
+        let mut buf = vec![1u8, 2, 3, 4];
+        assert!(decode(&mut buf, 0, 0).is_err());
+        assert!(decode(&mut buf, 99, 0).is_err());
+    }
+}

--- a/rust/darc-codecs/src/grzip/lzp.rs
+++ b/rust/darc-codecs/src/grzip/lzp.rs
@@ -1,0 +1,128 @@
+//! GRZip's LZP stage, ported from `Compression/GRZip/LZP.c` (`GRZip_LZP_Decode`
+//! :131).
+//!
+//! A context-predicting pre-filter, not a compressor in its own right: an order-4
+//! rolling context hashes to a table of previous output positions, and when the
+//! context repeats, a flag byte plus a run length replaces the matched bytes. It
+//! runs both as the only stage (`Mode == -1`) and as the last stage after the
+//! BWT/arithmetic pipeline.
+//!
+//! Note this is a *different* LZP from `Compression/LZP/`, already ported as
+//! `crate::lzp` -- different flags, different hash, different stream. They share
+//! only the idea.
+//!
+//! Three flag bytes drive it: `0xF2` marks a match, `0xF3` continues a run
+//! length, and the run terminator's contribution is `byte ^ 0xFF^0xF3`. A run
+//! that never terminates and a match length that outruns the output are both
+//! reachable from a corrupt block; the C was fixed to bound each, and the same
+//! bounds are here.
+
+use super::{GrzError, GRZ_UNEXPECTED_EOF};
+
+const MATCH_FLAG: u8 = 0xF2;
+const RUN_FLAG: u8 = 0xF3;
+const XOR_FLAG: u32 = (0xFFu8 ^ RUN_FLAG) as u32;
+
+/// `GRZip_LZP_Decode`. `out_size` is the block's decompressed length, taken
+/// from the block header, and bounds every write.
+pub fn decode(
+    input: &[u8],
+    out: &mut [u8],
+    min_match_len: u32,
+    ht_size: u32,
+) -> Result<usize, GrzError> {
+    // The header copy below touches the first four bytes of each buffer.
+    if input.len() < 4 || out.len() < 4 {
+        return Err(GRZ_UNEXPECTED_EOF);
+    }
+    // `ht_size` is a mask, so the table needs one more entry than its value.
+    // The C sizes this by sizeof(uint8*) -- an earlier revision used a smaller
+    // element and wrote past the end. Here the entries are output offsets:
+    // 0 doubles as "unset" exactly as NULL does there, and no real entry can be
+    // 0 because the first four bytes are copied before the loop starts.
+    let mut contexts = vec![0usize; ht_size as usize + 1];
+
+    out[..4].copy_from_slice(&input[..4]);
+    let mut ctx: u32 = ((input[3] as u32))
+        | ((input[2] as u32) << 8)
+        | ((input[1] as u32) << 16)
+        | ((input[0] as u32) << 24);
+
+    let mut ip = 4usize;
+    let mut op = 4usize;
+
+    while ip < input.len() {
+        let hash = (((ctx >> 15) ^ ctx ^ (ctx >> 3)) & ht_size) as usize;
+        let pointer = contexts[hash];
+        contexts[hash] = op;
+
+        if pointer != 0 {
+            let b = input[ip];
+            ip += 1;
+            if b != MATCH_FLAG {
+                if op >= out.len() {
+                    return Err(GRZ_UNEXPECTED_EOF);
+                }
+                out[op] = b;
+                ctx = (ctx << 8) | b as u32;
+                op += 1;
+            } else {
+                // Run length: each byte contributes `byte ^ XOR_FLAG`, and the
+                // run continues while the byte is RUN_FLAG. Bounded against the
+                // input end -- unbounded, this walked off a truncated block.
+                let mut common: u32 = 0;
+                while ip < input.len() {
+                    let r = input[ip];
+                    common = common.wrapping_add((r as u32) ^ XOR_FLAG);
+                    ip += 1;
+                    if r != RUN_FLAG {
+                        break;
+                    }
+                }
+                if common != 0 {
+                    let len = common as usize + min_match_len as usize - 1;
+                    // The copy source is an earlier output position, so bounding
+                    // the destination bounds the source too.
+                    if len > out.len() - op {
+                        return Err(GRZ_UNEXPECTED_EOF);
+                    }
+                    // Byte at a time and overlapping-safe: `pointer` may be
+                    // close enough behind `op` that the copy reads bytes it has
+                    // just written, which is how a run is expressed.
+                    let mut src = pointer;
+                    for _ in 0..len {
+                        out[op] = out[src];
+                        op += 1;
+                        src += 1;
+                    }
+                    if op < 4 {
+                        return Err(GRZ_UNEXPECTED_EOF);
+                    }
+                    ctx = (out[op - 1] as u32)
+                        | ((out[op - 2] as u32) << 8)
+                        | ((out[op - 3] as u32) << 16)
+                        | ((out[op - 4] as u32) << 24);
+                } else {
+                    // A bare match flag with a zero run is a literal 0xF2.
+                    if op >= out.len() {
+                        return Err(GRZ_UNEXPECTED_EOF);
+                    }
+                    out[op] = MATCH_FLAG;
+                    ctx = (ctx << 8) | MATCH_FLAG as u32;
+                    op += 1;
+                }
+            }
+        } else {
+            if op >= out.len() {
+                return Err(GRZ_UNEXPECTED_EOF);
+            }
+            let b = input[ip];
+            ip += 1;
+            out[op] = b;
+            ctx = (ctx << 8) | b as u32;
+            op += 1;
+        }
+    }
+
+    Ok(op)
+}

--- a/rust/darc-codecs/src/grzip/mod.rs
+++ b/rust/darc-codecs/src/grzip/mod.rs
@@ -35,6 +35,7 @@ pub mod lzp;
 pub mod mtf_ari;
 pub mod rec;
 pub mod st4;
+pub mod stream;
 pub mod wfc_ari;
 
 use core::ffi::c_int;

--- a/rust/darc-codecs/src/grzip/mod.rs
+++ b/rust/darc-codecs/src/grzip/mod.rs
@@ -28,12 +28,14 @@
 
 #![allow(dead_code)] // WIP: stages land before the dispatcher that uses them
 
+pub mod ari;
 pub mod block;
 pub mod bwt;
 pub mod lzp;
 pub mod mtf_ari;
 pub mod rec;
 pub mod st4;
+pub mod wfc_ari;
 
 use core::ffi::c_int;
 

--- a/rust/darc-codecs/src/grzip/mod.rs
+++ b/rust/darc-codecs/src/grzip/mod.rs
@@ -28,9 +28,11 @@
 
 #![allow(dead_code)] // WIP: stages land before the dispatcher that uses them
 
+pub mod block;
 pub mod bwt;
 pub mod lzp;
 pub mod rec;
+pub mod st4;
 
 use core::ffi::c_int;
 

--- a/rust/darc-codecs/src/grzip/mod.rs
+++ b/rust/darc-codecs/src/grzip/mod.rs
@@ -28,6 +28,7 @@
 
 #![allow(dead_code)] // WIP: stages land before the dispatcher that uses them
 
+pub mod bwt;
 pub mod lzp;
 pub mod rec;
 

--- a/rust/darc-codecs/src/grzip/mod.rs
+++ b/rust/darc-codecs/src/grzip/mod.rs
@@ -1,0 +1,101 @@
+//! GRZip decoder, ported from `Compression/GRZip/`.
+//!
+//! **Work in progress.** The LZP and record-de-interleave stages are ported;
+//! the arithmetic decoders, the inverse BWT/ST4 and the block dispatcher are
+//! not, so nothing is wired to `grzip_decompress` yet and the C decoder still
+//! runs. As with every codec before it, the `#ifndef DARC_RUST` exclusion goes
+//! in only once the whole path is verified byte-exact.
+//!
+//! ## Shape
+//!
+//! `GRZip_DecompressBlock` (C_GRZip.cpp:233) reads a 28-byte block header and
+//! dispatches on `Mode` at offset 4:
+//!
+//! | `Mode` | path |
+//! |---|---|
+//! | `-1` | stored `memcpy`, or LZP alone |
+//! | `-2` | **recursive**: 2 or 4 nested blocks, recombined by `GRZip_Rec_Decode` |
+//! | else | MTF-arith or WFC-arith, then inverse BWT or ST4, then LZP |
+//!
+//! The recursive case is the one to be careful with. Nothing in the C bounds
+//! how deeply `Mode == -2` may nest, and the depth comes straight from the
+//! block header, so the port needs an explicit limit that the C does not have.
+//!
+//! Note the header sizes were already hardened C-side in an earlier pass --
+//! bounds against `GRZ_MaxBlockSize`, the `AriOutSize` rounding fix, and an
+//! input length passed to both arithmetic decoders. Read those comments before
+//! concluding a check is missing.
+
+#![allow(dead_code)] // WIP: stages land before the dispatcher that uses them
+
+pub mod lzp;
+pub mod rec;
+
+use core::ffi::c_int;
+
+/// Error codes (`libGRZip.h:46-52`). These are GRZip's own, not FreeArc's; the
+/// dispatcher maps them at the boundary.
+pub type GrzError = c_int;
+pub const GRZ_NOT_ENOUGH_MEMORY: GrzError = -1;
+pub const GRZ_CRC_ERROR: GrzError = -2;
+pub const GRZ_UNEXPECTED_EOF: GrzError = -3;
+pub const GRZ_NOT_COMPRESSIBLE: GrzError = -4;
+
+/// `GRZ_MaxBlockSize` (:54). Every length in a block header is bounded by this,
+/// which is what makes a corrupt header a rejection rather than a wild
+/// allocation.
+pub const GRZ_MAX_BLOCK_SIZE: usize = 8 * 1024 * 1024 - 512;
+
+/// Mode bits (:61-67).
+pub const GRZ_COMPRESSION_ST4: i32 = 0x2;
+pub const GRZ_COMPRESSION_MTF: i32 = 0x4;
+
+/// The block header is 28 bytes: seven little-endian 32-bit words, of which
+/// two are reserved constants used as a weak integrity check.
+pub const BLOCK_HEADER: usize = 28;
+
+#[cfg(test)]
+mod tests {
+    use super::rec;
+
+    /// Modes 1 and 2 are pure de-interleaves, so a round trip through the
+    /// obvious inverse pins the byte order without needing the C.
+    #[test]
+    fn plain_deinterleave_restores_record_order() {
+        // Mode 1: input is [all first bytes][all second bytes].
+        let size = 8;
+        let input = [1u8, 3, 5, 7, 2, 4, 6, 8];
+        let mut out = vec![0u8; size];
+        rec::decode(&input, size, &mut out, 1);
+        assert_eq!(out, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+
+        // Mode 2: four planes.
+        let input = [1u8, 5, 2, 6, 3, 7, 4, 8];
+        let mut out = vec![0u8; size];
+        rec::decode(&input, size, &mut out, 2);
+        assert_eq!(out, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+
+    /// The zigzag uses a bitwise complement, not a negation. An even delta is a
+    /// plain right shift, so a run of zero deltas must reproduce the seed.
+    #[test]
+    fn delta_records_accumulate_from_zero() {
+        // Mode 3, two 16-bit records, both deltas even (no sign bit).
+        // Bytes are [high plane][low plane]: delta_i = (input[i]<<8)|input[i+n].
+        let size = 4;
+        let input = [0u8, 0, 4, 0]; // deltas 0x0004 -> 2, and 0x0000 -> 0
+        let mut out = vec![0u8; size];
+        rec::decode(&input, size, &mut out, 3);
+        // first record 2, second 2+0
+        assert_eq!(u16::from_le_bytes([out[0], out[1]]), 2);
+        assert_eq!(u16::from_le_bytes([out[2], out[3]]), 2);
+    }
+
+    #[test]
+    fn oversized_or_empty_input_is_ignored_not_panicking() {
+        let mut out = vec![0u8; 4];
+        rec::decode(&[], 0, &mut out, 3);
+        rec::decode(&[1, 2], 99, &mut out, 4); // size beyond the buffers
+        rec::decode(&[1, 2, 3, 4], 4, &mut out, 77); // unknown mode
+    }
+}

--- a/rust/darc-codecs/src/grzip/mod.rs
+++ b/rust/darc-codecs/src/grzip/mod.rs
@@ -31,6 +31,7 @@
 pub mod block;
 pub mod bwt;
 pub mod lzp;
+pub mod mtf_ari;
 pub mod rec;
 pub mod st4;
 

--- a/rust/darc-codecs/src/grzip/mtf_ari.rs
+++ b/rust/darc-codecs/src/grzip/mtf_ari.rs
@@ -1,0 +1,348 @@
+//! MTF + arithmetic decoder, ported from `Compression/GRZip/MTF_Ari.c`
+//! (`GRZip_MTF_Ari_Decode` :404).
+//!
+//! This is the entropy stage that follows the BWT or ST4. It decodes a
+//! move-to-front rank, then a run length for that symbol, both through a binary
+//! arithmetic coder driven by a stack of adaptive context models.
+//!
+//! ## How a symbol is spelled
+//!
+//! 1. **Rank 0-3** from a quaternary model that mixes three tables: a global
+//!    one, one keyed on the previous character, and one keyed on the recent
+//!    rank and run-length history.
+//! 2. If the rank is 3, the real rank is **escaped**: a unary group number
+//!    (0-6) then a binary position within that group, which together index
+//!    `GRNUM_TO_GRBEGIN`. Group 6 with position 127 is the **end marker** --
+//!    the only exit from the loop.
+//! 3. The rank drives a **move-to-front list**, giving the character.
+//! 4. A **log2 run length**, again unary, then that many bits of the run's
+//!    remainder, offset by `LOG2_RLE_SIZE`.
+//!
+//! Every model is a frequency in `[0, MODEL_MAX_FREQ]` updated by shifting
+//! toward or away from the maximum -- `x += (MAX-x)>>k` on a zero bit,
+//! `x -= x>>k` on a one. The shift constants differ per model and are what tune
+//! adaptation speed; they must match exactly or the two sides diverge.
+//!
+//! ## Bounds
+//!
+//! The C gained several bounds in an earlier hardening pass, all reproduced
+//! here: an over-read counter so a truncated block stops instead of spinning on
+//! zero bytes, a rank-search limit so a corrupt frequency cannot walk past the
+//! five-entry models, a `Log2RunSize` ceiling, and a run length checked against
+//! the remaining output. The one exit is the end marker, so without them a
+//! corrupt block never terminates.
+
+use super::{GrzError, GRZ_UNEXPECTED_EOF};
+
+const MAX_BYTE: usize = 256;
+const RANGE_TOP: u32 = 1 << 24;
+const MODEL_NUM_BITS: u32 = 11;
+const MODEL_MAX_FREQ: u32 = 1 << MODEL_NUM_BITS;
+
+const M_LOG2RLE_SHIFT_0: u32 = 6;
+const M_LOG2RLE_SHIFT_1: u32 = 3;
+const M_LOG2RLE_SHIFT_2: u32 = 6;
+const M_L1_SHIFT_0: u32 = 4;
+const M_L1_SHIFT_1: u32 = 6;
+const M_L2_SHIFT: u32 = 7;
+
+const MODEL_L0_0_MAX_FREQ: u32 = 58;
+const MODEL_L0_1_MAX_FREQ: u32 = 62;
+const MODEL_L0_2_MAX_FREQ: u32 = 204;
+
+/// `GRZ_Log2MaxBlockSize` (libGRZip.h:55).
+const LOG2_MAX_BLOCK: usize = 23;
+
+/// `WFCMTF_GrNum2GrBegin` (WFC_MTF.h:90).
+const GRNUM_TO_GRBEGIN: [u32; 7] = [3, 5, 9, 17, 33, 65, 129];
+
+/// `WFCMTF_Log2RLESize` (WFC_MTF.h:92) -- the base run length for each log2
+/// bucket.
+const LOG2_RLE_SIZE: [u32; LOG2_MAX_BLOCK + 1] = [
+    1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072,
+    262144, 524288, 1048576, 2097152, 4194304, 8388608,
+];
+
+/// How far past the compressed data the decoder may read before giving up.
+/// The C counts the same and checks it at the top of the symbol loop.
+const MAX_OVERREAD: u32 = 64;
+
+struct Rc<'a> {
+    input: &'a [u8],
+    pos: usize,
+    code: u32,
+    range: u32,
+    overread: u32,
+}
+
+impl<'a> Rc<'a> {
+    /// `ARI_InTgtByte`: past the end, yield zero and count it.
+    #[inline]
+    fn byte(&mut self) -> u32 {
+        if self.pos < self.input.len() {
+            let b = self.input[self.pos] as u32;
+            self.pos += 1;
+            b
+        } else {
+            self.overread += 1;
+            0
+        }
+    }
+
+    fn new(input: &'a [u8]) -> Self {
+        let mut rc = Rc { input, pos: 0, code: 0, range: u32::MAX, overread: 0 };
+        // Five bytes, four of them followed by a shift.
+        for _ in 0..4 {
+            rc.code |= rc.byte();
+            rc.code <<= 8;
+        }
+        rc.code |= rc.byte();
+        rc
+    }
+
+    /// `ARI_GetFreq`: divides `range` in place, then scales the code by it.
+    #[inline]
+    fn get_freq(&mut self, tot: u32) -> u32 {
+        self.range /= tot.max(1);
+        if self.range == 0 {
+            0
+        } else {
+            self.code / self.range
+        }
+    }
+
+    /// `ARI_Decode`. The `TotFreq` argument the C takes is assigned and never
+    /// used -- the division already happened in `get_freq` -- so it is absent.
+    #[inline]
+    fn decode(&mut self, freq: u32, cum: u32) {
+        self.code = self.code.wrapping_sub(cum.wrapping_mul(self.range));
+        self.range = self.range.wrapping_mul(freq);
+        while self.range < RANGE_TOP {
+            let b = self.byte();
+            self.code = (self.code << 8) | b;
+            self.range <<= 8;
+        }
+    }
+
+    #[inline]
+    fn decode_0(&mut self, f: u32) {
+        self.decode(f, 0);
+    }
+
+    #[inline]
+    fn decode_1(&mut self, f: u32) {
+        self.decode(MODEL_MAX_FREQ - f, f);
+    }
+}
+
+#[inline]
+fn up0(v: &mut u32, k: u32) {
+    *v += (MODEL_MAX_FREQ - *v) >> k;
+}
+
+#[inline]
+fn up1(v: &mut u32, k: u32) {
+    *v -= *v >> k;
+}
+
+/// `GRZip_MTF_Ari_Decode`. `out_size` is the capacity of `out`; the return is
+/// how many bytes were written.
+pub fn decode(input: &[u8], out: &mut [u8], out_size: usize) -> Result<usize, GrzError> {
+    let cap = out_size.min(out.len());
+    let mut rc = Rc::new(input);
+
+    let mut mtf: [u32; MAX_BYTE] = core::array::from_fn(|i| i as u32);
+
+    let mut m_l0_0 = [1u32, 1, 1, 1, 4];
+    let mut m_l0_1 = vec![0u32; MAX_BYTE * 5];
+    let mut m_l0_2 = vec![0u32; 4 * MAX_BYTE * 5];
+    let half = MODEL_MAX_FREQ >> 1;
+    let mut m_l1_0 = [half; 8];
+    // The C initialises only rows 0..6 (`for (i=0;i<7;i++)`), leaving row 7 as
+    // uninitialised stack. CtxL1 is a group number in 0..6, so row 7 is never
+    // read; initialising it too is unreachable rather than divergent.
+    let mut m_l1_1 = [[half; 8]; 8];
+    let mut m_l2_0 = [[half; 128]; 8];
+    let mut m_rle_0 = [[half; LOG2_MAX_BLOCK + 1]; 64];
+    let mut m_rle_2 = [[half; LOG2_MAX_BLOCK + 1]; LOG2_MAX_BLOCK + 1];
+    let mut m_rle_1 = vec![half; MAX_BYTE * (LOG2_MAX_BLOCK + 1)];
+
+    let mut ctx_rle: usize = 0;
+    let mut ctx_l0: usize = 0;
+    let mut ctx_l1: usize = 0;
+    let mut ch: usize = 0;
+    let mut op = 0usize;
+
+    loop {
+        // The only exit is the end marker, so a corrupt stream would otherwise
+        // spin forever on zero bytes.
+        if rc.overread > MAX_OVERREAD {
+            return Err(GRZ_UNEXPECTED_EOF);
+        }
+
+        let pred = ch;
+        let v = pred * 5; // Model_L0_1[PredChar]
+        let u = (4 * ctx_l0 + (ctx_rle & 3)) * 5; // Model_L0_2[...]
+
+        let total = m_l0_0[4] + m_l0_2[u + 4] + m_l0_1[v + 4];
+        let frq = rc.get_freq(total);
+        // Bounded at 4: a corrupt frequency could otherwise walk past the
+        // five-entry models. A valid stream always stops by rank 4.
+        let mut cum = 0u32;
+        let mut rank = 0usize;
+        while frq >= cum && rank < 4 {
+            cum += m_l0_0[rank] + m_l0_2[u + rank] + m_l0_1[v + rank];
+            rank += 1;
+        }
+        rank -= 1;
+        cum -= m_l0_0[rank] + m_l0_2[u + rank] + m_l0_1[v + rank];
+
+        rc.decode(m_l0_0[rank] + m_l0_2[u + rank] + m_l0_1[v + rank], cum);
+
+        m_l0_0[rank] += 2;
+        m_l0_2[u + rank] += 2;
+        m_l0_1[v + rank] += 2;
+        m_l0_0[4] += 2;
+        m_l0_2[u + 4] += 2;
+        m_l0_1[v + 4] += 2;
+
+        // Update_Model_L0: halve each model that has outgrown its ceiling. Note
+        // the global one rounds up, the two context ones do not.
+        if m_l0_0[4] > MODEL_L0_0_MAX_FREQ {
+            let mut sum = 0;
+            for i in 0..4 {
+                m_l0_0[i] = (m_l0_0[i] + 1) >> 1;
+                sum += m_l0_0[i];
+            }
+            m_l0_0[4] = sum;
+        }
+        if m_l0_1[v + 4] > MODEL_L0_1_MAX_FREQ {
+            let mut sum = 0;
+            for i in 0..4 {
+                m_l0_1[v + i] >>= 1;
+                sum += m_l0_1[v + i];
+            }
+            m_l0_1[v + 4] = sum;
+        }
+        if m_l0_2[u + 4] > MODEL_L0_2_MAX_FREQ {
+            let mut sum = 0;
+            for i in 0..4 {
+                m_l0_2[u + i] >>= 1;
+                sum += m_l0_2[u + i];
+            }
+            m_l0_2[u + 4] = sum;
+        }
+
+        let mut wrank = rank;
+        if rank == 3 {
+            // Escape: a unary group number, then a binary position inside it.
+            let mut grnum = 0usize;
+            let mut grpos = 0u32;
+            while grnum != 6 {
+                let p = (m_l1_0[grnum] + m_l1_1[ctx_l1][grnum]) >> 1;
+                if rc.get_freq(MODEL_MAX_FREQ) < p {
+                    rc.decode_0(p);
+                    up0(&mut m_l1_0[grnum], M_L1_SHIFT_0);
+                    up0(&mut m_l1_1[ctx_l1][grnum], M_L1_SHIFT_1);
+                    break;
+                }
+                rc.decode_1(p);
+                up1(&mut m_l1_0[grnum], M_L1_SHIFT_0);
+                up1(&mut m_l1_1[ctx_l1][grnum], M_L1_SHIFT_1);
+                grnum += 1;
+            }
+            ctx_l1 = grnum;
+
+            let mut ctx_l2 = 1usize;
+            for _ in 0..=grnum {
+                let p = m_l2_0[grnum][ctx_l2];
+                if rc.get_freq(MODEL_MAX_FREQ) < p {
+                    rc.decode_0(p);
+                    up0(&mut m_l2_0[grnum][ctx_l2], M_L2_SHIFT);
+                    ctx_l2 <<= 1;
+                    grpos <<= 1;
+                } else {
+                    rc.decode_1(p);
+                    up1(&mut m_l2_0[grnum][ctx_l2], M_L2_SHIFT);
+                    ctx_l2 = (ctx_l2 << 1) | 1;
+                    grpos = (grpos << 1) | 1;
+                }
+            }
+            // The end marker, and the loop's only exit.
+            if grnum == 6 && grpos == 127 {
+                break;
+            }
+            wrank = (GRNUM_TO_GRBEGIN[grnum] + grpos) as usize;
+        }
+
+        // Move-to-front.
+        wrank = (wrank + 1) & 0xFF;
+        ch = mtf[wrank] as usize;
+        if wrank != 0 {
+            let mut t = wrank;
+            while t > 0 {
+                mtf[t] = mtf[t - 1];
+                t -= 1;
+            }
+            mtf[0] = ch as u32;
+        }
+        wrank = wrank.wrapping_sub(1) & 0xFF;
+
+        let clamped = wrank.min(3);
+        ctx_l0 = ((ctx_l0 << 2) | clamped) & 0xFF;
+
+        // Log2 of the run length, unary.
+        let rle0_row = ctx_rle + 16 * clamped;
+        let u1 = ch * (LOG2_MAX_BLOCK + 1);
+        let mut log2_run = 0usize;
+        loop {
+            let p = (m_rle_0[rle0_row][log2_run] + m_rle_1[u1 + log2_run]) >> 1;
+            if rc.get_freq(MODEL_MAX_FREQ) < p {
+                rc.decode_0(p);
+                up0(&mut m_rle_0[rle0_row][log2_run], M_LOG2RLE_SHIFT_0);
+                up0(&mut m_rle_1[u1 + log2_run], M_LOG2RLE_SHIFT_1);
+                break;
+            }
+            rc.decode_1(p);
+            up1(&mut m_rle_0[rle0_row][log2_run], M_LOG2RLE_SHIFT_0);
+            up1(&mut m_rle_1[u1 + log2_run], M_LOG2RLE_SHIFT_1);
+            log2_run += 1;
+            // A run cannot outlast the block, so a valid stream never gets here.
+            if log2_run > LOG2_MAX_BLOCK {
+                return Err(GRZ_UNEXPECTED_EOF);
+            }
+        }
+
+        ctx_rle = if log2_run < 2 {
+            (ctx_rle << 1) & 0xF
+        } else {
+            ((ctx_rle << 1) | 1) & 0xF
+        };
+
+        // The run's remaining bits, most significant first.
+        let mut run: u32 = 0;
+        for i in 0..log2_run {
+            let p = m_rle_2[log2_run][i];
+            if rc.get_freq(MODEL_MAX_FREQ) < p {
+                rc.decode_0(p);
+                up0(&mut m_rle_2[log2_run][i], M_LOG2RLE_SHIFT_2);
+                run <<= 1;
+            } else {
+                rc.decode_1(p);
+                up1(&mut m_rle_2[log2_run][i], M_LOG2RLE_SHIFT_2);
+                run = (run << 1) | 1;
+            }
+        }
+        run += LOG2_RLE_SIZE[log2_run];
+
+        if run as usize > cap - op {
+            return Err(GRZ_UNEXPECTED_EOF);
+        }
+        for _ in 0..run {
+            out[op] = ch as u8;
+            op += 1;
+        }
+    }
+
+    Ok(op)
+}

--- a/rust/darc-codecs/src/grzip/mtf_ari.rs
+++ b/rust/darc-codecs/src/grzip/mtf_ari.rs
@@ -1,348 +1,38 @@
-//! MTF + arithmetic decoder, ported from `Compression/GRZip/MTF_Ari.c`
+//! Move-to-front symbol list, the MTF half of `Compression/GRZip/MTF_Ari.c`
 //! (`GRZip_MTF_Ari_Decode` :404).
 //!
-//! This is the entropy stage that follows the BWT or ST4. It decodes a
-//! move-to-front rank, then a run length for that symbol, both through a binary
-//! arithmetic coder driven by a stack of adaptive context models.
-//!
-//! ## How a symbol is spelled
-//!
-//! 1. **Rank 0-3** from a quaternary model that mixes three tables: a global
-//!    one, one keyed on the previous character, and one keyed on the recent
-//!    rank and run-length history.
-//! 2. If the rank is 3, the real rank is **escaped**: a unary group number
-//!    (0-6) then a binary position within that group, which together index
-//!    `GRNUM_TO_GRBEGIN`. Group 6 with position 127 is the **end marker** --
-//!    the only exit from the loop.
-//! 3. The rank drives a **move-to-front list**, giving the character.
-//! 4. A **log2 run length**, again unary, then that many bits of the run's
-//!    remainder, offset by `LOG2_RLE_SIZE`.
-//!
-//! Every model is a frequency in `[0, MODEL_MAX_FREQ]` updated by shifting
-//! toward or away from the maximum -- `x += (MAX-x)>>k` on a zero bit,
-//! `x -= x>>k` on a one. The shift constants differ per model and are what tune
-//! adaptation speed; they must match exactly or the two sides diverge.
-//!
-//! ## Bounds
-//!
-//! The C gained several bounds in an earlier hardening pass, all reproduced
-//! here: an over-read counter so a truncated block stops instead of spinning on
-//! zero bytes, a rank-search limit so a corrupt frequency cannot walk past the
-//! five-entry models, a `Log2RunSize` ceiling, and a run length checked against
-//! the remaining output. The one exit is the end marker, so without them a
-//! corrupt block never terminates.
+//! Everything except the rank-to-character step lives in [`super::ari`], which
+//! the WFC coder shares; this is just the list discipline.
 
-use super::{GrzError, GRZ_UNEXPECTED_EOF};
+use super::ari::{self, SymbolList, MAX_BYTE};
+use super::GrzError;
 
-const MAX_BYTE: usize = 256;
-const RANGE_TOP: u32 = 1 << 24;
-const MODEL_NUM_BITS: u32 = 11;
-const MODEL_MAX_FREQ: u32 = 1 << MODEL_NUM_BITS;
-
-const M_LOG2RLE_SHIFT_0: u32 = 6;
-const M_LOG2RLE_SHIFT_1: u32 = 3;
-const M_LOG2RLE_SHIFT_2: u32 = 6;
-const M_L1_SHIFT_0: u32 = 4;
-const M_L1_SHIFT_1: u32 = 6;
-const M_L2_SHIFT: u32 = 7;
-
-const MODEL_L0_0_MAX_FREQ: u32 = 58;
-const MODEL_L0_1_MAX_FREQ: u32 = 62;
-const MODEL_L0_2_MAX_FREQ: u32 = 204;
-
-/// `GRZ_Log2MaxBlockSize` (libGRZip.h:55).
-const LOG2_MAX_BLOCK: usize = 23;
-
-/// `WFCMTF_GrNum2GrBegin` (WFC_MTF.h:90).
-const GRNUM_TO_GRBEGIN: [u32; 7] = [3, 5, 9, 17, 33, 65, 129];
-
-/// `WFCMTF_Log2RLESize` (WFC_MTF.h:92) -- the base run length for each log2
-/// bucket.
-const LOG2_RLE_SIZE: [u32; LOG2_MAX_BLOCK + 1] = [
-    1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072,
-    262144, 524288, 1048576, 2097152, 4194304, 8388608,
-];
-
-/// How far past the compressed data the decoder may read before giving up.
-/// The C counts the same and checks it at the top of the symbol loop.
-const MAX_OVERREAD: u32 = 64;
-
-struct Rc<'a> {
-    input: &'a [u8],
-    pos: usize,
-    code: u32,
-    range: u32,
-    overread: u32,
+struct Mtf {
+    list: [u32; MAX_BYTE],
 }
 
-impl<'a> Rc<'a> {
-    /// `ARI_InTgtByte`: past the end, yield zero and count it.
-    #[inline]
-    fn byte(&mut self) -> u32 {
-        if self.pos < self.input.len() {
-            let b = self.input[self.pos] as u32;
-            self.pos += 1;
-            b
-        } else {
-            self.overread += 1;
-            0
-        }
-    }
-
-    fn new(input: &'a [u8]) -> Self {
-        let mut rc = Rc { input, pos: 0, code: 0, range: u32::MAX, overread: 0 };
-        // Five bytes, four of them followed by a shift.
-        for _ in 0..4 {
-            rc.code |= rc.byte();
-            rc.code <<= 8;
-        }
-        rc.code |= rc.byte();
-        rc
-    }
-
-    /// `ARI_GetFreq`: divides `range` in place, then scales the code by it.
-    #[inline]
-    fn get_freq(&mut self, tot: u32) -> u32 {
-        self.range /= tot.max(1);
-        if self.range == 0 {
-            0
-        } else {
-            self.code / self.range
-        }
-    }
-
-    /// `ARI_Decode`. The `TotFreq` argument the C takes is assigned and never
-    /// used -- the division already happened in `get_freq` -- so it is absent.
-    #[inline]
-    fn decode(&mut self, freq: u32, cum: u32) {
-        self.code = self.code.wrapping_sub(cum.wrapping_mul(self.range));
-        self.range = self.range.wrapping_mul(freq);
-        while self.range < RANGE_TOP {
-            let b = self.byte();
-            self.code = (self.code << 8) | b;
-            self.range <<= 8;
-        }
-    }
-
-    #[inline]
-    fn decode_0(&mut self, f: u32) {
-        self.decode(f, 0);
-    }
-
-    #[inline]
-    fn decode_1(&mut self, f: u32) {
-        self.decode(MODEL_MAX_FREQ - f, f);
-    }
-}
-
-#[inline]
-fn up0(v: &mut u32, k: u32) {
-    *v += (MODEL_MAX_FREQ - *v) >> k;
-}
-
-#[inline]
-fn up1(v: &mut u32, k: u32) {
-    *v -= *v >> k;
-}
-
-/// `GRZip_MTF_Ari_Decode`. `out_size` is the capacity of `out`; the return is
-/// how many bytes were written.
-pub fn decode(input: &[u8], out: &mut [u8], out_size: usize) -> Result<usize, GrzError> {
-    let cap = out_size.min(out.len());
-    let mut rc = Rc::new(input);
-
-    let mut mtf: [u32; MAX_BYTE] = core::array::from_fn(|i| i as u32);
-
-    let mut m_l0_0 = [1u32, 1, 1, 1, 4];
-    let mut m_l0_1 = vec![0u32; MAX_BYTE * 5];
-    let mut m_l0_2 = vec![0u32; 4 * MAX_BYTE * 5];
-    let half = MODEL_MAX_FREQ >> 1;
-    let mut m_l1_0 = [half; 8];
-    // The C initialises only rows 0..6 (`for (i=0;i<7;i++)`), leaving row 7 as
-    // uninitialised stack. CtxL1 is a group number in 0..6, so row 7 is never
-    // read; initialising it too is unreachable rather than divergent.
-    let mut m_l1_1 = [[half; 8]; 8];
-    let mut m_l2_0 = [[half; 128]; 8];
-    let mut m_rle_0 = [[half; LOG2_MAX_BLOCK + 1]; 64];
-    let mut m_rle_2 = [[half; LOG2_MAX_BLOCK + 1]; LOG2_MAX_BLOCK + 1];
-    let mut m_rle_1 = vec![half; MAX_BYTE * (LOG2_MAX_BLOCK + 1)];
-
-    let mut ctx_rle: usize = 0;
-    let mut ctx_l0: usize = 0;
-    let mut ctx_l1: usize = 0;
-    let mut ch: usize = 0;
-    let mut op = 0usize;
-
-    loop {
-        // The only exit is the end marker, so a corrupt stream would otherwise
-        // spin forever on zero bytes.
-        if rc.overread > MAX_OVERREAD {
-            return Err(GRZ_UNEXPECTED_EOF);
-        }
-
-        let pred = ch;
-        let v = pred * 5; // Model_L0_1[PredChar]
-        let u = (4 * ctx_l0 + (ctx_rle & 3)) * 5; // Model_L0_2[...]
-
-        let total = m_l0_0[4] + m_l0_2[u + 4] + m_l0_1[v + 4];
-        let frq = rc.get_freq(total);
-        // Bounded at 4: a corrupt frequency could otherwise walk past the
-        // five-entry models. A valid stream always stops by rank 4.
-        let mut cum = 0u32;
-        let mut rank = 0usize;
-        while frq >= cum && rank < 4 {
-            cum += m_l0_0[rank] + m_l0_2[u + rank] + m_l0_1[v + rank];
-            rank += 1;
-        }
-        rank -= 1;
-        cum -= m_l0_0[rank] + m_l0_2[u + rank] + m_l0_1[v + rank];
-
-        rc.decode(m_l0_0[rank] + m_l0_2[u + rank] + m_l0_1[v + rank], cum);
-
-        m_l0_0[rank] += 2;
-        m_l0_2[u + rank] += 2;
-        m_l0_1[v + rank] += 2;
-        m_l0_0[4] += 2;
-        m_l0_2[u + 4] += 2;
-        m_l0_1[v + 4] += 2;
-
-        // Update_Model_L0: halve each model that has outgrown its ceiling. Note
-        // the global one rounds up, the two context ones do not.
-        if m_l0_0[4] > MODEL_L0_0_MAX_FREQ {
-            let mut sum = 0;
-            for i in 0..4 {
-                m_l0_0[i] = (m_l0_0[i] + 1) >> 1;
-                sum += m_l0_0[i];
-            }
-            m_l0_0[4] = sum;
-        }
-        if m_l0_1[v + 4] > MODEL_L0_1_MAX_FREQ {
-            let mut sum = 0;
-            for i in 0..4 {
-                m_l0_1[v + i] >>= 1;
-                sum += m_l0_1[v + i];
-            }
-            m_l0_1[v + 4] = sum;
-        }
-        if m_l0_2[u + 4] > MODEL_L0_2_MAX_FREQ {
-            let mut sum = 0;
-            for i in 0..4 {
-                m_l0_2[u + i] >>= 1;
-                sum += m_l0_2[u + i];
-            }
-            m_l0_2[u + 4] = sum;
-        }
-
-        let mut wrank = rank;
-        if rank == 3 {
-            // Escape: a unary group number, then a binary position inside it.
-            let mut grnum = 0usize;
-            let mut grpos = 0u32;
-            while grnum != 6 {
-                let p = (m_l1_0[grnum] + m_l1_1[ctx_l1][grnum]) >> 1;
-                if rc.get_freq(MODEL_MAX_FREQ) < p {
-                    rc.decode_0(p);
-                    up0(&mut m_l1_0[grnum], M_L1_SHIFT_0);
-                    up0(&mut m_l1_1[ctx_l1][grnum], M_L1_SHIFT_1);
-                    break;
-                }
-                rc.decode_1(p);
-                up1(&mut m_l1_0[grnum], M_L1_SHIFT_0);
-                up1(&mut m_l1_1[ctx_l1][grnum], M_L1_SHIFT_1);
-                grnum += 1;
-            }
-            ctx_l1 = grnum;
-
-            let mut ctx_l2 = 1usize;
-            for _ in 0..=grnum {
-                let p = m_l2_0[grnum][ctx_l2];
-                if rc.get_freq(MODEL_MAX_FREQ) < p {
-                    rc.decode_0(p);
-                    up0(&mut m_l2_0[grnum][ctx_l2], M_L2_SHIFT);
-                    ctx_l2 <<= 1;
-                    grpos <<= 1;
-                } else {
-                    rc.decode_1(p);
-                    up1(&mut m_l2_0[grnum][ctx_l2], M_L2_SHIFT);
-                    ctx_l2 = (ctx_l2 << 1) | 1;
-                    grpos = (grpos << 1) | 1;
-                }
-            }
-            // The end marker, and the loop's only exit.
-            if grnum == 6 && grpos == 127 {
-                break;
-            }
-            wrank = (GRNUM_TO_GRBEGIN[grnum] + grpos) as usize;
-        }
-
-        // Move-to-front.
-        wrank = (wrank + 1) & 0xFF;
-        ch = mtf[wrank] as usize;
-        if wrank != 0 {
-            let mut t = wrank;
+impl SymbolList for Mtf {
+    /// The classic move-to-front: take the character at `rank`, slide
+    /// everything above it down one, and put it at the head.
+    fn pick(&mut self, rank: usize) -> u8 {
+        let ch = self.list[rank];
+        if rank != 0 {
+            let mut t = rank;
             while t > 0 {
-                mtf[t] = mtf[t - 1];
+                self.list[t] = self.list[t - 1];
                 t -= 1;
             }
-            mtf[0] = ch as u32;
+            self.list[0] = ch;
         }
-        wrank = wrank.wrapping_sub(1) & 0xFF;
-
-        let clamped = wrank.min(3);
-        ctx_l0 = ((ctx_l0 << 2) | clamped) & 0xFF;
-
-        // Log2 of the run length, unary.
-        let rle0_row = ctx_rle + 16 * clamped;
-        let u1 = ch * (LOG2_MAX_BLOCK + 1);
-        let mut log2_run = 0usize;
-        loop {
-            let p = (m_rle_0[rle0_row][log2_run] + m_rle_1[u1 + log2_run]) >> 1;
-            if rc.get_freq(MODEL_MAX_FREQ) < p {
-                rc.decode_0(p);
-                up0(&mut m_rle_0[rle0_row][log2_run], M_LOG2RLE_SHIFT_0);
-                up0(&mut m_rle_1[u1 + log2_run], M_LOG2RLE_SHIFT_1);
-                break;
-            }
-            rc.decode_1(p);
-            up1(&mut m_rle_0[rle0_row][log2_run], M_LOG2RLE_SHIFT_0);
-            up1(&mut m_rle_1[u1 + log2_run], M_LOG2RLE_SHIFT_1);
-            log2_run += 1;
-            // A run cannot outlast the block, so a valid stream never gets here.
-            if log2_run > LOG2_MAX_BLOCK {
-                return Err(GRZ_UNEXPECTED_EOF);
-            }
-        }
-
-        ctx_rle = if log2_run < 2 {
-            (ctx_rle << 1) & 0xF
-        } else {
-            ((ctx_rle << 1) | 1) & 0xF
-        };
-
-        // The run's remaining bits, most significant first.
-        let mut run: u32 = 0;
-        for i in 0..log2_run {
-            let p = m_rle_2[log2_run][i];
-            if rc.get_freq(MODEL_MAX_FREQ) < p {
-                rc.decode_0(p);
-                up0(&mut m_rle_2[log2_run][i], M_LOG2RLE_SHIFT_2);
-                run <<= 1;
-            } else {
-                rc.decode_1(p);
-                up1(&mut m_rle_2[log2_run][i], M_LOG2RLE_SHIFT_2);
-                run = (run << 1) | 1;
-            }
-        }
-        run += LOG2_RLE_SIZE[log2_run];
-
-        if run as usize > cap - op {
-            return Err(GRZ_UNEXPECTED_EOF);
-        }
-        for _ in 0..run {
-            out[op] = ch as u8;
-            op += 1;
-        }
+        ch as u8
     }
+}
 
-    Ok(op)
+/// `GRZip_MTF_Ari_Decode`. Note the C's parameter order here is
+/// `(Input, Size = compressed length, Output, OutSize = capacity)` -- the WFC
+/// sibling swaps the meanings of its second and fourth arguments, which is a
+/// trap worth stating out loud rather than discovering at the call site.
+pub fn decode(input: &[u8], out: &mut [u8], out_size: usize) -> Result<usize, GrzError> {
+    let mut list = Mtf { list: core::array::from_fn(|i| i as u32) };
+    ari::decode(input, out, out_size, &mut list)
 }

--- a/rust/darc-codecs/src/grzip/rec.rs
+++ b/rust/darc-codecs/src/grzip/rec.rs
@@ -1,0 +1,98 @@
+//! Record-structure de-interleaving, ported from
+//! `Compression/GRZip/Rec_Flt.c` (`GRZip_Rec_Decode` :208).
+//!
+//! Reached only from the recursive `Mode == -2` block, which splits its input
+//! into 2 or 4 sub-blocks, decodes each independently, and then recombines them
+//! here. Four modes:
+//!
+//! * **1 / 2** -- plain byte de-interleave for 2- and 4-byte records: the input
+//!   holds all the first bytes, then all the second bytes, and so on.
+//! * **3 / 4** -- the same, but the records are 16- or 32-bit values that were
+//!   *delta-coded* with a zigzag sign map, so each is a difference from its
+//!   predecessor rather than a literal.
+//!
+//! The zigzag is `Delta&1 ? !(Delta>>1) : Delta>>1` -- note the C uses `~`, a
+//! bitwise complement, not a negation. On unsigned values those agree only
+//! because the sum is taken modulo the word size, so this reproduces the
+//! complement exactly rather than "fixing" it to `-(x+1)`.
+//!
+//! Every mode reads exactly `Size` bytes and writes exactly `Size`, so the
+//! caller's buffers bound everything; the slicing here is checked regardless.
+
+/// `GRZip_Rec_Decode`. `size` is both the input and output length.
+pub fn decode(input: &[u8], size: usize, out: &mut [u8], mode: i32) {
+    if size == 0 || input.len() < size || out.len() < size {
+        return;
+    }
+    match mode {
+        3 => {
+            // 16-bit delta records. The low byte of each comes from the first
+            // half of the input, the high byte from `NumRecords` bytes later.
+            let n = size >> 1;
+            let mut pred: u16 = 0;
+            for i in 0..n {
+                let mut delta = input[i] as u16;
+                delta = (delta << 8) | input[i + n] as u16;
+                delta = if delta & 1 != 0 { !(delta >> 1) } else { delta >> 1 };
+                let code = delta.wrapping_add(pred);
+                pred = code;
+                out[i * 2..i * 2 + 2].copy_from_slice(&code.to_le_bytes());
+            }
+            // Trailing bytes that did not fill a whole record.
+            let mut i = 2 * n;
+            let mut p = n;
+            while i < size {
+                out[i] = input[p + n];
+                i += 1;
+                p += 1;
+            }
+        }
+        4 => {
+            // 32-bit delta records, assembled most-significant byte first from
+            // four equally spaced planes.
+            let n = size >> 2;
+            let (p1, p2, p3) = (n, 2 * n, 3 * n);
+            let mut pred: u32 = 0;
+            for i in 0..n {
+                let mut delta = input[i] as u32;
+                delta = (delta << 8) | input[i + p3] as u32;
+                delta = (delta << 8) | input[i + p2] as u32;
+                delta = (delta << 8) | input[i + p1] as u32;
+                delta = if delta & 1 != 0 { !(delta >> 1) } else { delta >> 1 };
+                let code = delta.wrapping_add(pred);
+                pred = code;
+                out[i * 4..i * 4 + 4].copy_from_slice(&code.to_le_bytes());
+            }
+            let mut i = 4 * n;
+            let mut p = n;
+            while i < size {
+                out[i] = input[p + p3];
+                i += 1;
+                p += 1;
+            }
+        }
+        1 => {
+            let mut p = 0;
+            for step in 0..2 {
+                let mut i = step;
+                while i < size {
+                    out[i] = input[p];
+                    p += 1;
+                    i += 2;
+                }
+            }
+        }
+        2 => {
+            let mut p = 0;
+            for step in 0..4 {
+                let mut i = step;
+                while i < size {
+                    out[i] = input[p];
+                    p += 1;
+                    i += 4;
+                }
+            }
+        }
+        _ => {}
+    }
+}

--- a/rust/darc-codecs/src/grzip/st4.rs
+++ b/rust/darc-codecs/src/grzip/st4.rs
@@ -1,0 +1,145 @@
+//! Inverse sort-transform of order 4, ported from `Compression/GRZip/ST4.c`
+//! (`GRZip_ST4_Decode` :99).
+//!
+//! ST4 is the BWT's cheaper cousin: instead of sorting full rotations it sorts
+//! only by the next four bytes, which is far faster to compute and almost as
+//! good for the entropy stage. The encoder picks it over the BWT via
+//! `GRZ_Compression_ST4` in the block mode.
+//!
+//! Inverting it is not the BWT's single LF-mapping walk. Because the sort key
+//! is bounded, several rows can tie, and the reconstruction needs a second
+//! level of indirection to break those ties in the order the encoder saw them.
+//! That is what the `ST_INDIRECT` bit in the table marks, and why the final
+//! loop has two branches rather than one.
+//!
+//! The table packs three things into each 32-bit word: the byte in the top 8
+//! bits, `ST_INDIRECT` (bit 23) as the indirection flag, and a position in the
+//! low 23 bits. A block is capped at just under 8 MB, which is what keeps
+//! positions inside those 23 bits.
+
+use super::{GrzError, GRZ_CRC_ERROR};
+
+const MAX_BYTE: usize = 256;
+const MAX_WORD: usize = 65536;
+/// `ST_INDIRECT` (:43) -- bit 23, both a flag and the mask for the position.
+const INDIRECT: u32 = 0x800000;
+
+/// `GRZip_ST4_Decode`, in place. `fbp` is the first-byte position from the
+/// block header; the C left it unchecked until an earlier hardening pass, where
+/// out of range it indexed off the end of `Table`.
+pub fn decode(buf: &mut [u8], size: usize, fbp: i32) -> Result<(), GrzError> {
+    if size == 0 || buf.len() < size {
+        return Err(GRZ_CRC_ERROR);
+    }
+    // Table holds size+1 entries, so fbp == size is legitimate.
+    if fbp < 0 || fbp as usize > size {
+        return Err(GRZ_CRC_ERROR);
+    }
+    // Positions must fit the low 23 bits alongside the flag.
+    if size >= INDIRECT as usize {
+        return Err(GRZ_CRC_ERROR);
+    }
+    let fbp = fbp as usize;
+
+    let mut t = [0i32; MAX_BYTE];
+    let mut context2 = vec![0i32; MAX_WORD];
+    // One bit per position, marking where a new order-2 context begins.
+    let mut flag = vec![0u8; (size + 8) >> 3];
+    let mut table = vec![0u32; size + 1];
+
+    // First-column counts, then their exclusive prefix sums.
+    for i in 0..size {
+        t[buf[i] as usize] += 1;
+    }
+    {
+        let mut sum = 0i32;
+        let mut j = 0usize;
+        for i in 0..MAX_BYTE {
+            sum += t[i];
+            t[i] = sum - t[i];
+            while (j as i32) < sum {
+                context2[((buf[j] as usize) << 8) | i] += 1;
+                j += 1;
+            }
+        }
+    }
+    let s_init = t;
+
+    // Walk the order-2 contexts, marking the first row of each run per byte.
+    let mut last_seen = [-1i64; MAX_BYTE];
+    {
+        let mut sum = 0i32;
+        let mut j = 0usize;
+        // LastSeen starts at -1 (the C memsets 0xFF) so no context matches
+        // initially.
+        for i in 0..MAX_WORD {
+            let cstart = sum;
+            sum += context2[i];
+            while (j as i32) < sum {
+                let c = buf[j] as usize;
+                if last_seen[c] != cstart as i64 {
+                    last_seen[c] = cstart as i64;
+                    let bit = t[c] as usize;
+                    flag[bit >> 3] |= 1 << (bit & 7);
+                }
+                t[c] += 1;
+                j += 1;
+            }
+        }
+    }
+
+    // Build the reconstruction table. An entry is either a direct first-column
+    // position, or ST_INDIRECT plus the previous occurrence of the same byte --
+    // the tie-break the bounded sort key makes necessary.
+    let mut s = s_init;
+    last_seen = [0i64; MAX_BYTE];  // secure_memzero before the table build
+    {
+        let mut cstart: i64 = 0;
+        for i in 0..size {
+            let c = buf[i] as usize;
+            if flag[i >> 3] & (1 << (i & 7)) != 0 {
+                cstart = i as i64;
+            }
+            if last_seen[c] <= cstart {
+                table[i] = s[c] as u32;
+                last_seen[c] = i as i64 + 1;
+            } else {
+                table[i] = ((last_seen[c] - 1) as u32) | INDIRECT;
+            }
+            s[c] += 1;
+            table[i] |= (c as u32) << 24;
+        }
+    }
+    table[size] = INDIRECT;
+
+    // Follow the chain. Both branches advance a counter stored in the table
+    // itself, which is how repeated contexts stay in encoder order.
+    let mut j = fbp;
+    let mut sum = table[fbp];
+    for i in 0..size {
+        if sum & INDIRECT != 0 {
+            let at = (sum & (INDIRECT - 1)) as usize;
+            if at >= table.len() {
+                return Err(GRZ_CRC_ERROR);
+            }
+            j = (table[at] & (INDIRECT - 1)) as usize;
+            table[at] = table[at].wrapping_add(1);
+            if j >= table.len() {
+                return Err(GRZ_CRC_ERROR);
+            }
+            sum = table[j];
+        } else {
+            if j >= table.len() {
+                return Err(GRZ_CRC_ERROR);
+            }
+            table[j] = table[j].wrapping_add(1);
+            j = (sum & (INDIRECT - 1)) as usize;
+            if j >= table.len() {
+                return Err(GRZ_CRC_ERROR);
+            }
+            sum = table[j];
+        }
+        buf[i] = (sum >> 24) as u8;
+    }
+    Ok(())
+}

--- a/rust/darc-codecs/src/grzip/stream.rs
+++ b/rust/darc-codecs/src/grzip/stream.rs
@@ -1,0 +1,110 @@
+//! The stream wrapper, ported from `Compression/GRZip/C_GRZip.cpp`
+//! (`grzip_decompress` :601, `GRZipMTDecompressor::main_cycle` :576).
+//!
+//! A GRZip stream is a bare sequence of blocks, each a 28-byte header followed
+//! by its compressed body. There is no stream header and no terminator: the
+//! read callback returning zero where a header would start *is* the end.
+//!
+//! The C decodes blocks on a worker pool and reassembles them in order. That is
+//! a throughput choice, not a format one -- the bytes written are the same
+//! blocks in the same order -- so this is a serial loop. Multithreading can be
+//! added later without touching the format.
+//!
+//! Sizes come from `MTCompressor`'s allocation of `*(sint32*)(BlockSign+16) +
+//! 1024` for the body and `*(sint32*)InBuf + 1024` for the output, so those two
+//! header words are what bound each block here too.
+
+use super::block::decompress_block;
+use super::{GRZ_MAX_BLOCK_SIZE, GRZ_NOT_ENOUGH_MEMORY};
+use crate::ffi::{Io, FREEARC_ERRCODE_BAD_COMPRESSED_DATA, OK};
+use core::ffi::c_int;
+
+const BAD: c_int = FREEARC_ERRCODE_BAD_COMPRESSED_DATA as c_int;
+const HDR: usize = 28;
+
+fn word(b: &[u8], at: usize) -> i32 {
+    i32::from_le_bytes([b[at], b[at + 1], b[at + 2], b[at + 3]])
+}
+
+/// `grzip_decompress`.
+pub fn decompress(io: &Io) -> c_int {
+    match run(io) {
+        Ok(()) => OK,
+        Err(e) => e,
+    }
+}
+
+fn run(io: &Io) -> Result<(), c_int> {
+    let mut sign = [0u8; HDR];
+    loop {
+        // A short read here is the end of the stream, not an error -- but only
+        // if it is *empty*. Anything between 1 and 27 bytes is a truncated
+        // header, which the C distinguishes the same way.
+        let n = io.read(&mut sign);
+        if n < 0 {
+            return Err(n);
+        }
+        if n == 0 {
+            return Ok(());
+        }
+        if n as usize != HDR {
+            return Err(BAD);
+        }
+        // `GRZip_CheckBlockSign` checks only this one reserved word; the rest of
+        // the header is validated by the block decoder.
+        if word(&sign, 24) != 0 {
+            return Err(BAD);
+        }
+
+        let packed = word(&sign, 16);
+        let raw = word(&sign, 0);
+        if packed < 0
+            || raw < 0
+            || packed as usize > GRZ_MAX_BLOCK_SIZE
+            || raw as usize > GRZ_MAX_BLOCK_SIZE
+        {
+            return Err(BAD);
+        }
+
+        // Header plus body, exactly as the C assembles it before decoding: the
+        // block decoder expects the 28-byte header in front of its input.
+        let mut inbuf = Vec::new();
+        if inbuf.try_reserve(HDR + packed as usize + 1024).is_err() {
+            return Err(GRZ_NOT_ENOUGH_MEMORY);
+        }
+        inbuf.extend_from_slice(&sign);
+        inbuf.resize(HDR + packed as usize, 0);
+        if packed > 0 {
+            let got = io.read(&mut inbuf[HDR..]);
+            if got < 0 {
+                return Err(got);
+            }
+            if got != packed {
+                return Err(BAD);
+            }
+        }
+
+        let mut out = Vec::new();
+        if out.try_reserve(raw as usize + 1024).is_err() {
+            return Err(GRZ_NOT_ENOUGH_MEMORY);
+        }
+        out.resize(raw as usize + 1024, 0);
+
+        let written = decompress_block(&inbuf, &mut out).map_err(map_err)?;
+        if written > 0 {
+            let w = io.write(&out[..written]);
+            if w < 0 {
+                return Err(w);
+            }
+        }
+    }
+}
+
+/// GRZip's own error codes are not FreeArc's; the C maps them at this boundary
+/// and so does this.
+fn map_err(e: c_int) -> c_int {
+    match e {
+        GRZ_NOT_ENOUGH_MEMORY => crate::ffi::FREEARC_ERRCODE_NOT_ENOUGH_MEMORY,
+        _ => BAD, // every other GRZip failure is corrupt data
+    }
+}

--- a/rust/darc-codecs/src/grzip/wfc_ari.rs
+++ b/rust/darc-codecs/src/grzip/wfc_ari.rs
@@ -1,0 +1,131 @@
+//! Weighted-frequency-count symbol list, the WFC half of
+//! `Compression/GRZip/WFC_Ari.c` (`GRZip_WFC_Ari_Decode` :498).
+//!
+//! Everything except the rank-to-character step lives in [`super::ari`], which
+//! the MTF coder shares.
+//!
+//! ## What WFC does differently
+//!
+//! Move-to-front promotes a character all the way to the head on every use, so
+//! one appearance of a rare byte costs every other byte a rank. WFC instead
+//! keeps a *weight* per character and sorts the list by it. A character used
+//! now gains `WFC_VAL0`; characters used 1, 2, 4, ... 2048 symbols ago each
+//! lose a decreasing amount. The twelve decrements sum to exactly `WFC_VAL0`,
+//! so the total weight in the system is conserved.
+//!
+//! That is why the list needs a history buffer: to know which character was
+//! `Pos` symbols back, the decoder keeps one byte per decoded *symbol* (not per
+//! output byte, which run-lengths make far more numerous).
+//!
+//! `CharWeight[256] = -1` is a sentinel that terminates the insertion walk. It
+//! only works while every real weight stays above -1; the walk is bounded at
+//! the sentinel index here rather than trusting that, since a corrupt block
+//! could in principle drive a weight below it and walk off the list.
+
+use super::ari::{self, SymbolList, MAX_BYTE};
+use super::GrzError;
+
+/// Weight granted to the character just decoded (`WFC_Val0`, :42).
+const VAL0: i32 = 131072;
+
+/// Weights removed from the characters 1, 2, 4, ... 2048 symbols back
+/// (`WFC_Val1`..`WFC_Val12`, :43-54). These sum to exactly `VAL0`.
+const VALS: [i32; 12] = [114688, 7272, 4240, 2364, 1263, 649, 320, 153, 70, 31, 14, 8];
+
+/// How far back each of those weights looks (`WFC_Pos1`..`WFC_Pos12`, :56-67).
+const POSITIONS: [usize; 12] = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048];
+
+struct Wfc {
+    /// Characters ordered by weight, with a sentinel at index `MAX_BYTE`.
+    list: [i32; MAX_BYTE + 1],
+    /// Inverse of `list`.
+    index: [i32; MAX_BYTE + 1],
+    /// Current weight per character; `weight[MAX_BYTE]` is the -1 sentinel.
+    weight: [i32; MAX_BYTE + 1],
+    /// One byte per decoded symbol, for the look-back above.
+    history: Vec<u8>,
+    pos: usize,
+}
+
+impl Wfc {
+    fn new(capacity: usize) -> Self {
+        let mut w = Wfc {
+            list: core::array::from_fn(|i| i as i32),
+            index: core::array::from_fn(|i| i as i32),
+            weight: [0; MAX_BYTE + 1],
+            history: vec![0u8; capacity],
+            pos: 0,
+        };
+        w.weight[MAX_BYTE] = -1;
+        w
+    }
+
+    /// `Update_Weight0`: the character just decoded gains `VAL0` and moves to
+    /// the head unconditionally.
+    fn promote(&mut self, c: usize) {
+        self.weight[c] += VAL0;
+        let mut j = self.index[c] as usize;
+        while j > 0 {
+            let moved = self.list[j - 1];
+            self.list[j] = moved;
+            self.index[moved as usize] = j as i32;
+            j -= 1;
+        }
+        self.list[0] = c as i32;
+        self.index[c] = 0;
+    }
+
+    /// `Update_Weight`: `c` loses `amount` and sinks past every character that
+    /// now outweighs it. Skipped for the character just decoded, which
+    /// `promote` has already placed.
+    fn demote(&mut self, c: usize, amount: i32, current: usize) {
+        let w = self.weight[c] - amount;
+        self.weight[c] = w;
+        if c == current {
+            return;
+        }
+        let mut j = self.index[c] as usize;
+        // The sentinel at MAX_BYTE stops this in the C; bound it explicitly so
+        // a weight driven below -1 by a corrupt block cannot walk off the end.
+        while j + 1 <= MAX_BYTE && self.weight[self.list[j + 1] as usize] > w {
+            let moved = self.list[j + 1];
+            self.list[j] = moved;
+            self.index[moved as usize] = j as i32;
+            j += 1;
+        }
+        self.list[j] = c as i32;
+        self.index[c] = j as i32;
+    }
+}
+
+impl SymbolList for Wfc {
+    fn pick(&mut self, rank: usize) -> u8 {
+        let ch = self.list[rank] as usize;
+        if self.pos < self.history.len() {
+            self.history[self.pos] = ch as u8;
+        }
+        self.promote(ch);
+        // `Update_Weight_Full` for each of the twelve look-back distances.
+        for (amount, back) in VALS.iter().zip(POSITIONS.iter()) {
+            if self.pos >= *back {
+                let c = self.history[self.pos - *back] as usize;
+                self.demote(c, *amount, ch);
+            }
+        }
+        self.pos += 1;
+        ch as u8
+    }
+}
+
+/// `GRZip_WFC_Ari_Decode`.
+///
+/// **The C's parameter order is not the MTF one.** There it is
+/// `(Input, Size = compressed length, Output, OutSize)`; here it is
+/// `(Input, Size = *decoded* length, Output, InSize = compressed length)` --
+/// the second and fourth arguments swap meaning between two functions that are
+/// otherwise near-identical. `Size` is the decoded length because `WFC_Init`
+/// uses it to size the history buffer.
+pub fn decode(input: &[u8], out: &mut [u8], out_size: usize) -> Result<usize, GrzError> {
+    let mut list = Wfc::new(out_size.min(out.len()).max(1));
+    ari::decode(input, out, out_size, &mut list)
+}

--- a/rust/darc-codecs/src/lib.rs
+++ b/rust/darc-codecs/src/lib.rs
@@ -10,6 +10,7 @@
 pub mod delta;
 pub mod dict;
 pub mod dict_encode;
+pub mod grzip;
 pub mod lz4;
 pub mod lzp;
 pub mod mm;

--- a/rust/difftest/grzip-check.sh
+++ b/rust/difftest/grzip-check.sh
@@ -73,5 +73,27 @@ for mode in 0 2 4 6 0x100 0x102 0x104 0x106 0x50104 0x50100; do
   total=$((total+fail))
 done
 
+# Stream level. Only this layer splits input into blocks, so it is the only
+# place an input past GRZ_MaxBlockSize (8 MB - 512) means anything -- the block
+# harness above physically cannot take one. Per the Tornado lesson, a corpus
+# that fits inside one block leaves the whole splitting path untested.
+python3 - "$W/big" <<'PY2'
+import sys,struct
+open(sys.argv[1],"wb").write(b"".join(
+    struct.pack("<I", (i*2654435761)&0xffffffff) if i%3 else b"the quick brown fox "[:4]
+    for i in range(3000000)))
+PY2
+sfail=0; sn=0
+for f in "$W"/in/* "$W/big"; do
+  sn=$((sn+1)); name=$(basename "$f")
+  "$W/c"  sc < "$f"    >| "$W/ss" 2>/dev/null || { echo "  [stream] $name: C-compress FAILED"; sfail=$((sfail+1)); continue; }
+  "$W/c"  sd < "$W/ss" >| "$W/sc" 2>/dev/null || { echo "  [stream] $name: C-decode FAILED";   sfail=$((sfail+1)); continue; }
+  "$W/rs" sd < "$W/ss" >| "$W/sr" 2>/dev/null || { echo "  [stream] $name: RUST-decode FAILED"; sfail=$((sfail+1)); continue; }
+  cmp -s "$f" "$W/sc" || { echo "  [stream] $name: C-decode != original (harness bug)"; sfail=$((sfail+1)); continue; }
+  cmp -s "$f" "$W/sr" || { echo "  [stream] $name: RUST-decode != original"; sfail=$((sfail+1)); continue; }
+done
+echo "  [stream, multi-block] $sn inputs, $sfail differing"
+total=$((total+sfail))
+
 echo "grzip decode: $total total differing"
 [ "$total" -eq 0 ] && echo "GRZip decoder matches the C original byte for byte" || exit 1

--- a/rust/difftest/grzip-check.sh
+++ b/rust/difftest/grzip-check.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Differential-test the GRZip decoder port against the C original.
+#
+# GRZip is ported decode-first, so the C compressor is the only encoder. This
+# works at the BLOCK level rather than the stream level: grzip_decompress (the
+# multithreaded stream wrapper) is not ported yet, but GRZip_DecompressBlock is,
+# and it is where every ported stage actually runs.
+#
+# The mode word selects the pipeline: bit1 picks ST4 over BWT, bit2 picks the
+# MTF arithmetic coder over WFC, and the upper bits carry LZP parameters. Only
+# the MTF modes are tested, because WFC_Ari.c is not ported yet -- those modes
+# are asserted to REJECT cleanly rather than silently produce wrong bytes.
+set -uo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+W="${TMPDIR:-/tmp}/grzip-check.$$"; mkdir -p "$W"
+trap 'rm -rf "$W"' EXIT
+
+( cd "$ROOT/rust" && cargo build --release -p darc-codecs ) >/dev/null 2>&1 \
+  || { echo "cargo build failed" >&2; exit 1; }
+LIB="$ROOT/rust/target/release/libdarc_codecs.a"
+
+# Trailing arguments land after the sources: GNU ld resolves an archive against
+# only the objects already seen, so a library placed first is silently dropped.
+cc() { local out="$1"; shift
+  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+    -I"$ROOT" -I"$ROOT/Compression" \
+    "$ROOT/rust/difftest/grzip_ref.cpp" "$ROOT/rust/difftest/grzip_ccodec.cpp" \
+    "$ROOT/Compression/Common.cpp" "$@" -o "$out"; }
+cc "$W/c"                    || exit 1
+cc "$W/rs" -DUSE_RUST "$LIB" || exit 1
+
+# Inputs for both the transforms and the entropy stage: text (skewed statistics,
+# long MTF runs), records of fixed-width numbers (the Mode==-2 recursive path
+# and the delta de-interleaves), runs (the RLE ladder), noise (literal-heavy,
+# and where the encoder gives up and stores), and sizes around the awkward
+# boundaries. Everything stays UNDER GRZ_MaxBlockSize (8 MB - 512): this is a
+# block-level harness, and GRZip_CompressBlock cannot take more than one block.
+# Block splitting lives in the stream wrapper, which is not ported yet -- when
+# it is, the stream-level harness needs an input past that size.
+python3 - "$W/in" <<'PY'
+import os,sys,struct
+d=sys.argv[1]; os.makedirs(d,exist_ok=True)
+def prng(seed,n):
+    s=seed; o=bytearray()
+    for _ in range(n): s=(s*1103515245+12345)&0xffffffff; o.append((s>>16)&0xff)
+    return bytes(o)
+w=lambda n,b: open(f"{d}/{n}","wb").write(b)
+w("text",     b"the quick brown fox jumps over the lazy dog. "*9000)
+w("repeats",  (b"ABCDEFGHIJKLMNOP"*64 + prng(1,128))*300)
+w("runs",     b"".join(bytes([i%251])*(1+(i%97)) for i in range(6000)))
+w("noise",    prng(7, 400000))
+w("zeros",    b"\x00"*300000)
+w("rec4",     b"".join(struct.pack("<I", i*7+3) for i in range(120000)))
+w("rec2",     b"".join(struct.pack("<H", (i*11)&0xffff) for i in range(200000)))
+w("mixed",    b"".join((prng(i,600) + b"pattern"*120) for i in range(200)))
+w("big",      b"".join(struct.pack("<I", (i*2654435761)&0xffffffff) for i in range(1800000)))  # ~7 MB, just under one block
+for n in (1,2,3,4,27,28,29,255,256,257,4096,65537):
+    w(f"n_{n}", (b"the quick brown fox "*4000)[:n])
+PY
+
+total=0; wfc_bad=0
+for mode in 4 6 0x104 0x106 0x50104; do
+  fail=0; n=0
+  for f in "$W"/in/*; do
+    n=$((n+1)); name=$(basename "$f")
+    sz=$(( $(wc -c < "$f") * 2 + 1048576 ))
+    "$W/c"  c "$mode" < "$f"   >| "$W/s"  2>/dev/null || { echo "  [$mode] $name: C-compress FAILED"; fail=$((fail+1)); continue; }
+    "$W/c"  d "$sz"   < "$W/s" >| "$W/oc" 2>/dev/null || { echo "  [$mode] $name: C-decode FAILED";   fail=$((fail+1)); continue; }
+    "$W/rs" d "$sz"   < "$W/s" >| "$W/or" 2>/dev/null || { echo "  [$mode] $name: RUST-decode FAILED"; fail=$((fail+1)); continue; }
+    cmp -s "$f" "$W/oc" || { echo "  [$mode] $name: C-decode != original (harness bug)"; fail=$((fail+1)); continue; }
+    cmp -s "$f" "$W/or" || { echo "  [$mode] $name: RUST-decode != original"; fail=$((fail+1)); continue; }
+  done
+  echo "  [mode $mode] $n inputs, $fail differing"
+  total=$((total+fail))
+done
+
+# WFC is not ported. Assert it is REJECTED rather than quietly decoded wrong --
+# a stage that silently produces plausible bytes is worse than one that errors.
+for mode in 0 2; do
+  "$W/c"  c "$mode" < "$W/in/text" >| "$W/s" 2>/dev/null
+  if "$W/rs" d 4000000 < "$W/s" >| "$W/or" 2>/dev/null; then
+    echo "  [mode $mode] WFC is NOT ported but the port returned success"; wfc_bad=$((wfc_bad+1))
+  fi
+done
+[ "$wfc_bad" -eq 0 ] && echo "  [WFC modes] correctly rejected (not yet ported)"
+
+echo "grzip decode: $total total differing"
+[ "$total" -eq 0 ] && [ "$wfc_bad" -eq 0 ] \
+  && echo "GRZip MTF path matches the C original byte for byte" || exit 1

--- a/rust/difftest/grzip-check.sh
+++ b/rust/difftest/grzip-check.sh
@@ -7,9 +7,8 @@
 # and it is where every ported stage actually runs.
 #
 # The mode word selects the pipeline: bit1 picks ST4 over BWT, bit2 picks the
-# MTF arithmetic coder over WFC, and the upper bits carry LZP parameters. Only
-# the MTF modes are tested, because WFC_Ari.c is not ported yet -- those modes
-# are asserted to REJECT cleanly rather than silently produce wrong bytes.
+# MTF arithmetic coder over WFC, and the upper bits carry LZP parameters. All
+# four transform/coder combinations are covered, with LZP off and on.
 set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 W="${TMPDIR:-/tmp}/grzip-check.$$"; mkdir -p "$W"
@@ -58,8 +57,8 @@ for n in (1,2,3,4,27,28,29,255,256,257,4096,65537):
     w(f"n_{n}", (b"the quick brown fox "*4000)[:n])
 PY
 
-total=0; wfc_bad=0
-for mode in 4 6 0x104 0x106 0x50104; do
+total=0
+for mode in 0 2 4 6 0x100 0x102 0x104 0x106 0x50104 0x50100; do
   fail=0; n=0
   for f in "$W"/in/*; do
     n=$((n+1)); name=$(basename "$f")
@@ -74,16 +73,5 @@ for mode in 4 6 0x104 0x106 0x50104; do
   total=$((total+fail))
 done
 
-# WFC is not ported. Assert it is REJECTED rather than quietly decoded wrong --
-# a stage that silently produces plausible bytes is worse than one that errors.
-for mode in 0 2; do
-  "$W/c"  c "$mode" < "$W/in/text" >| "$W/s" 2>/dev/null
-  if "$W/rs" d 4000000 < "$W/s" >| "$W/or" 2>/dev/null; then
-    echo "  [mode $mode] WFC is NOT ported but the port returned success"; wfc_bad=$((wfc_bad+1))
-  fi
-done
-[ "$wfc_bad" -eq 0 ] && echo "  [WFC modes] correctly rejected (not yet ported)"
-
 echo "grzip decode: $total total differing"
-[ "$total" -eq 0 ] && [ "$wfc_bad" -eq 0 ] \
-  && echo "GRZip MTF path matches the C original byte for byte" || exit 1
+[ "$total" -eq 0 ] && echo "GRZip decoder matches the C original byte for byte" || exit 1

--- a/rust/difftest/grzip_ccodec.cpp
+++ b/rust/difftest/grzip_ccodec.cpp
@@ -1,0 +1,44 @@
+/* The C GRZip codec for the differential harness.
+ *
+ * C_GRZip.cpp includes its six component .c files itself, so this is a single
+ * translation unit like the real build. The shim at the bottom exposes the two
+ * block entry points, which are file-scope in C_GRZip.cpp and absent from
+ * libGRZip.h -- the driver cannot declare them itself.
+ *
+ * The block level is deliberately where this harness cuts. grzip_decompress
+ * (the stream wrapper) is not ported yet, but GRZip_DecompressBlock is, and it
+ * is where every stage that has been ported actually runs.
+ */
+// C_GRZip.cpp registers itself as a COMPRESSION_METHOD at static-init time and
+// asks the library how many threads to use. Neither matters at the block level,
+// and pulling in CompressionLibrary.cpp would drag in every other codec, so the
+// two symbols are stubbed. GetCompressionThreads only sizes a memory estimate.
+#include "../../Compression/GRZip/C_GRZip.cpp"
+// The real synchronization primitives, textually included rather than compiled
+// standalone: on their own they fail on TRUE/FALSE, which C_GRZip.cpp's include
+// chain has already defined by this point. Cheaper and less fragile than
+// stubbing the whole worker-thread pool.
+#include "../../Compression/LZMA/Windows/Synchronization.cpp"
+
+// Stubs for the archiver-side plumbing C_GRZip.cpp pulls in. None of it is on
+// the block path: AddCompressionMethod registers the method at static-init
+// time, GetCompressionThreads only sizes a memory estimate, and LoadFromDLL /
+// WaitForMultipleObjects belong to the stream-level multithreaded wrapper
+// (grzip_compress / grzip_decompress), which this harness deliberately does not
+// exercise. Linking the real ones would drag in CompressionLibrary.cpp and
+// every other codec with it.
+int AddCompressionMethod (CM_PARSER)   { return 0; }
+extern "C" int GetCompressionThreads (void) { return 1; }
+FARPROC LoadFromDLL (char *)           { return 0; }
+// Signature per the linker: (count, handles, wait_all, timeout).
+// COMPRESSION_METHOD::doit is only reachable through GRZIP_METHOD, which the
+// block path never constructs; it exists here to satisfy the vtable.
+int COMPRESSION_METHOD::doit (char *, int, void *, CALLBACK_FUNC *) { return -1; }
+
+extern "C" {
+int darc_grz_compress_block (unsigned char *in, int size, unsigned char *out, int mode)
+{ return GRZip_CompressBlock (in, size, out, mode); }
+
+int darc_grz_decompress_block (unsigned char *in, int size, unsigned char *out)
+{ return GRZip_DecompressBlock (in, size, out); }
+}

--- a/rust/difftest/grzip_ccodec.cpp
+++ b/rust/difftest/grzip_ccodec.cpp
@@ -41,4 +41,13 @@ int darc_grz_compress_block (unsigned char *in, int size, unsigned char *out, in
 
 int darc_grz_decompress_block (unsigned char *in, int size, unsigned char *out)
 { return GRZip_DecompressBlock (in, size, out); }
+
+int darc_grz_stream_compress (int method, int blocksize, int enable_lzp, int minlen,
+                              int hashlog, int altsort, int adaptive, int deltaflt,
+                              CALLBACK_FUNC *cb, void *aux)
+{ return grzip_compress (method, blocksize, enable_lzp, minlen, hashlog,
+                         altsort, adaptive, deltaflt, cb, aux); }
+
+int darc_grz_stream_decompress (CALLBACK_FUNC *cb, void *aux)
+{ return grzip_decompress (cb, aux); }
 }

--- a/rust/difftest/grzip_ref.cpp
+++ b/rust/difftest/grzip_ref.cpp
@@ -1,0 +1,59 @@
+/* Reference driver for differential-testing the GRZip decoder port.
+ *
+ *     grzip_ref c MODE  <in >block
+ *     grzip_ref d SIZE  <block >out
+ *
+ * Built a second time with -DUSE_RUST so `d` drives the Rust port. GRZip is
+ * ported decode-first, so the C compressor is the only encoder.
+ *
+ * This works at the *block* level rather than the stream level: the stream
+ * wrapper (grzip_decompress) is not ported yet, but GRZip_DecompressBlock is,
+ * and it is where every ported stage actually runs. SIZE is the output
+ * capacity, which the stream layer would otherwise supply.
+ *
+ * MODE is GRZip's mode word: bit1 selects ST4 over BWT, bit2 selects the MTF
+ * arithmetic coder over WFC, and the upper bits carry the LZP parameters.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern "C" {
+int darc_grz_compress_block   (unsigned char *in, int size, unsigned char *out, int mode);
+int darc_grz_decompress_block (unsigned char *in, int size, unsigned char *out);
+#ifdef USE_RUST
+int darc_rs_grzip_decompress_block (const unsigned char *in, int in_size,
+                                    unsigned char *out, int out_cap);
+#endif
+}
+
+int main (int argc, char **argv) {
+  if (argc<2 || (argv[1][0]!='c'&&argv[1][0]!='d')) {
+    fprintf(stderr,"usage: %s c MODE | d SIZE\n",argv[0]); return 2; }
+  size_t cap=1<<20, len=0; unsigned char *in=(unsigned char*)malloc(cap); if(!in) return 3;
+  for(;;){ if(len==cap){cap*=2; unsigned char*g=(unsigned char*)realloc(in,cap); if(!g){free(in);return 3;} in=g;}
+    size_t n=fread(in+len,1,cap-len,stdin); if(n==0)break; len+=n; }
+
+  int rc;
+  // Generous slack: the compressor may expand incompressible input, and the
+  // decompressor's capacity is supplied by the caller in the real pipeline.
+  size_t out_cap = len*2 + (1<<20);
+  unsigned char *out=(unsigned char*)malloc(out_cap);
+  if(!out){free(in);return 3;}
+
+  if (argv[1][0]=='c') {
+    int mode = argc>2? (int)strtol(argv[2],NULL,0) : 0;
+    rc = darc_grz_compress_block (in, (int)len, out, mode);
+  } else {
+    int size = argc>2? atoi(argv[2]) : (int)out_cap;
+    if ((size_t)size > out_cap) size = (int)out_cap;
+#ifdef USE_RUST
+    rc = darc_rs_grzip_decompress_block (in, (int)len, out, size);
+#else
+    rc = darc_grz_decompress_block (in, (int)len, out);
+#endif
+  }
+  if (rc<0){ fprintf(stderr,"codec returned %d\n",rc); free(in); free(out); return 4; }
+  if (rc>0 && fwrite(out,1,(size_t)rc,stdout)!=(size_t)rc){ free(in); free(out); return 5; }
+  free(in); free(out); return 0;
+}

--- a/rust/difftest/grzip_ref.cpp
+++ b/rust/difftest/grzip_ref.cpp
@@ -21,15 +21,50 @@
 extern "C" {
 int darc_grz_compress_block   (unsigned char *in, int size, unsigned char *out, int mode);
 int darc_grz_decompress_block (unsigned char *in, int size, unsigned char *out);
+int darc_grz_stream_compress  (int method, int blocksize, int enable_lzp, int minlen,
+                               int hashlog, int altsort, int adaptive, int deltaflt,
+                               int (*cb)(const char*, void*, int, void*), void *aux);
+int darc_grz_stream_decompress(int (*cb)(const char*, void*, int, void*), void *aux);
 #ifdef USE_RUST
 int darc_rs_grzip_decompress_block (const unsigned char *in, int in_size,
                                     unsigned char *out, int out_cap);
+int darc_rs_grzip_decompress (int (*cb)(const char*, void*, int, void*), void *aux);
 #endif
 }
 
+/* Callback pair for the stream-level modes ("sc" / "sd"), which drive
+ * grzip_compress / grzip_decompress rather than a single block. Only the stream
+ * layer splits input into blocks, so this is the only way to exercise an input
+ * larger than GRZ_MaxBlockSize. */
+struct Buffers {
+  const unsigned char *in; size_t in_len, in_pos;
+  unsigned char *out; size_t out_len, out_cap;
+};
+static int io_callback (const char *what, void *data, int size, void *aux) {
+  Buffers *b = (Buffers*) aux;
+  if (size < 0) return -1;
+  if (strcmp(what,"read")==0) {
+    size_t avail=b->in_len-b->in_pos, n=(size_t)size<avail?(size_t)size:avail;
+    memcpy(data,b->in+b->in_pos,n); b->in_pos+=n; return (int)n;
+  }
+  if (strcmp(what,"write")==0) {
+    if (b->out_len+(size_t)size>b->out_cap) {
+      size_t cap=b->out_cap?b->out_cap:65536;
+      while (cap<b->out_len+(size_t)size) cap*=2;
+      unsigned char *g=(unsigned char*)realloc(b->out,cap);
+      if(!g) return -1;
+      b->out=g; b->out_cap=cap;
+    }
+    memcpy(b->out+b->out_len,data,(size_t)size); b->out_len+=(size_t)size; return size;
+  }
+  return 0;
+}
+
 int main (int argc, char **argv) {
-  if (argc<2 || (argv[1][0]!='c'&&argv[1][0]!='d')) {
-    fprintf(stderr,"usage: %s c MODE | d SIZE\n",argv[0]); return 2; }
+  int stream = (argc>1 && argv[1][0]=='s');
+  const char *op = stream? argv[1]+1 : (argc>1? argv[1] : "");
+  if (argc<2 || (op[0]!='c'&&op[0]!='d')) {
+    fprintf(stderr,"usage: %s c MODE | d SIZE | sc | sd\n",argv[0]); return 2; }
   size_t cap=1<<20, len=0; unsigned char *in=(unsigned char*)malloc(cap); if(!in) return 3;
   for(;;){ if(len==cap){cap*=2; unsigned char*g=(unsigned char*)realloc(in,cap); if(!g){free(in);return 3;} in=g;}
     size_t n=fread(in+len,1,cap-len,stdin); if(n==0)break; len+=n; }
@@ -41,7 +76,20 @@ int main (int argc, char **argv) {
   unsigned char *out=(unsigned char*)malloc(out_cap);
   if(!out){free(in);return 3;}
 
-  if (argv[1][0]=='c') {
+  if (stream) {
+    Buffers b={in,len,0,NULL,0,0};
+    if (op[0]=='c') rc = darc_grz_stream_compress (1, 8*1024*1024, 1, 32, 15, 0, 0, 0, io_callback,&b);  // GRZIP_METHOD defaults
+#ifdef USE_RUST
+    else            rc = darc_rs_grzip_decompress (io_callback,&b);
+#else
+    else            rc = darc_grz_stream_decompress (io_callback,&b);
+#endif
+    if (rc<0){ fprintf(stderr,"codec returned %d\n",rc); free(in); free(out); free(b.out); return 4; }
+    if (b.out_len && fwrite(b.out,1,b.out_len,stdout)!=b.out_len){ free(in); free(out); free(b.out); return 5; }
+    free(in); free(out); free(b.out); return 0;
+  }
+
+  if (op[0]=='c') {
     int mode = argc>2? (int)strtol(argv[2],NULL,0) : 0;
     rc = darc_grz_compress_block (in, (int)len, out, mode);
   } else {


### PR DESCRIPTION
Ports GRZip's decoder to `rust/darc-codecs/src/grzip/`, selected by `DARC_RUST=1`. Decode-first, as with REP, Dict, LZP, TTA, MM and Tornado.

GRZip is a BWT-family codec: an entropy stage, then an inverse block-sort transform, then LZP — with a recursive mode that splits a block into record planes and reassembles them.

| module | from |
|---|---|
| `ari.rs` | the shared range coder + context-model stack |
| `mtf_ari.rs` / `wfc_ari.rs` | the two symbol-list disciplines |
| `bwt.rs` | inverse BWT, both variants |
| `st4.rs` | inverse order-4 sort transform |
| `lzp.rs` | GRZip's LZP (unrelated to `Compression/LZP/`) |
| `rec.rs` | record de-interleave + delta |
| `block.rs` | the 28-byte header and Mode dispatch |
| `stream.rs` | the block sequence |

## Verification

| | |
|---|---|
| Differential vs C | **232/232 byte-identical** — 210 block-level across ten modes (all four transform/coder combinations × LZP off/on), 22 stream-level |
| Sabotage | 6 sabotages break **10–66** cases each, one per module |
| Archive format | stock and `DARC_RUST` both 22/22, identical fingerprints, `grzip` still `8b06f966e25e211f` |
| Really linked | `C_GRZip.o` → `U _grzip_decompress` |

## The bug the harness caught

**My inverse BWT was wrong, and had been since I wrote it.** I assumed the two forward transforms produce the same permutation and that `StrongBWT_Flag` merely reinterprets `FBP`, so one inverse served both. They are different transforms: the strong variant carries a sentinel row, so its table has `Size+1` entries with a gap at `FBP`, its prefix sum starts at 1, and its walk is anchored at 0. Sixty lines of C I never opened — the same error as Tornado's `IMPOSSIBLE_LEN`.

Two things about how it surfaced:

- **It survived my own round-trip test.** `bwt.rs` tests its inverse against a forward BWT written in the same file, which pins the fast variant and says nothing about the strong one. A self-consistent test proves self-consistency; the C was never in the loop.
- **The failure pattern named the culprit.** Every ST4 mode passed, every BWT mode failed. When modes partition the code, differential output is diagnostic, not just pass/fail — that split pointed at the transform rather than at the 300 freshly-written lines of entropy coder I'd otherwise have suspected first.

## Ordering, and why the harness came before the last coder

`MTF_Ari.c` and `WFC_Ari.c` are near-duplicates — identical range coder, model stack and run-length ladder, differing only in how a rank becomes a character. I built the harness and verified the MTF path *before* writing WFC, then moved the shared ~150 lines into `ari.rs` behind a `SymbolList` trait and re-ran the harness to confirm no regression. WFC then worked first time. Verifying before piling more code on unverified code is what made that possible.

## Bounds the C does not have

- **Recursion depth.** A `Mode == -2` block contains whole blocks and recurses, with nothing in the C limiting depth and the nesting coming from attacker-controlled header bytes. In C that's stack exhaustion; a `Result` cannot catch a stack overflow. Real blocks nest once; `MAX_DEPTH = 8`.
- **The WFC insertion walk**, bounded at the sentinel index rather than trusting that every weight stays above the `-1` fence.

## Notes

The stream harness carries a 20 MB input deliberately — only that layer splits blocks, so it's the only place an input past `GRZ_MaxBlockSize` means anything. The block harness physically cannot take one.

The stream pass first failed for **both** C and Rust, which is how I knew it was my harness rather than the port: I'd passed `grzip_compress` a zero `BlockSize` instead of the `GRZIP_METHOD` defaults.

`grzip-check.sh` joins the per-codec differential step in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)