### PR TITLE
difftest: take the C reference from a pinned revision

### DIFF
--- a/RUST_PORT_PROGRESS.md
+++ b/RUST_PORT_PROGRESS.md
@@ -174,13 +174,25 @@ Two mechanical prerequisites, neither done:
 - **Pin the difftest harnesses to a git revision** (item 6) before any C decoder
   goes.
 
-### 6. Preserve the differential-test oracle
+### 6. Preserve the differential-test oracle — DONE
 
-11 harnesses and 16 `_ref`/`_ccodec` shims compile the **C** codec as the
-reference Rust is compared against. Deleting the C decoders destroys the only
-thing that can prove Rust ≡ C. Decision taken: **pin the harnesses to a git
-revision** (build the C reference from `git show <sha>:path`) rather than
-keeping a second copy in the tree.
+`rust/difftest/c-reference.sh` extracts `Compression/` at a pinned revision
+(`DARC_C_REF_SHA`) with `git archive`, copies the CURRENT shims in beside it so
+their `#include "../../Compression/..."` paths resolve into the pinned tree, and
+exports `CREF`. The ten Compression-based harnesses compile their C reference
+from `$CREF` while the Rust staticlib and harness logic stay current.
+`srep-check.sh` is deliberately excluded: its oracle is the `srep` **binary**
+from `srep/compile`, not sources under `Compression/`.
+
+The reference is **always** the pinned revision, even while the C is still in
+the tree. A fallback that only engaged after deletion would sit untested until
+it became load-bearing — how the MicroHs cache guard shipped broken. A fixed
+oracle also cannot drift, so a concurrent C change cannot mask a Rust
+regression.
+
+Verified by deleting `rep.cpp`, `Delta.cpp` and `dict.cpp` from the working
+tree and re-running: all harnesses still pass. Bumping `DARC_C_REF_SHA` changes
+what "correct" means for every harness, so it is a deliberate act.
 
 ### 7. Port `lz4hc.c` to Rust — blocks pruning `Compression/LZ4`
 

--- a/rust/difftest/bsc-bwt-check.sh
+++ b/rust/difftest/bsc-bwt-check.sh
@@ -14,6 +14,10 @@
 # decode surface, so both must be exercised (the "path never reached" trap).
 set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# The C reference comes from a pinned revision, not the working tree -- see
+# c-reference.sh for why.
+. "$ROOT/rust/difftest/c-reference.sh"
+CREF="$(darc_c_reference "$ROOT")" || exit 1
 W="${TMPDIR:-/tmp}/bsc-bwt-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -25,9 +29,9 @@ LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 # trails the sources so it links on GNU ld.
 cc() { local out="$1"; shift
   clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
-    -I"$ROOT" -I"$ROOT/Compression" \
-    "$ROOT/rust/difftest/bsc_bwt_ref.cpp" "$ROOT/rust/difftest/bsc_ccodec.cpp" \
-    "$ROOT/Compression/BSC/libbsc/bwt/libsais/libsais.c" "$@" -o "$out"; }
+    -I"$CREF" -I"$CREF/Compression" \
+    "$CREF/rust/difftest/bsc_bwt_ref.cpp" "$CREF/rust/difftest/bsc_ccodec.cpp" \
+    "$CREF/Compression/BSC/libbsc/bwt/libsais/libsais.c" "$@" -o "$out"; }
 cc "$W/c"                    || exit 1
 cc "$W/rs" -DUSE_RUST "$LIB" || exit 1
 

--- a/rust/difftest/bsc-check.sh
+++ b/rust/difftest/bsc-check.sh
@@ -13,6 +13,10 @@
 # mixer). All three are ported.
 set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# The C reference comes from a pinned revision, not the working tree -- see
+# c-reference.sh for why.
+. "$ROOT/rust/difftest/c-reference.sh"
+CREF="$(darc_c_reference "$ROOT")" || exit 1
 W="${TMPDIR:-/tmp}/bsc-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -24,9 +28,9 @@ LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 # args land after the sources so the Rust staticlib links on GNU ld.
 cc() { local out="$1"; shift
   clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
-    -I"$ROOT" -I"$ROOT/Compression" \
-    "$ROOT/rust/difftest/bsc_ref.cpp" "$ROOT/rust/difftest/bsc_ccodec.cpp" \
-    "$ROOT/Compression/BSC/libbsc/bwt/libsais/libsais.c" "$@" -o "$out"; }
+    -I"$CREF" -I"$CREF/Compression" \
+    "$CREF/rust/difftest/bsc_ref.cpp" "$CREF/rust/difftest/bsc_ccodec.cpp" \
+    "$CREF/Compression/BSC/libbsc/bwt/libsais/libsais.c" "$@" -o "$out"; }
 cc "$W/c"                    || exit 1
 cc "$W/rs" -DUSE_RUST "$LIB" || exit 1
 

