### PR TITLE
Make the Rust codecs the default build (DARC_NO_RUST=1 opts out)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -371,6 +371,22 @@ jobs:
           make minstall
         fi
         echo "$HOME/.mcabal/bin" >> "$GITHUB_PATH"
+    # bindgen parses DArc's headers as C++, so it reads llvm-mingw's libc++ --
+    # whose headers use __builtin_clzg (Clang 19+). llvm-mingw ships the clang
+    # driver but no libclang.so, so bindgen otherwise falls back to whatever
+    # older libclang is on the box and dies on that builtin. Same pinned LLVM
+    # the Linux build job uses.
+    - name: Install LLVM and Clang (for bindgen)
+      uses: KyleMayes/install-llvm-action@ebc0426251bc40c7cd31162802432c68818ab8f0 # v2
+      with:
+        version: "21.1.8"
+    # Exported for EVERY later step, not just one: each cargo build in this job
+    # runs bindgen, and attaching this to a single step is exactly how the first
+    # build ended up on a stale libclang.
+    - name: Point bindgen at the pinned libclang
+      run: |
+        test -d "$LLVM_PATH/lib" || { echo "::error::no $LLVM_PATH/lib"; exit 1; }
+        echo "LIBCLANG_PATH=$LLVM_PATH/lib" >> "$GITHUB_ENV"
     # The Rust codecs are built by default now, so this must precede the first
     # build, not follow it. Targets come from rust-toolchain.toml.
     - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
@@ -404,18 +420,7 @@ jobs:
     # reach aarch64-pc-windows-gnullvm through llvm-mingw, a different toolchain
     # from the x86-64 job's mingw-w64, so it is checked separately. Wine has no
     # ARM64 emulation, so this proves the build and the link, not execution.
-    # bindgen parses DArc's headers as C++, so it reads llvm-mingw's libc++ --
-    # whose headers use __builtin_clzg (Clang 19+). llvm-mingw ships the clang
-    # driver but no libclang.so, so bindgen otherwise falls back to whatever
-    # older libclang is on the box and dies on that builtin. Same pinned LLVM
-    # the Linux build job uses.
-    - name: Install LLVM and Clang (for bindgen)
-      uses: KyleMayes/install-llvm-action@ebc0426251bc40c7cd31162802432c68818ab8f0 # v2
-      with:
-        version: "21.1.8"
     - name: Build (Windows ARM64 cross, C-only) and compare
-      env:
-        LIBCLANG_PATH: ${{ env.LLVM_PATH }}/lib
       run: |
         # The build above is now the Rust one (default), and it is what was
         # uploaded for the native ARM64 job. Rebuild C-only purely to prove the

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,6 +251,21 @@ jobs:
           make minstall
         fi
         echo "$HOME/.mcabal/bin" >> "$GITHUB_PATH"
+    # The Rust codecs are built by default now, so this must precede the first
+    # build, not follow it. Targets come from rust-toolchain.toml.
+    - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+    - name: Cache cargo and the pinned toolchain
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: |
+          ~/.cargo/registry/index
+          ~/.cargo/registry/cache
+          ~/.cargo/git/db
+          ~/.rustup/toolchains
+          rust/target
+        key: cargo-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml', 'rust/Cargo.lock') }}
+        restore-keys: |
+          cargo-${{ runner.os }}-${{ runner.arch }}-
     - name: Build (Windows cross)
       run: |
         chmod +x compile-win64-c compile-mhs-win64
@@ -282,13 +297,13 @@ jobs:
     # zstd-sys and bindgen both need the mingw toolchain rather than the host's.
     # Until this passes, no C decoder can be deleted -- the shipped Windows
     # binaries would be left with nothing.
-    - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-      with:
-        targets: x86_64-pc-windows-gnu
-    - name: Build (Windows cross, DARC_RUST)
+    - name: Build (Windows cross, C-only) and compare
       run: |
+        cp Tests/arc-mhs-win64.exe /tmp/arc-win-rs.exe
+        DARC_NO_RUST=1 ./compile-mhs-win64
         cp Tests/arc-mhs-win64.exe /tmp/arc-win-c.exe
-        DARC_RUST=1 ./compile-mhs-win64
+        # restore the default (Rust) build as the artifact under test
+        cp /tmp/arc-win-rs.exe Tests/arc-mhs-win64.exe
     - name: Verify the Rust codecs actually linked
       run: |
         test -f Tests/arc-mhs-win64.exe || { echo "::error::no DARC_RUST Windows binary"; exit 1; }
