### PR TITLE
SREP: fix a heap overflow that intermittently produced corrupt archives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ cabal.project.local~
 Tests/*arc
 # Standalone SREP binary, produced by srep/compile (external compressor per arc.ini)
 Tests/srep
+# ...and the debug bundle a sanitizer build leaves beside it. `Tests/srep`
+# does not match a `.dSYM` directory, so `git add -A` once swept 964 KB of
+# DWARF into a commit.
+Tests/*.dSYM/
 common.mak
 *_stub.h
 *.comb

--- a/Compression/SREP/hash_table.cpp
+++ b/Compression/SREP/hash_table.cpp
@@ -34,7 +34,17 @@ struct SliceHash
     check_slices    = int((MIN_MATCH-L)/slice_size) - io_accelerator;  // if less that this amount of slices around match has the same hashes, then we are sure that match can't be extended to MIN_MATCH size
     if (io_accelerator<0 || check_slices<=0)
          memreq = 0;                                                   // no need in SliceHash since each potential match is almost guaranteed to have MIN_MATCH matched bytes
-    else memreq = filesize/L * sizeof(entry);                          // one `entry` per L input bytes
+    // One `entry` per L input bytes, ROUNDED UP. `filesize/L` truncates, so a
+    // file whose size is not a multiple of L got no slot for its final partial
+    // chunk, and prepare_buffer() -- which indexes by offset/L -- wrote one
+    // entry past the end of h[].
+    //
+    // This corrupts the heap rather than crashing, so the visible symptom was an
+    // srep archive that failed its own checksum on decompression, intermittently
+    // (~1-6% of runs, depending on heap layout). Caught by ASan:
+    //   WRITE of size 4 ... 0 bytes after 876-byte region, SliceHash::prepare_buffer
+    // with filesize=900000, L=4096 -> 219 entries allocated, chunk 219 written.
+    else memreq = (filesize/L + 1) * sizeof(entry);
   }
 
   // Actual memory allocation (should be performed after allocation of more frequently accessed arrays of the HashTable)


### PR DESCRIPTION
The `srep-check.sh` harness failed intermittently in CI (`[-m1f -b16kb] farapart: C-decompress FAILED`). It is **not a flaky test** — the C compressor was writing corrupt archives.

## The bug

`SliceHash` stores one entry per `L` input bytes, indexed by `offset/L`, but sized the array with a **truncating** division:

```c
memreq = filesize/L * sizeof(entry);
```

A file whose size isn't a multiple of `L` gets no slot for its final partial chunk, so `SliceHash::prepare_buffer` writes one entry past the end of `h[]`. Rounding up fixes it.

It corrupts the heap rather than crashing, which is why the symptom was an archive that failed **its own checksum** on decompression, intermittently, depending on heap layout.

## Why it matters beyond the harness

DArc invokes `srep` as an external compressor, so a `-msrep` archive could contain a stream that will not extract. The checksum catches it at decompress time, so this is not silent data loss — but it is an **unextractable archive produced by a compress that reported success**.

## Diagnosis

- 2/30, then 1/100 compress→decompress cycles failed on `-m1f -b16kb` over a 900,000-byte input.
- The bad archive had the **same size** but different bytes, and failed *deterministically* on retry — so the compressor, not the decompressor. Decompressing a fixed archive 400 times never failed.
- ASan located it on the first run:

```
WRITE of size 4 ... 0 bytes after 876-byte region
  SliceHash::prepare_buffer  hash_table.cpp:68
  BG_COMPRESSION_THREAD::run io.cpp:154
```

876 bytes = 219 `uint32` entries. With `filesize=900000, L=4096`: `900000/4096` = 219 allocated, but `ceil()` = 220 chunks, so chunk 219 overflows. The report matches the arithmetic exactly.

## Two hypotheses ruled out

Recorded so they aren't re-tried:

- **Not** the fixed-name temp files (`srep-data.tmp`, `srep-virtual-memory.tmp`, both relative to CWD) — none were present at the failure, and decompressing a fixed archive 400× never failed.
- **Not** a threading race — `-t1` reproduces it at the same rate.

## Verified

| | |
|---|---|
| ASan | clean over 40 runs (was: report on run 1) |
| 400 compress→decompress cycles | 0 corrupt archives, 0 round-trip failures |
| output unchanged | all 400 match the known-good hash, so no behaviour change where no overflow occurred |
| `rust/difftest/srep-check.sh` | green, v1–v4 |

Also adds `Tests/*.dSYM/` to `.gitignore`: `Tests/srep` doesn't match a `.dSYM` directory, and `git add -A` swept 964 KB of DWARF into a commit while preparing this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)