--- a/rust/difftest/bsc-full-check.sh
+++ b/rust/difftest/bsc-full-check.sh
@@ -13,6 +13,10 @@
 # a failure. All three coders (static, adaptive, fast) are covered.
 set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# The C reference comes from a pinned revision, not the working tree -- see
+# c-reference.sh for why.
+. "$ROOT/rust/difftest/c-reference.sh"
+CREF="$(darc_c_reference "$ROOT")" || exit 1
 W="${TMPDIR:-/tmp}/bsc-full-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -22,9 +26,9 @@ LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 
 cc() { local out="$1"; shift
   clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
-    -I"$ROOT" -I"$ROOT/Compression" \
-    "$ROOT/rust/difftest/bsc_full_ref.cpp" "$ROOT/rust/difftest/bsc_ccodec.cpp" \
-    "$ROOT/Compression/BSC/libbsc/bwt/libsais/libsais.c" "$@" -o "$out"; }
+    -I"$CREF" -I"$CREF/Compression" \
+    "$CREF/rust/difftest/bsc_full_ref.cpp" "$CREF/rust/difftest/bsc_ccodec.cpp" \
+    "$CREF/Compression/BSC/libbsc/bwt/libsais/libsais.c" "$@" -o "$out"; }
 cc "$W/c"                    || exit 1
 cc "$W/rs" -DUSE_RUST "$LIB" || exit 1
 

--- a/rust/difftest/bsc-st-check.sh
+++ b/rust/difftest/bsc-st-check.sh
@@ -18,6 +18,10 @@
 # highly-repetitive inputs to trigger.
 set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# The C reference comes from a pinned revision, not the working tree -- see
+# c-reference.sh for why.
+. "$ROOT/rust/difftest/c-reference.sh"
+CREF="$(darc_c_reference "$ROOT")" || exit 1
 W="${TMPDIR:-/tmp}/bsc-st-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -27,9 +31,9 @@ LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 
 cc() { local out="$1"; shift
   clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
-    -I"$ROOT" -I"$ROOT/Compression" \
-    "$ROOT/rust/difftest/bsc_st_ref.cpp" "$ROOT/rust/difftest/bsc_ccodec.cpp" \
-    "$ROOT/Compression/BSC/libbsc/bwt/libsais/libsais.c" "$@" -o "$out"; }
+    -I"$CREF" -I"$CREF/Compression" \
+    "$CREF/rust/difftest/bsc_st_ref.cpp" "$CREF/rust/difftest/bsc_ccodec.cpp" \
+    "$CREF/Compression/BSC/libbsc/bwt/libsais/libsais.c" "$@" -o "$out"; }
 cc "$W/c"                    || exit 1
 cc "$W/rs" -DUSE_RUST "$LIB" || exit 1
 