@@ -298,12 +313,6 @@ jobs:
           echo "::error::DARC_RUST Windows build is byte-identical to the C build -- the Rust codecs were not linked"
           exit 1; }
         echo "DARC_RUST binary: $(wc -c < Tests/arc-mhs-win64.exe) bytes (C build: $(wc -c < /tmp/arc-win-c.exe))"
-    # Building is not working. Round-trip real archives through the Rust codecs
-    # on the Windows target.
-    - name: Smoke-test the DARC_RUST build under Wine
-      run: |
-        chmod +x Tests/win-test.sh
-        Tests/win-test.sh
 
   # ── Windows on ARM64 ────────────────────────────────────────────────────────
   # Split across two jobs because neither half can be done alone:
@@ -362,6 +371,21 @@ jobs:
           make minstall
         fi
         echo "$HOME/.mcabal/bin" >> "$GITHUB_PATH"
+    # The Rust codecs are built by default now, so this must precede the first
+    # build, not follow it. Targets come from rust-toolchain.toml.
+    - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+    - name: Cache cargo and the pinned toolchain
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: |
+          ~/.cargo/registry/index
+          ~/.cargo/registry/cache
+          ~/.cargo/git/db
+          ~/.rustup/toolchains
+          rust/target
+        key: cargo-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml', 'rust/Cargo.lock') }}
+        restore-keys: |
+          cargo-${{ runner.os }}-${{ runner.arch }}-
     - name: Build (Windows ARM64 cross)
       run: |
         chmod +x compile-win64-c compile-mhs-win64
@@ -380,9 +404,6 @@ jobs:
     # reach aarch64-pc-windows-gnullvm through llvm-mingw, a different toolchain
     # from the x86-64 job's mingw-w64, so it is checked separately. Wine has no
     # ARM64 emulation, so this proves the build and the link, not execution.
-    - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-      with:
-        targets: aarch64-pc-windows-gnullvm
     # bindgen parses DArc's headers as C++, so it reads llvm-mingw's libc++ --
     # whose headers use __builtin_clzg (Clang 19+). llvm-mingw ships the clang
     # driver but no libclang.so, so bindgen otherwise falls back to whatever
@@ -392,13 +413,18 @@ jobs:
       uses: KyleMayes/install-llvm-action@ebc0426251bc40c7cd31162802432c68818ab8f0 # v2
       with:
         version: "21.1.8"
-    - name: Build (Windows ARM64 cross, DARC_RUST)
+    - name: Build (Windows ARM64 cross, C-only) and compare
       env:
         LIBCLANG_PATH: ${{ env.LLVM_PATH }}/lib
       run: |
+        # The build above is now the Rust one (default), and it is what was
+        # uploaded for the native ARM64 job. Rebuild C-only purely to prove the
+        # two differ, then put the Rust binary back.
+        cp Tests/arc-mhs-win-arm64.exe /tmp/arc-arm64-rs.exe
+        DARC_NO_RUST=1 DARC_WIN_ARCH=aarch64 ./compile-mhs-win64
         cp Tests/arc-mhs-win-arm64.exe /tmp/arc-arm64-c.exe
-        DARC_RUST=1 DARC_WIN_ARCH=aarch64 ./compile-mhs-win64
-        test -f Tests/arc-mhs-win-arm64.exe || { echo "::error::no DARC_RUST ARM64 binary"; exit 1; }
+        cp /tmp/arc-arm64-rs.exe Tests/arc-mhs-win-arm64.exe
+        test -f Tests/arc-mhs-win-arm64.exe || { echo "::error::no ARM64 binary"; exit 1; }
         cmp -s /tmp/arc-arm64-c.exe Tests/arc-mhs-win-arm64.exe && {
           echo "::error::DARC_RUST ARM64 build is byte-identical to the C build -- the Rust codecs were not linked"
           exit 1; }
@@ -801,15 +827,15 @@ jobs:
     - name: Archives identical with and without the Rust codecs
       run: |
         chmod +x compile* Tests/*.sh
-        ./compile > /tmp/build-c.log 2>&1 || { tail -30 /tmp/build-c.log; exit 1; }
+        DARC_NO_RUST=1 ./compile > /tmp/build-c.log 2>&1 || { tail -30 /tmp/build-c.log; exit 1; }
         cp Tests/arc /tmp/arc-c
         Tests/run-tests.sh /tmp/arc-c > /tmp/suite-c.log 2>&1 || { tail -40 /tmp/suite-c.log; exit 1; }
 
         rm -rf /tmp/out/FreeArc
-        DARC_RUST=1 ./compile > /tmp/build-rs.log 2>&1 || { tail -30 /tmp/build-rs.log; exit 1; }
+        ./compile > /tmp/build-rs.log 2>&1 || { tail -30 /tmp/build-rs.log; exit 1; }
         # If the Rust library were not really linked the binary would be
         # unchanged, which is exactly how this went wrong once.
-        cmp -s /tmp/arc-c Tests/arc && { echo "::error::DARC_RUST build is byte-identical to the C build -- the Rust codecs were not linked"; exit 1; }
+        cmp -s /tmp/arc-c Tests/arc && { echo "::error::default build is byte-identical to the DARC_NO_RUST build -- the Rust codecs were not linked"; exit 1; }
         Tests/run-tests.sh Tests/arc > /tmp/suite-rs.log 2>&1 || { tail -40 /tmp/suite-rs.log; exit 1; }
 
         grep -E "^[a-z0-9-]+ +(ok|FAIL) " /tmp/suite-c.log  | awk '{print $1, $NF}' | sort > /tmp/fp-c.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Since Wine has no ARM64 emulation, the ARM64 binary cannot be exercised on the m
 
 Binaries land in `Tests/`, which despite the name is a build *output* directory, not a test suite — it holds the produced binaries (gitignored via `Tests/*arc`) alongside the committed `arc.groups` solid-ordering config.
 
-Prerequisites: `mhs`, `clang`, `make`, `liblua5.1-dev`, `libncurses-dev`. `libcurl` is optional and auto-detected — its absence adds `-DFREEARC_NOURL` and drops URL-archive support. CI pins MicroHs to a specific commit SHA with a checksum (`.github/workflows/build.yml`); match that commit when reproducing CI failures locally.
+Prerequisites: `mhs`, `clang`, `make`, `cargo`, `liblua5.1-dev`, `libncurses-dev`. **The Rust codecs are built and linked by default** — `cargo` is required. `DARC_NO_RUST=1` opts out and builds the C implementations instead; it exists so CI can build both and prove they produce identical archives. `libcurl` is optional and auto-detected — its absence adds `-DFREEARC_NOURL` and drops URL-archive support. CI pins MicroHs to a specific commit SHA with a checksum (`.github/workflows/build.yml`); match that commit when reproducing CI failures locally.
 
 ### Build-system gotchas
 
@@ -48,6 +48,7 @@ CPP defines are the main axis of variation, threaded through both the Haskell an
 | `FREEARC_UNIX` / `FREEARC_WIN` | Target OS |
 | `FREEARC_64BIT` | Set from `getconf LONG_BIT` |
 | `__MHS__` | Building under MicroHs rather than GHC |
+| `DARC_RUST` | Codec entry points come from the Rust crates (default; `DARC_NO_RUST=1` disables) |
 | `FREEARC_GUI` | Build the GUI binary instead of console |
 | `FREEARC_NOURL` | No libcurl/WinInet — URL support compiled out |
 | `FREEARC_NO_LUA` | No Lua — `Options.hs` stubs the interpreter out |

--- a/RUST_PORT_PROGRESS.md
+++ b/RUST_PORT_PROGRESS.md
@@ -130,9 +130,18 @@ pinned to a full commit SHA, and cargo/rustup/`rust/target` plus `~/.mcabal` are
 cached. The MicroHs rebuild is guarded inside the script on `mhs` already
 existing, so the `PATH` export still runs on a cache hit.
 
-### 4. Flip `DARC_RUST` to the default, then prune
+### 4. Flip `DARC_RUST` to the default — DONE
 
-In dependency order once the gate above is open:
+The Rust codecs are built and linked by default; `DARC_NO_RUST=1` opts out.
+The opt-out is deliberately kept: CI builds both ways and asserts the archives
+are byte-identical, and that comparison is what licenses deleting the C. Both
+Windows jobs invert the same way, and their uploaded artifacts — the ones the
+interop jobs and the real ARM64 runner exercise — are now the Rust build.
+
+Verified locally: both builds succeed (4.47 MB Rust vs 2.68 MB C-only), the
+binaries differ, and all 24 fingerprints are identical across them.
+
+### 5. Prune, in dependency order:
 
 - **`Compression/Zstd`** (2.2 MB) — the one tree with no blocking gap. The
   wrapper no longer calls it; the makefile still *compiles* it, so that must
@@ -149,10 +158,10 @@ Two mechanical prerequisites, neither done:
 - **Stop `Compression/Zstd/makefile` compiling libzstd.** The wrapper no longer
   calls it, but the makefile still builds the whole tree into `C_Zstd.o`, so the
   directory cannot simply be deleted.
-- **Pin the difftest harnesses to a git revision** (item 5) before any C decoder
+- **Pin the difftest harnesses to a git revision** (item 6) before any C decoder
   goes.
 
-### 5. Preserve the differential-test oracle
+### 6. Preserve the differential-test oracle
 
 11 harnesses and 16 `_ref`/`_ccodec` shims compile the **C** codec as the
 reference Rust is compared against. Deleting the C decoders destroys the only
@@ -160,7 +169,7 @@ thing that can prove Rust ≡ C. Decision taken: **pin the harnesses to a git
 revision** (build the C reference from `git show <sha>:path`) rather than
 keeping a second copy in the tree.
 
-### 6. Port `lz4hc.c` to Rust — blocks pruning `Compression/LZ4`
+### 7. Port `lz4hc.c` to Rust — blocks pruning `Compression/LZ4`
 
 `lz4_flex` has no high-compression mode, and `lz4hc.c` does `#include "lz4.c"`
 for shared code (`lz4hc.c:56-66`), so the two files are a unit: **`lz4.c` cannot
@@ -173,7 +182,7 @@ compression ratio when creating archives (66,063 vs 71,029 bytes on the test
 corpus, ~7.5%). Also needed: `LZ4_compressBound` (trivial formula,
 `C_LZ4.cpp:66`).
 
-### 7. Hand-port PPMD (1,065 lines)
+### 8. Hand-port PPMD (1,065 lines)
 
 The last real hand-portable codec besides 4x4. **No crate path:** `ppmd-rust`
 was measured and rejected — DArc's PPMD is Shkarin var.H with **Subbotin's**
@@ -182,7 +191,7 @@ carryless range coder (32-bit `low`, `TOP=1<<24`, `MAX_O` 128); `ppmd-rust` is
 different stream. Do not revisit the crate. `-mppmd` already has a fingerprint
 case.
 
-### 8. Decide explicitly whether to port 4x4 — recommendation: no
+### 9. Decide explicitly whether to port 4x4 — recommendation: no
 
 Threading meta-codec; its decode delegates to the library dispatcher
 `Decompress()` per block, so the only portable logic is block framing
@@ -192,7 +201,7 @@ exe preset, not this codec). A Rust decode would be an FFI shim calling C
 `Decompress`, which under `DARC_RUST` dispatches back to Rust drop-ins
 (Rust→C→Rust). Record the decision so it is not re-litigated.
 
-### 9. Port the Haskell application layer (17,843 lines, 41 files)
+### 10. Port the Haskell application layer (17,843 lines, 41 files)
 
 The largest remaining piece. Suggested order (from `CLAUDE.md`):
 `Arc.hs:71` (`doMain`) → `Cmdline.hs:35` (`parseCmdline`) → `Arc.hs:110` (`run`)
@@ -224,7 +233,7 @@ Facts that shape the port:
 When this lands, MicroHs and the `compat-ghc`/`compat-oldtime` shims become
 removable too, and the build collapses to cargo.
 
-### 10. Performance: measure before optimising
+### 11. Performance: measure before optimising
 
 Several Rust ports are deliberately scalar where the C is vectorised: BSC's LZP
 and adler32, the QLFC SIMD variants, and the BSC fast coder's SIMD MTF shuffles.
@@ -232,7 +241,7 @@ and adler32, the QLFC SIMD variants, and the BSC fast coder's SIMD MTF shuffles.
 bottleneck. Scalar is a *shipped configuration* of libbsc (i386,
 `-DLIBBSC_NO_UNALIGNED_ACCESS`), not a subset, so correctness is not at issue.
 
-### 11. Deferred C-side bugs (both verified still present)
+### 12. Deferred C-side bugs (both verified still present)
 
 - **ARM64 `ulong32` miscompilation.** `tomcrypt_macros.h:13` types `ulong32` as
   `unsigned` only for `__x86_64__`/sparc64 and `unsigned long` otherwise — 64-bit
@@ -247,7 +256,7 @@ bottleneck. Scalar is a *shipped configuration* of libbsc (i386,
   which ship with correct vectors and would have caught the above on the first
   ARM64 build. Re-enable at least in CI (it will fail until the bug is fixed).
 
-### 12. Build/quality odds and ends
+### 13. Build/quality odds and ends
 
 - **`-mtor` is 35% larger on llvm-mingw builds** (34,771 → 47,043 for the
   identical spec `tor:434kb`; 11 other methods differ by <0.5%). Output is

--- a/compile
+++ b/compile
@@ -57,7 +57,7 @@ if [ -n "${DARC_SANITIZE:-}" ]; then
   export DARC_DEBUG_FLAGS="-g -fsanitize=${DARC_SANITIZE} -fno-omit-frame-pointer"
   echo "sanitizer build: -fsanitize=${DARC_SANITIZE}"
 fi
-# Optional Rust codecs: DARC_RUST=1 ./compile
+# Rust codecs: ON by default. DARC_NO_RUST=1 ./compile builds the C instead.
 #
 # This must run BEFORE any C is compiled. C_Delta.h keys off DARC_RUST, and
 # C_Delta.cpp is built by Compression/compile below -- adding the define after
@@ -66,16 +66,19 @@ fi
 #
 # Builds rust/darc-codecs and links it, and defines DARC_RUST so the affected
 # headers declare their codec entry points extern "C" -- which is what makes the
-# archiver bind to the Rust symbols instead of the C++ ones. Off by default
-# while the port is partial.
+# archiver bind to the Rust symbols instead of the C++ ones.
 #
-# Keeping it a switch rather than a replacement is deliberate: it makes the two
-# implementations directly comparable through the real archiver, so the test
-# suite's archive fingerprints can prove they produce identical bytes.
+# The opt-out is kept rather than removed: it makes the two implementations
+# directly comparable through the real archiver, so the test suite's archive
+# fingerprints can prove they produce identical bytes. That comparison is what
+# licenses deleting the C, so it outlives the switch being "optional".
 rust_lib=""
-if [ -n "${DARC_RUST:-}" ]; then
+# The Rust codecs are ON by default. DARC_NO_RUST=1 opts out and builds the C
+# implementations instead -- kept so CI can build both and prove they produce
+# identical archives, and so a bisect can still reach a pure-C binary.
+if [ -z "${DARC_NO_RUST:-}" ]; then
   command -v cargo >/dev/null 2>&1 || {
-    echo "error: DARC_RUST is set but cargo was not found in PATH" >&2; exit 1; }
+    echo "error: cargo not found in PATH -- it is required to build DArc (set DARC_NO_RUST=1 for a C-only build)" >&2; exit 1; }
   echo "building Rust codecs and crypto"
   ( cd rust && cargo build --release -p darc-codecs -p darc-crypto --features darc-codecs/dropin ) || {
     echo "error: cargo build failed" >&2; exit 1; }

--- a/compile-mhs-win64
+++ b/compile-mhs-win64
@@ -42,11 +42,11 @@ done
 WINOUT=${WINOUT:-/tmp/out/FreeArc-win64-mhs-$arch-$toolchain}
 mkdir -p "$WINOUT"
 
-# ── Optional Rust codecs, cross-compiled for the Windows target ──────────────
+# ── Rust codecs, cross-compiled for the Windows target ──────────────────────
 #
-# DARC_RUST=1 builds rust/darc-codecs + darc-crypto for this target and links
-# them, the same switch ./compile offers natively. This must run BEFORE any C is
-# compiled: the codec headers key off DARC_RUST, so adding the define after
+# Builds rust/darc-codecs + darc-crypto for this target and links them. This is
+# the default; DARC_NO_RUST=1 opts out. It must run BEFORE any C is compiled:
+# the codec headers key off DARC_RUST, so adding the define after
 # compile-win64-c would leave the C++ symbols bound while the staticlibs sat
 # unused in the link -- the mistake ./compile documents at length.
 #
@@ -63,9 +63,10 @@ mkdir -p "$WINOUT"
 # long-width family of bugs this repository has fixed a dozen times, so the
 # target is passed explicitly rather than left to default.
 rust_libs=""
-if [ -n "${DARC_RUST:-}" ]; then
+# ON by default; DARC_NO_RUST=1 opts out. See ./compile.
+if [ -z "${DARC_NO_RUST:-}" ]; then
   command -v cargo >/dev/null 2>&1 ||
-    { echo "error: DARC_RUST is set but cargo was not found in PATH" >&2; exit 1; }
+    { echo "error: cargo not found in PATH -- it is required to build DArc (set DARC_NO_RUST=1 for a C-only build)" >&2; exit 1; }
 
   case "$arch" in
     x86_64)  rust_target="x86_64-pc-windows-gnu"      ;;
@@ -167,7 +168,7 @@ MHS=1 WINOUT="$WINOUT" DARC_WIN_ARCH="$arch" DARC_WIN_TOOLCHAIN="$toolchain" ./c
 # 3) MHS cross-compile setup
 # mhs targets.conf has [environment] block that pulls cc/ccflags/cclibs/conf from env vars
 defines="-DFREEARC_WIN -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT -DFREEARC_NOURL -DFREEARC_NO_LUA"
-[ -n "${DARC_RUST:-}" ] && defines="$defines -DDARC_RUST"
+[ -z "${DARC_NO_RUST:-}" ] && defines="$defines -DDARC_RUST"
 
 c_objs=(
   "$WINOUT/Environment.o" "$WINOUT/URL.o" "$WINOUT/Common.o"
@@ -211,7 +212,7 @@ win_libs="-static $cxx_libs -lwinpthread -lwinmm -lws2_32 -ladvapi32 -lshell32 -
 # bcrypt. Without these the link fails with a wall of "undefined reference to
 # NtOpenFile / RtlNtStatusToDosError". Only added under DARC_RUST so the pure-C
 # link line stays exactly as it was.
-[ -n "${DARC_RUST:-}" ] && win_libs="$win_libs -lntdll -luserenv -lbcrypt"
+[ -z "${DARC_NO_RUST:-}" ] && win_libs="$win_libs -lntdll -luserenv -lbcrypt"
 
 # Build MHSCCLIBS from C objects (one space-separated string)
 linker_inputs=""

--- a/compile-win64-c
+++ b/compile-win64-c
@@ -60,7 +60,7 @@ command -v "$CC" >/dev/null 2>&1 ||
 # the Rust staticlib. Compiling them without it binds the C implementations and
 # leaves the staticlib unused in the link -- the failure ./compile documents.
 RUST_DEF=""
-[[ -n "${DARC_RUST:-}" ]] && RUST_DEF="-DDARC_RUST"
+[[ -z "${DARC_NO_RUST:-}" ]] && RUST_DEF="-DDARC_RUST"
 
 MHS_DEF=""
 if [[ -n "${MHS:-}" ]]; then


### PR DESCRIPTION
Every shipped build path now builds and links the Rust codecs — proven by CI across linux ×2, macOS, windows-amd64 (Wine-exercised) and windows-arm64 (real hardware). So the switch flips: `./compile` and `compile-mhs-win64` use Rust by default, and **`DARC_NO_RUST=1`** selects the C implementations.

This is the gate for deleting C. Nothing is deleted here.

## Why the opt-out stays

CI builds both ways and asserts the **archives are byte-identical**. That comparison is what licenses deleting the C at all, so it outlives the switch being "optional" — and it keeps a pure-C binary reachable for a bisect.

## Two ordering bugs the flip would otherwise have introduced

Both found by reading the job order rather than by CI, and both fixed here:

- **The Windows jobs set Rust up *after* their first build.** Harmless while that build was C-only; now it is the Rust one. The toolchain — and a cargo cache, which those jobs never had — has to precede it.
- **The Windows artifacts are now the Rust build.** They are what the interop jobs and the real `windows-11-arm` runner exercise, which is an improvement, but it means the C build is now produced solely to assert the two differ, with the Rust binary restored afterwards so the artifact remains the thing under test.

Also drops a Wine smoke-test that re-ran a binary an earlier step had already exercised, and the `targets:` inputs on the toolchain actions (`rust-toolchain.toml` supplies those).

## Verification

Locally, both modes built and compared:

| | |
|---|---|
| default (Rust) | 4,473,984 bytes |
| `DARC_NO_RUST=1` | 2,677,440 bytes |
| binaries differ | yes — staticlibs genuinely linked |
| round-trips | 24/24 both |
| **archive fingerprints** | **all 24 identical across the two builds** |

## What this unblocks

Per `RUST_PORT_PROGRESS.md`, the remaining prerequisites before the first C actually goes: stop `Compression/Zstd/makefile` compiling libzstd, and pin the 11 difftest harnesses to a git revision so they keep their C oracle. Then `Compression/Zstd` — 2.2 MB — is the first tree deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)