--- a/rust/difftest/c-reference.sh
+++ b/rust/difftest/c-reference.sh
@@ -1,0 +1,59 @@
+# Materialise the C codec sources at a pinned revision, for the differential
+# harnesses to compile as their reference. Sourced, not executed.
+#
+# ── Why ──────────────────────────────────────────────────────────────────────
+#
+# Every <codec>-check.sh proves the Rust port matches the C by compiling BOTH
+# and requiring identical output. As the port deletes the C it replaces, that
+# reference disappears from the working tree — and with it the only thing that
+# can demonstrate a replacement is correct. So the C is taken from git history
+# instead of from the checkout.
+#
+# The reference is ALWAYS the pinned revision, even while the C is still present
+# in the tree. Two reasons:
+#
+#   * A fallback that only engages once the C is deleted would sit untested
+#     until the moment it becomes load-bearing. That is exactly how the MicroHs
+#     cache guard shipped broken — the run that introduced it populated the
+#     cache rather than restoring it, so it never took the path it broke.
+#   * A fixed oracle cannot drift. Comparing against whatever C happens to be in
+#     the tree lets a concurrent C change mask a Rust regression.
+#
+# ── How ──────────────────────────────────────────────────────────────────────
+#
+# `git archive` extracts Compression/ at the pinned SHA, then the CURRENT
+# difftest shims are copied in beside it. That combination matters: the shims
+# `#include "../../Compression/..."` by relative path, so placing them inside
+# the extracted tree makes those includes resolve to the pinned C with no source
+# edits at all, while leaving the harness logic itself free to evolve.
+#
+# Bumping the pin is a deliberate act: it changes what "correct" means for every
+# harness. Do it only to pick up a genuine C-side fix, and say so in the commit.
+
+# Last revision containing the full C codec set (zstd's libzstd was removed in
+# 5c2c6ce itself, and has no harness).
+DARC_C_REF_SHA="5c2c6ce"
+
+# Usage: darc_c_reference <repo-root>   → echoes the reference tree's path
+darc_c_reference() {
+  local root="$1"
+  local sha="$DARC_C_REF_SHA"
+  local cref="${TMPDIR:-/tmp}/darc-c-ref-$sha"
+
+  # Rebuild the shim copy every time (cheap, and the shims are live source);
+  # extract the pinned C only once.
+  if [ ! -d "$cref/Compression" ]; then
+    rm -rf "$cref"; mkdir -p "$cref"
+    git -C "$root" rev-parse --verify --quiet "$sha^{commit}" >/dev/null || {
+      echo "c-reference: pinned revision $sha not found -- fetch history first" >&2
+      return 1; }
+    git -C "$root" archive "$sha" Compression | tar -x -C "$cref" || {
+      echo "c-reference: could not extract Compression/ at $sha" >&2
+      return 1; }
+  fi
+
+  mkdir -p "$cref/rust/difftest"
+  cp "$root"/rust/difftest/*.cpp "$cref/rust/difftest/" 2>/dev/null
+
+  echo "$cref"
+}

--- a/rust/difftest/c-reference.sh
+++ b/rust/difftest/c-reference.sh
@@ -31,8 +31,13 @@
 # harness. Do it only to pick up a genuine C-side fix, and say so in the commit.
 
 # Last revision containing the full C codec set (zstd's libzstd was removed in
-# 5c2c6ce itself, and has no harness).
-DARC_C_REF_SHA="5c2c6ce"
+# this commit itself, and has no harness).
+#
+# The FULL 40-character hash, not an abbreviation: `git fetch origin <sha>`
+# rejects a short SHA outright ("couldn't find remote ref"), which is how the
+# shallow-clone fetch below is able to work at all. Abbreviations can also grow
+# ambiguous as history does.
+DARC_C_REF_SHA="5c2c6ce1244db759a17aea61cb243f3ace41fe61"
 
 # Usage: darc_c_reference <repo-root>   → echoes the reference tree's path
 darc_c_reference() {
@@ -44,8 +49,15 @@ darc_c_reference() {
   # extract the pinned C only once.
   if [ ! -d "$cref/Compression" ]; then
     rm -rf "$cref"; mkdir -p "$cref"
+    # CI checks out shallow (actions/checkout defaults to fetch-depth: 1), so
+    # the pinned commit is usually absent. Fetch just that one commit rather
+    # than making every job clone full history.
+    if ! git -C "$root" rev-parse --verify --quiet "$sha^{commit}" >/dev/null; then
+      git -C "$root" fetch --depth=1 --quiet origin "$sha" 2>/dev/null || true
+    fi
     git -C "$root" rev-parse --verify --quiet "$sha^{commit}" >/dev/null || {
-      echo "c-reference: pinned revision $sha not found -- fetch history first" >&2
+      echo "c-reference: pinned revision $sha is not available and could not be" >&2
+      echo "fetched. In CI, give the checkout enough history (fetch-depth: 0)." >&2
       return 1; }
     git -C "$root" archive "$sha" Compression | tar -x -C "$cref" || {
       echo "c-reference: could not extract Compression/ at $sha" >&2

--- a/rust/difftest/dispack-check.sh
+++ b/rust/difftest/dispack-check.sh
@@ -12,6 +12,10 @@
 # code inputs, so the filtered path is genuinely on the critical path here.
 set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# The C reference comes from a pinned revision, not the working tree -- see
+# c-reference.sh for why.
+. "$ROOT/rust/difftest/c-reference.sh"
+CREF="$(darc_c_reference "$ROOT")" || exit 1
 W="${TMPDIR:-/tmp}/dispack-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -21,9 +25,9 @@ LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 
 cc() { local out="$1"; shift
   clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
-    -I"$ROOT" -I"$ROOT/Compression" \
-    "$ROOT/rust/difftest/dispack_ref.cpp" "$ROOT/rust/difftest/dispack_ccodec.cpp" \
-    "$ROOT/Compression/Common.cpp" "$@" -o "$out"; }
+    -I"$CREF" -I"$CREF/Compression" \
+    "$CREF/rust/difftest/dispack_ref.cpp" "$CREF/rust/difftest/dispack_ccodec.cpp" \
+    "$CREF/Compression/Common.cpp" "$@" -o "$out"; }
 cc "$W/c"                    || exit 1
 cc "$W/rs" -DUSE_RUST "$LIB" || exit 1
 

--- a/rust/difftest/grzip-check.sh
+++ b/rust/difftest/grzip-check.sh
@@ -11,6 +11,10 @@
 # four transform/coder combinations are covered, with LZP off and on.
 set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# The C reference comes from a pinned revision, not the working tree -- see
+# c-reference.sh for why.
+. "$ROOT/rust/difftest/c-reference.sh"
+CREF="$(darc_c_reference "$ROOT")" || exit 1
 W="${TMPDIR:-/tmp}/grzip-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -22,9 +26,9 @@ LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 # only the objects already seen, so a library placed first is silently dropped.
 cc() { local out="$1"; shift
   clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
-    -I"$ROOT" -I"$ROOT/Compression" \
-    "$ROOT/rust/difftest/grzip_ref.cpp" "$ROOT/rust/difftest/grzip_ccodec.cpp" \
-    "$ROOT/Compression/Common.cpp" "$@" -o "$out"; }
+    -I"$CREF" -I"$CREF/Compression" \
+    "$CREF/rust/difftest/grzip_ref.cpp" "$CREF/rust/difftest/grzip_ccodec.cpp" \
+    "$CREF/Compression/Common.cpp" "$@" -o "$out"; }
 cc "$W/c"                    || exit 1
 cc "$W/rs" -DUSE_RUST "$LIB" || exit 1
 

--- a/rust/difftest/mm-check.sh
+++ b/rust/difftest/mm-check.sh
@@ -13,6 +13,10 @@
 # block boundary -- the one piece of state that spans the whole stream.
 set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# The C reference comes from a pinned revision, not the working tree -- see
+# c-reference.sh for why.
+. "$ROOT/rust/difftest/c-reference.sh"
+CREF="$(darc_c_reference "$ROOT")" || exit 1
 W="${TMPDIR:-/tmp}/mm-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -27,9 +31,9 @@ LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 cc() { # cc <output> [args appended after the sources]
   local out="$1"; shift
   clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
-    -I"$ROOT" -I"$ROOT/Compression" \
-    "$ROOT/rust/difftest/mm_ref.cpp" "$ROOT/rust/difftest/mm_ccodec.cpp" \
-    "$ROOT/Compression/Common.cpp" "$@" -o "$out"
+    -I"$CREF" -I"$CREF/Compression" \
+    "$CREF/rust/difftest/mm_ref.cpp" "$CREF/rust/difftest/mm_ccodec.cpp" \
+    "$CREF/Compression/Common.cpp" "$@" -o "$out"
 }
 cc "$W/c"                    || exit 1
 cc "$W/rs" -DUSE_RUST "$LIB" || exit 1

--- a/rust/difftest/rep-check.sh
+++ b/rust/difftest/rep-check.sh
@@ -7,6 +7,10 @@
 # defines an archive format.
 set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# The C reference comes from a pinned revision, not the working tree -- see
+# c-reference.sh for why.
+. "$ROOT/rust/difftest/c-reference.sh"
+CREF="$(darc_c_reference "$ROOT")" || exit 1
 W="${TMPDIR:-/tmp}/rep-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -22,9 +26,9 @@ LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 cc() { # cc <output> [args appended after the sources]
   local out="$1"; shift
   clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
-    -DREP_LIBRARY -I"$ROOT" -I"$ROOT/Compression" \
-    "$ROOT/rust/difftest/rep_ref.cpp" "$ROOT/Compression/REP/rep.cpp" \
-    "$ROOT/Compression/Common.cpp" "$@" -o "$out"
+    -DREP_LIBRARY -I"$CREF" -I"$CREF/Compression" \
+    "$CREF/rust/difftest/rep_ref.cpp" "$CREF/Compression/REP/rep.cpp" \
+    "$CREF/Compression/Common.cpp" "$@" -o "$out"
 }
 cc "$W/c"                    || exit 1
 cc "$W/rs" -DUSE_RUST "$LIB" || exit 1

--- a/rust/difftest/srep-check.sh
+++ b/rust/difftest/srep-check.sh
@@ -35,6 +35,8 @@
 # block silently tests nothing that matters.
 set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# No c-reference.sh here: SREP's oracle is the `srep` BINARY built from
+# srep/compile, not sources under Compression/, and srep/ is not being deleted.
 W="${TMPDIR:-/tmp}/srep-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 

--- a/rust/difftest/tornado-check.sh
+++ b/rust/difftest/tornado-check.sh
@@ -12,6 +12,10 @@
 # nothing else, so a corpus that skips any of them proves little.
 set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# The C reference comes from a pinned revision, not the working tree -- see
+# c-reference.sh for why.
+. "$ROOT/rust/difftest/c-reference.sh"
+CREF="$(darc_c_reference "$ROOT")" || exit 1
 W="${TMPDIR:-/tmp}/tornado-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -23,9 +27,9 @@ LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 # only the objects already seen, so a library placed first is silently dropped.
 cc() { local out="$1"; shift
   clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
-    -I"$ROOT" -I"$ROOT/Compression" \
-    "$ROOT/rust/difftest/tornado_ref.cpp" "$ROOT/rust/difftest/tornado_ccodec.cpp" \
-    "$ROOT/Compression/Common.cpp" "$@" -o "$out"; }
+    -I"$CREF" -I"$CREF/Compression" \
+    "$CREF/rust/difftest/tornado_ref.cpp" "$CREF/rust/difftest/tornado_ccodec.cpp" \
+    "$CREF/Compression/Common.cpp" "$@" -o "$out"; }
 cc "$W/c"                    || exit 1
 cc "$W/rs" -DUSE_RUST "$LIB" || exit 1
 

--- a/rust/difftest/tta-check.sh
+++ b/rust/difftest/tta-check.sh
@@ -8,6 +8,10 @@
 # format.
 set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# The C reference comes from a pinned revision, not the working tree -- see
+# c-reference.sh for why.
+. "$ROOT/rust/difftest/c-reference.sh"
+CREF="$(darc_c_reference "$ROOT")" || exit 1
 W="${TMPDIR:-/tmp}/tta-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -23,10 +27,10 @@ LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 cc() { # cc <output> [args appended after the sources]
   local out="$1"; shift
   clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
-    -I"$ROOT" -I"$ROOT/Compression" \
-    "$ROOT/rust/difftest/tta_ref.cpp" "$ROOT/rust/difftest/tta_ccodec.cpp" \
-    "$ROOT/rust/difftest/mmdet_ccodec.cpp" \
-    "$ROOT/Compression/Common.cpp" "$@" -o "$out"
+    -I"$CREF" -I"$CREF/Compression" \
+    "$CREF/rust/difftest/tta_ref.cpp" "$CREF/rust/difftest/tta_ccodec.cpp" \
+    "$CREF/rust/difftest/mmdet_ccodec.cpp" \
+    "$CREF/Compression/Common.cpp" "$@" -o "$out"
 }
 cc "$W/c"                    || exit 1
 cc "$W/rs" -DUSE_RUST "$LIB" || exit 1


### PR DESCRIPTION
The differential harnesses prove the Rust port matches the C by compiling **both**. As the port deletes the C it replaces, that reference leaves the working tree — and with it the only thing that can show a replacement is correct. Deleting Delta, Dict and REP would have silently taken their harnesses with them.

This is the prerequisite for the next deletion. Nothing is deleted here.

## How

`rust/difftest/c-reference.sh` extracts `Compression/` at a pinned SHA with `git archive`, then copies the **current** shims in beside it.

That combination is what makes this need **no source edits**: the shims `#include "../../Compression/..."` by relative path (32 sites), so placing them inside the extracted tree resolves those to the pinned C — while the harness logic itself stays free to evolve. The Rust staticlib and the cargo build keep pointing at the working tree, so the port under test is always current.

## Always pinned, not "pinned once the C is gone"

Two reasons, both learned the hard way in this repo:

- A fallback that only engaged after deletion would sit **untested until it became load-bearing** — exactly how the MicroHs cache guard shipped broken, its introducing run populating the cache rather than restoring it.
- A **fixed** oracle cannot drift. Comparing against whatever C happens to be in the tree would let a concurrent C change mask a Rust regression.

Bumping `DARC_C_REF_SHA` therefore changes what "correct" means for every harness, and is a deliberate act.

## Scope

Ten harnesses converted. **`srep-check.sh` deliberately left alone** — its oracle is the `srep` *binary* built by `srep/compile`, not sources under `Compression/`, and `srep/` is not being deleted. Adding the dependency there would have been dead weight.

## Verification

| check | result |
|---|---|
| all ten harnesses vs the pinned reference | pass |
| **with `rep.cpp`, `Delta.cpp`, `dict.cpp` deleted from the tree** | **still pass** |

That second row is the property the next deletion depends on, so it is tested directly rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)