### PR TITLE
DisPack: port the forward filter (the encoder) to Rust

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -830,6 +830,11 @@ jobs:
         rust/difftest/tornado-check.sh
         rust/difftest/grzip-check.sh
         rust/difftest/dispack-check.sh
+        # The other direction: DisPack's ENCODER must be byte-exact too, since
+        # DisPack is one of DArc's own formats. Filtered output that merely
+        # round-trips through our own decoder would still make archives that
+        # older builds read differently.
+        rust/difftest/dispack-filter-check.sh
         # LZP is ported in BOTH directions and its C is deleted, so this is the
         # only remaining oracle for it -- and it had no check script at all
         # until the C was pruned (lzp_ref.cpp sat orphaned; run.sh covers Delta).

--- a/Compression/DisPack/C_DisPack.cpp
+++ b/Compression/DisPack/C_DisPack.cpp
@@ -7,6 +7,15 @@ extern "C" {
 #include "C_DisPack.h"
 }
 
+#ifdef DARC_RUST
+// The Rust forward filter (rust/darc-codecs/src/dispack/encode.rs), verified
+// byte-identical to DisFilter over 76 comparisons across four load origins --
+// see rust/difftest/dispack-filter-check.sh. The decoder already comes from
+// Rust; this is the other half.
+extern "C" int darc_rs_dispack_filter (const unsigned char *src, int srcSize,
+                                       unsigned origin, unsigned char *dst, int dstCap);
+#endif
+
 // Compatibility shims for macros that exist in FreeArc 0.67 but not in DArc.
 #ifndef BIGALLOC
 #define BIGALLOC(type, ptr, size)                                          \
@@ -186,8 +195,22 @@ int DISPACK_METHOD::compress (CALLBACK_FUNC *callback, void *auxdata)
         if (InSize)
         {
             // Encode the executable code
+#ifdef DARC_RUST
+            // Worst case is every input byte escaping to two, plus the ST_MAX
+            // header words. DisFilter allocates its own buffer, so this branch
+            // allocates one to match and the shared free() below still applies.
+            {
+                int cap = InSize*2 + 4096;
+                Out = (BYTE*) malloc (cap);
+                if (Out==NULL)  ReturnErrorCode(FREEARC_ERRCODE_NOT_ENOUGH_MEMORY);
+                int n = darc_rs_dispack_filter (In, InSize, BaseAddress, Out, cap);
+                if (n < 0)  {free(Out); Out=NULL; ReturnErrorCode(FREEARC_ERRCODE_GENERAL);}
+                OutSize = n;
+            }
+#else
             Out = DisFilter(In, InSize, BaseAddress, OutSize);
             if (Out==NULL)  ReturnErrorCode(FREEARC_ERRCODE_NOT_ENOUGH_MEMORY);
+#endif
             WRITE4 (TAG_EXE);
             WRITE4 (InSize);
             WRITE4 (OutSize);

--- a/RUST_PORT_PROGRESS.md
+++ b/RUST_PORT_PROGRESS.md
@@ -293,7 +293,7 @@ not a thin corpus — at a given position every candidate path shares the same
 inputs were built specifically to break that (`priced`, `competing`) and did
 not. Those three lines are verified by transcription against the C only.
 
-### 8. Port the DisPack ENCODER — reconnaissance done, port not started
+### 8. Port the DisPack ENCODER — DONE
 
 The first encoder to take, and the only one whose completion deletes a whole
 directory. Cheaper than `DisPack.cpp`'s 31 KB suggests: most of that file is
@@ -310,6 +310,26 @@ clean rather than surgical:
 | `DisFilterCtx` | 371-599 | `DetectJumpTable`, `ProcessInstr` (418-564, the bulk), `Flush` (565-598) |
 | `DisFilter` | 600-654 | driver: main loop, then a checkpoint/undo tail so the last `MAXINSTR` bytes never read past the end, then escape-encodes any remainder |
 | `detect()` | `C_DisPack.cpp:142` | ~35 lines, EXE-type detection that decides whether to filter at all |
+
+**Result: byte-identical to the C over 76 comparisons across four load
+origins**, and the `dispack` fingerprint `6a46351e39373082` is unchanged, so
+archives are the same end to end. Wired under `DARC_RUST` in `C_DisPack.cpp`;
+the C `DisFilter` stays for `DARC_NO_RUST` until the directory is deleted.
+
+Seven sabotages, all caught — but **two were blind until the corpus was fixed,
+and the second fix needed a mechanism, not more data**:
+
+- *Jump-table threshold 3→2* was unobservable because the corpus had only a
+  run of 64 **consecutive** in-range dwords, which both thresholds accept
+  identically. Only a run of **exactly two** distinguishes them.
+- *MTF search bound 255→254* survived a first attempt that simply threw 400
+  distinct targets at it: every distinct target is a **miss**, so `find_mtf`
+  never returns a hit and the bound is unreachable. It only matters on a lookup
+  landing at exactly index 254. `add_mtf` pushes to the front, so inserting
+  `t0..t299` leaves `mtf[k] == t(299-k)` and puts `t45` at 254; referencing
+  `t45` next is found with the real bound and missed with a smaller one. The
+  catch confirms it exactly — 1581 vs 1585 bytes, the four extra bytes of a
+  full address where a one-byte index belonged.
 
 Two things to get right, both already known from the decode port:
 

--- a/rust/darc-codecs/src/dispack/encode.rs
+++ b/rust/darc-codecs/src/dispack/encode.rs
@@ -1,0 +1,447 @@
+//! DisPack forward filter -- `DisFilter` and `DisFilterCtx` (`DisPack.cpp:328-654`).
+//!
+//! The mirror of [`super::filter`]. Where the decoder reassembles one
+//! instruction stream from `ST_MAX` parallel byte streams, this splits it: the
+//! opcode goes to `ST_OP`, a byte displacement to whichever `ST_DISP8_Rn`
+//! matches the register, an immediate to `ST_IMM8/16/32`, and so on. Grouping
+//! like with like is the whole trick -- the entropy coder downstream sees runs
+//! of similar bytes instead of interleaved instruction fields.
+//!
+//! Two transforms go beyond splitting, and both are why this must be
+//! byte-exact rather than merely reversible:
+//!
+//! * **Relative call/jump targets become absolute.** The same callee reached
+//!   from different call sites has a different relative displacement each time
+//!   but one absolute address, which compresses far better.
+//! * **Call targets are then MTF-coded.** A recently-called function costs one
+//!   index byte in `ST_CALL_IDX` instead of four address bytes in `ST_CALL32`.
+//!
+//! ## Endianness is asymmetric, and deliberately so
+//!
+//! The instruction stream is x86, so operands are read **little-endian**
+//! (`Fetch16`/`Fetch32`). The values written into the output streams are
+//! **big-endian** (`Store16B`/`Store32B`) -- putting the high-order byte first
+//! groups the slowly-varying bytes of nearby addresses together, which is again
+//! about what the entropy coder sees. But the `ST_MAX` stream *sizes* in the
+//! block header are written with `Write32`, which is **little-endian**.
+//!
+//! So: header LE, payload BE. Confirmed against the ported decoder rather than
+//! inferred -- [`super::filter`] reads the header with `from_le_bytes` and the
+//! payload with `from_be_bytes`.
+
+use super::tables::*;
+
+/// `MAXINSTR` (`DisPack.cpp:121`) -- the longest instruction this encoder will
+/// consume. The tail loop pads to this, so `process_instr` may always read it.
+pub const MAXINSTR: usize = 15;
+
+/// `OP_CALLF` -- far call, one of the three opcodes carrying a 16-bit operand
+/// ahead of the normal operand flow.
+const OP_CALLF: u8 = 0x9a;
+
+/// `FindMTF` (`DisPack.cpp:246`): index of `val`, moving it to the front.
+///
+/// Returns `None` when absent, having inserted it -- the caller then emits the
+/// full 32-bit address and a `0` index byte, which is what tells the decoder to
+/// read one. Note the search covers 255 entries, not 256: the last slot is
+/// write-only, evicted by `add_mtf` before it can ever be found.
+fn find_mtf(mtf: &mut [u32; 256], val: u32) -> Option<usize> {
+    for i in 0..255 {
+        if mtf[i] == val {
+            move_to_front(mtf, i, val);
+            return Some(i);
+        }
+    }
+    add_mtf(mtf, val);
+    None
+}
+
+/// `DisFilterCtx` (`DisPack.cpp:371`).
+struct Encoder {
+    /// One output buffer per stream. `DataBuffer` in the C, which grows by
+    /// doubling; a `Vec` does the same thing without the realloc bookkeeping.
+    buf: Vec<Vec<u8>>,
+    func_table: [u32; 256],
+    next_is_func: bool,
+    code_start: u32,
+    code_end: u32,
+}
+
+impl Encoder {
+    fn new(code_start: u32, code_end: u32) -> Self {
+        Encoder {
+            buf: vec![Vec::new(); ST_MAX],
+            func_table: [0u32; 256],
+            // The first instruction of a block starts a function.
+            next_is_func: true,
+            code_start,
+            code_end,
+        }
+    }
+
+    #[inline]
+    fn put8(&mut self, stream: usize, v: u8) {
+        self.buf[stream].push(v);
+    }
+    /// Big-endian, unlike the little-endian read that produced `v`.
+    #[inline]
+    fn put16(&mut self, stream: usize, v: u16) {
+        self.buf[stream].extend_from_slice(&v.to_be_bytes());
+    }
+    #[inline]
+    fn put32(&mut self, stream: usize, v: u32) {
+        self.buf[stream].extend_from_slice(&v.to_be_bytes());
+    }
+
+    /// `DetectJumpTable` (`DisPack.cpp:396`) -- count leading dwords that look
+    /// like in-range code addresses.
+    ///
+    /// Fewer than three in a row is treated as coincidence, not a table; that
+    /// threshold is format, since the decoder trusts the `JUMPTAB` marker.
+    fn detect_jump_table(&self, instr: &[u8], addr: u32) -> usize {
+        if addr >= self.code_end {
+            return 0;
+        }
+        let n_max = ((self.code_end - addr) / 4) as usize;
+        let mut count = 0usize;
+        while count < n_max {
+            let off = count * 4;
+            let Some(w) = instr.get(off..off + 4) else { break };
+            let coded = u32::from_le_bytes([w[0], w[1], w[2], w[3]]);
+            if coded >= self.code_start && coded < self.code_end {
+                count += 1;
+            } else {
+                break;
+            }
+        }
+        if count < 3 {
+            0
+        } else {
+            count
+        }
+    }
+
+    /// Emit one call target: an MTF index when the function is known, otherwise
+    /// index 0 plus the absolute address.
+    fn put_call_target(&mut self, target: u32) {
+        match find_mtf(&mut self.func_table, target) {
+            Some(ind) => self.put8(ST_CALL_IDX, (ind + 1) as u8),
+            None => {
+                self.put8(ST_CALL_IDX, 0);
+                self.put32(ST_CALL32, target);
+            }
+        }
+    }
+
+    /// `ProcessInstr` (`DisPack.cpp:418`) -- encode one instruction (or one
+    /// jump-table run) and return the number of input bytes consumed.
+    ///
+    /// `instr` is guaranteed to hold at least `MAXINSTR` bytes: the driver's
+    /// main loop stops that far from the end, and its tail loop pads.
+    fn process_instr(&mut self, instr: &[u8], memory: u32) -> usize {
+        let n_jump = self.detect_jump_table(instr, memory);
+        if n_jump != 0 {
+            // A jump/vtable run, emitted in chunks of at most 256 because the
+            // count is stored in one byte as count-1.
+            let mut remaining = n_jump;
+            let mut p = 0usize;
+            while remaining != 0 {
+                let count = remaining.min(256);
+                self.put8(ST_OP, JUMPTAB);
+                self.put8(ST_JUMPTBL_COUNT, (count - 1) as u8);
+                for _ in 0..count {
+                    let w = &instr[p..p + 4];
+                    let target = u32::from_le_bytes([w[0], w[1], w[2], w[3]]);
+                    p += 4;
+                    self.put_call_target(target);
+                }
+                remaining -= count;
+            }
+            return n_jump * 4;
+        }
+
+        let mut p = 0usize;
+        let mut code = instr[p];
+        p += 1;
+        let mut code2 = 0u8;
+        let mut o16 = false;
+
+        // A function begins after the previous one returned. int3 is padding
+        // between functions, so it does not count as the entry point.
+        if self.next_is_func && code != OP_INT3 {
+            add_mtf(&mut self.func_table, memory);
+            self.next_is_func = false;
+        }
+
+        if code == OP_OSIZE {
+            o16 = true;
+            code = instr[p];
+            p += 1;
+        }
+
+        let mut flags = if code == OP_2BYTE {
+            code2 = instr[p];
+            p += 1;
+            TABLE2[code2 as usize]
+        } else {
+            TABLE1[code as usize]
+        };
+
+        if code == OP_RETNI || code == OP_RETN || code == OP_INT3 {
+            self.next_is_func = true;
+        }
+
+        // Opcodes whose operand shape lives in the ModR/M reg field.
+        if flags == F_MEXTRA {
+            let m = instr[p];
+            flags = TABLEX[(((m >> 3) & 7) | ((code & 0x01) << 3) | ((code & 0x08) << 1)) as usize];
+        }
+
+        if flags == F_ERR {
+            // Not decodable: escape the single byte and resynchronise.
+            self.put8(ST_OP, ESCAPE);
+            self.put8(ST_OP, instr[0]);
+            return 1;
+        }
+
+        if o16 {
+            self.put8(ST_OP, OP_OSIZE);
+        }
+        self.put8(ST_OP, code);
+        if code == OP_2BYTE {
+            self.put8(ST_OP2, code2);
+        }
+
+        // Far call/jump carry a 48-bit address: the segment word is copied
+        // here and the 32-bit offset falls out of the normal flow below.
+        // `enter` likewise has a word operand followed by a byte operand.
+        if code == OP_CALLF || code == OP_JMPF || code == OP_ENTER {
+            let v = u16::from_le_bytes([instr[p], instr[p + 1]]);
+            p += 2;
+            self.put16(ST_IMM16, v);
+        }
+
+        if flags & F_MODE == F_MR {
+            let modrm = instr[p];
+            p += 1;
+            self.put8(ST_MODRM, modrm);
+            let mut sib = 0u8;
+
+            if modrm & 0x07 == 4 && modrm < 0xc0 {
+                sib = instr[p];
+                p += 1;
+                self.put8(ST_SIB, sib);
+            }
+
+            if modrm & 0xc0 == 0x40 {
+                // register + byte displacement: one stream per base register,
+                // which is what makes these bytes compressible.
+                let v = instr[p];
+                p += 1;
+                self.put8(ST_DISP8_R0 + (modrm & 0x07) as usize, v);
+            }
+
+            if modrm & 0xc0 == 0x80 || modrm & 0xc7 == 0x05 || (modrm < 0x40 && sib & 0x07 == 5) {
+                let w = &instr[p..p + 4];
+                let v = u32::from_le_bytes([w[0], w[1], w[2], w[3]]);
+                p += 4;
+                let stream = if modrm & 0xc7 == 0x05 { ST_ADDR32 } else { ST_DISP32 };
+                self.put32(stream, v);
+            }
+        }
+
+        if flags & F_MODE == F_AM {
+            match flags & F_TYPE {
+                F_AD => {
+                    let w = &instr[p..p + 4];
+                    let v = u32::from_le_bytes([w[0], w[1], w[2], w[3]]);
+                    p += 4;
+                    self.put32(ST_ADDR32, v);
+                }
+                F_DA => {
+                    let w = &instr[p..p + 4];
+                    let v = u32::from_le_bytes([w[0], w[1], w[2], w[3]]);
+                    p += 4;
+                    self.put32(ST_AJUMP32, v);
+                }
+                F_BR => {
+                    let v = instr[p];
+                    p += 1;
+                    self.put8(ST_JUMP8, v);
+                }
+                _ => {
+                    // F_DR: relative dword target -> absolute.
+                    let w = &instr[p..p + 4];
+                    let disp = u32::from_le_bytes([w[0], w[1], w[2], w[3]]);
+                    p += 4;
+                    // `p` is now the full instruction length, so this is
+                    // "displacement + address of the next instruction".
+                    let target = disp.wrapping_add(p as u32).wrapping_add(memory);
+                    if code != OP_CALLN {
+                        self.put32(ST_JUMP32, target);
+                    } else {
+                        self.put_call_target(target);
+                    }
+                }
+            }
+        } else {
+            match flags & F_TYPE {
+                F_BI => {
+                    let v = instr[p];
+                    p += 1;
+                    self.put8(ST_IMM8, v);
+                }
+                F_WI => {
+                    let v = u16::from_le_bytes([instr[p], instr[p + 1]]);
+                    p += 2;
+                    self.put16(ST_IMM16, v);
+                }
+                F_DI => {
+                    if !o16 {
+                        let w = &instr[p..p + 4];
+                        let v = u32::from_le_bytes([w[0], w[1], w[2], w[3]]);
+                        p += 4;
+                        self.put32(ST_IMM32, v);
+                    } else {
+                        let v = u16::from_le_bytes([instr[p], instr[p + 1]]);
+                        p += 2;
+                        self.put16(ST_IMM16, v);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        p
+    }
+
+    /// `Flush` (`DisPack.cpp:565`): `ST_MAX` little-endian sizes, then the
+    /// stream bodies back to back.
+    fn flush(self) -> Vec<u8> {
+        let total: usize = ST_MAX * 4 + self.buf.iter().map(|b| b.len()).sum::<usize>();
+        let mut out = Vec::with_capacity(total);
+        for b in &self.buf {
+            // Little-endian here, unlike the payload -- see the module header.
+            out.extend_from_slice(&(b.len() as u32).to_le_bytes());
+        }
+        for b in &self.buf {
+            out.extend_from_slice(b);
+        }
+        debug_assert_eq!(out.len(), total);
+        out
+    }
+}
+
+/// `DisFilter` (`DisPack.cpp:600`) -- filter one block of x86 code.
+///
+/// `origin` is the address the block would be loaded at; call/jump targets are
+/// made absolute relative to it, so the same bytes at a different origin
+/// produce a different (and equally valid) filtered stream.
+pub fn dis_filter(src: &[u8], origin: u32) -> Vec<u8> {
+    let size = src.len();
+    let mut ctx = Encoder::new(origin, origin.wrapping_add(size as u32));
+    let mut pos = 0usize;
+
+    // Main loop: stay MAXINSTR bytes clear of the end so every read is in
+    // range. Signed comparison, because `size - MAXINSTR` is negative for a
+    // short block and must skip the loop rather than wrap.
+    while (pos as isize) < size as isize - MAXINSTR as isize {
+        let bytes = ctx.process_instr(&src[pos..], origin.wrapping_add(pos as u32));
+        if bytes == 0 {
+            break; // cannot happen -- every path consumes >= 1 -- but never spin
+        }
+        pos += bytes;
+    }
+
+    // Tail: an instruction here could run past the end of the input, so encode
+    // into a zero-padded copy, and if it turns out to have consumed more than
+    // is really there, roll every stream back and stop.
+    while pos < size {
+        let mut instr_buf = [0u8; MAXINSTR];
+        let n = size - pos;
+        instr_buf[..n].copy_from_slice(&src[pos..]);
+
+        let checkpoint: Vec<usize> = ctx.buf.iter().map(|b| b.len()).collect();
+        let bytes = ctx.process_instr(&instr_buf, origin.wrapping_add(pos as u32));
+
+        if bytes != 0 && pos + bytes <= size {
+            pos += bytes;
+        } else {
+            for (b, &mark) in ctx.buf.iter_mut().zip(checkpoint.iter()) {
+                b.truncate(mark);
+            }
+            break;
+        }
+    }
+
+    // Whatever is left cannot be a whole instruction: escape it byte by byte.
+    while pos < size {
+        ctx.put8(ST_OP, ESCAPE);
+        ctx.put8(ST_OP, src[pos]);
+        pos += 1;
+    }
+
+    ctx.flush()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The header is `ST_MAX` little-endian sizes covering the rest exactly.
+    #[test]
+    fn header_describes_the_body() {
+        let out = dis_filter(&[0x90u8; 64], 0x401000);
+        assert!(out.len() >= ST_MAX * 4);
+        let mut sum = 0usize;
+        for i in 0..ST_MAX {
+            let b = &out[i * 4..i * 4 + 4];
+            sum += u32::from_le_bytes([b[0], b[1], b[2], b[3]]) as usize;
+        }
+        assert_eq!(ST_MAX * 4 + sum, out.len());
+    }
+
+    /// A run of nops is all one-byte opcodes: they land in ST_OP and nowhere
+    /// else, which is the simplest check that streams are being separated.
+    #[test]
+    fn nops_go_only_to_the_opcode_stream() {
+        let out = dis_filter(&[0x90u8; 64], 0x401000);
+        let sizes: Vec<u32> = (0..ST_MAX)
+            .map(|i| {
+                let b = &out[i * 4..i * 4 + 4];
+                u32::from_le_bytes([b[0], b[1], b[2], b[3]])
+            })
+            .collect();
+        assert!(sizes[ST_OP] > 0, "opcode stream is empty");
+        for (i, &s) in sizes.iter().enumerate() {
+            if i != ST_OP {
+                assert_eq!(s, 0, "stream {i} should be empty for a nop run");
+            }
+        }
+    }
+
+    /// Every input length must terminate and be accounted for, including the
+    /// ones shorter than MAXINSTR that skip the main loop entirely.
+    #[test]
+    fn every_length_terminates() {
+        for len in 0..64usize {
+            let src: Vec<u8> = (0..len).map(|i| (i * 7 % 251) as u8).collect();
+            let out = dis_filter(&src, 0x401000);
+            assert!(out.len() >= ST_MAX * 4, "len {len} produced no header");
+        }
+    }
+
+    /// find_mtf searches 255 entries, not 256: the final slot is write-only.
+    /// A hit must move to the front so the next lookup is cheaper.
+    #[test]
+    fn find_mtf_moves_to_front_and_misses_insert() {
+        let mut t = [0u32; 256];
+        assert_eq!(find_mtf(&mut t, 0xdead), None); // absent -> inserted
+        assert_eq!(t[0], 0xdead);
+        assert_eq!(find_mtf(&mut t, 0xdead), Some(0)); // now found at the front
+        assert_eq!(find_mtf(&mut t, 0xbeef), None);
+        assert_eq!(t[0], 0xbeef);
+        assert_eq!(find_mtf(&mut t, 0xdead), Some(1)); // pushed back by one
+        assert_eq!(t[0], 0xdead); // and moved to the front again
+    }
+}

--- a/rust/darc-codecs/src/dispack/mod.rs
+++ b/rust/darc-codecs/src/dispack/mod.rs
@@ -1,9 +1,10 @@
 //! DisPack x86 branch/call/jump filter, ported from `Compression/DisPack/`.
 //!
-//! **Work in progress.** The opcode tables and MTF helpers are ported; the
-//! inverse filter (`DisUnFilter`) and the tagged-chunk stream driver
-//! (`C_DisPack.cpp`) are not, so nothing is wired to `DISPACK_METHOD::decompress`
-//! yet and the C decoder still runs.
+//! **Both directions are ported and wired.** `filter` inverts the transform
+//! (`DisUnFilter`) and `encode` applies it (`DisFilter`); `decode` drives the
+//! tagged-chunk stream. Each is byte-identical to the C, checked by
+//! `rust/difftest/dispack-check.sh` (decode) and `dispack-filter-check.sh`
+//! (encode).
 //!
 //! DisPack rewrites x86 code for better compression: it splits an instruction
 //! stream into parallel byte streams and turns relative call/jump targets into
@@ -16,8 +17,9 @@
 //! DisPack arrived here already CP1251-corrupted (see the project notes), so
 //! the reference for this port is the clean upstream source.
 
-#![allow(dead_code)] // WIP: tables land before the filter that uses them
+#![allow(dead_code)] // a few table entries are format documentation, unused by either direction
 
 pub mod decode;
+pub mod encode;
 pub mod filter;
 pub mod tables;

--- a/rust/darc-codecs/src/exports.rs
+++ b/rust/darc-codecs/src/exports.rs
@@ -622,6 +622,37 @@ pub unsafe extern "C" fn darc_rs_lz4_compress_block(
     lz4::compress_block(s, d).map_or(0, |n| n as c_int)
 }
 
+/// DisPack forward filter, mirroring `DisFilter` (`DisPack.cpp:600`).
+///
+/// Returns the filtered length, or a negative code. Unlike the archiver's
+/// chunked driver this is the raw block transform, which is what the
+/// differential harness compares byte for byte against the C.
+///
+/// `dst` must have room for the worst case: every input byte escaping to two
+/// bytes, plus the `ST_MAX` header words.
+///
+/// # Safety
+/// `src` must be valid for `src_size` bytes, `dst` for `dst_cap` bytes.
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_dispack_filter(
+    src: *const u8,
+    src_size: c_int,
+    origin: u32,
+    dst: *mut u8,
+    dst_cap: c_int,
+) -> c_int {
+    if src.is_null() || dst.is_null() || src_size < 0 || dst_cap < 0 {
+        return FREEARC_ERRCODE_GENERAL;
+    }
+    let s = core::slice::from_raw_parts(src, src_size as usize);
+    let out = dispack::encode::dis_filter(s, origin);
+    if out.len() > dst_cap as usize {
+        return FREEARC_ERRCODE_GENERAL;
+    }
+    core::ptr::copy_nonoverlapping(out.as_ptr(), dst, out.len());
+    out.len() as c_int
+}
+
 /// LZ4 high-compression encode, mirroring `LZ4_compress_HC`: returns the
 /// compressed length, or 0 when the block does not fit -- which `C_LZ4.cpp`
 /// treats as "store this block raw", not as an error.

--- a/rust/difftest/dispack-filter-check.sh
+++ b/rust/difftest/dispack-filter-check.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Differential-test the DisPack FORWARD filter (the encoder) against the C.
+#
+# The existing dispack-check.sh covers decode: C filters, C and Rust unfilter,
+# both must return the original. This covers the other direction and is a
+# stricter test -- DisPack is one of DArc's own formats, so the encoder must be
+# BYTE-EXACT, not merely reversible. A filtered stream that differs from the C's
+# would still round-trip through our own decoder while making archives that
+# older builds decode differently.
+#
+# Two things this corpus has to get right, both already paid for by the decode
+# port:
+#
+#   * REAL x86 CODE. DisPack's interesting paths -- ModR/M, SIB, the relative
+#     call/jump rewrite, MTF-coded call targets, jump-table detection -- only run
+#     on things that disassemble. Random bytes exercise the escape path and
+#     nothing else, and a green run over random data means the test reached
+#     nothing. The code here is compiled on the spot for i386 and its E8
+#     relocation placeholders are rewritten into backward calls.
+#   * VARIED ORIGIN. DisFilter converts relative targets to absolute ones, so
+#     origin is part of the transform, not a formality. Same bytes at a
+#     different load address must still agree with the C.
+#
+# The C reference comes from a pinned revision -- see c-reference.sh.
+set -uo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$ROOT/rust/difftest/c-reference.sh"
+CREF="$(darc_c_reference "$ROOT")" || exit 1
+W="${TMPDIR:-/tmp}/dispack-filter-check.$$"; mkdir -p "$W" "$W/in"
+trap 'rm -rf "$W"' EXIT
+
+( cd "$ROOT/rust" && cargo build --release -p darc-codecs ) >/dev/null 2>&1 \
+  || { echo "cargo build failed" >&2; exit 1; }
+LIB="$ROOT/rust/target/release/libdarc_codecs.a"
+
+# $lib is a separate trailing argument, never folded into "$@" with the -D
+# flags: GNU ld resolves an archive only against undefined symbols it has
+# already seen, so a staticlib ahead of the sources links on macOS and fails on
+# Linux. That exact mistake shipped once.
+cc() { local out="$1" lib="$2"; shift 2
+  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+    -I"$CREF" -I"$CREF/Compression" "$@" \
+    "$CREF/rust/difftest/dispack_filter_ref.cpp" \
+    "$CREF/rust/difftest/dispack_ccodec.cpp" \
+    "$CREF/Compression/Common.cpp" \
+    ${lib:+"$lib"} -o "$out"; }
+cc "$W/t" "$LIB" || { echo "harness build failed" >&2; exit 1; }
+
+python3 - "$W" <<'PY'
+import os,sys,struct,subprocess
+w=sys.argv[1]
+def prng(seed,n):
+    s=seed; o=bytearray()
+    for _ in range(n): s=(s*1103515245+12345)&0xffffffff; o.append((s>>16)&0xff)
+    return bytes(o)
+
+src=f"{w}/x.c"
+open(src,"w").write('''
+__attribute__((noinline)) static int a(int x){return x*3+1;}
+__attribute__((noinline)) static int b(int x){return a(x)+a(x-1)+2;}
+__attribute__((noinline)) static int c(int x){return b(x)*a(x)-b(x+1);}
+__attribute__((noinline)) static int d(int x){return c(x)+b(x)+a(x)+c(x-2);}
+__attribute__((noinline)) static int e(int x){return d(x)^c(x)^b(x)^a(x);}
+__attribute__((noinline)) int top(int*p,int n){int s=0;for(int i=0;i<n;i++){s+=e(p[i])+d(s)+c(i)-b(s^i)+a(p[i&7]);if(s>100000)s=e(s)-d(i);}return s;}
+''')
+obj=f"{w}/x.o"
+r=subprocess.run(["clang","--target=i386-unknown-linux-gnu","-m32","-O2","-c",src,"-o",obj],
+                 capture_output=True)
+text=b""
+if r.returncode!=0:
+    sys.stderr.write("i386 compile unavailable; code corpus skipped\n")
+else:
+    d=open(obj,"rb").read()
+    e_shoff,=struct.unpack("<I",d[0x20:0x24]); ent,=struct.unpack("<H",d[0x2e:0x30])
+    num,=struct.unpack("<H",d[0x30:0x32]); stx,=struct.unpack("<H",d[0x32:0x34])
+    def sh(i): o=e_shoff+i*ent; return struct.unpack("<IIIIII",d[o:o+24])
+    st=sh(stx)[4]
+    for i in range(num):
+        name,_,_,_,off,size=sh(i)
+        if d[st+name:d.index(b"\0",st+name)].decode()==".text": text=d[off:off+size]
+
+def make_code(reps,seed):
+    blob=bytearray(text*reps); s=seed; i=0
+    while i<len(blob)-5:
+        if blob[i]==0xE8 and blob[i+1]==0==blob[i+2]==blob[i+3]==blob[i+4]:
+            s=(s*1103515245+12345)&0xffffff
+            blob[i+1]=s&0xff; blob[i+2]=(s>>8)&0xff; blob[i+3]=(s>>16)&0xff; blob[i+4]=0xFF
+        i+=1
+    return bytes(blob)
+
+wf=lambda n,b: open(f"{w}/in/{n}","wb").write(b)
+if text:
+    wf("code_small", make_code(30,1))
+    wf("code_big",   make_code(200,7))
+    wf("code_noise", make_code(60,3)+prng(9,40000))
+    open(f"{w}/HAVE_CODE","w").write("1")
+# A plausible jump table: dwords that all land inside the block's address range,
+# which is exactly what DetectJumpTable keys on (>=3 consecutive entries).
+base=0x401000
+tbl=b"".join(struct.pack("<I", base+((i*17)%0x8000)) for i in range(64))
+wf("jumptable", tbl + (text if text else prng(5,4000)))
+# Runs of EXACTLY TWO in-range dwords, separated by an out-of-range one. The
+# threshold is "fewer than 3 is coincidence, not a table", so this is the only
+# shape that distinguishes 3 from 2 -- with 64 consecutive entries above, both
+# thresholds behave identically and a sabotage of the constant goes unnoticed.
+pairs=bytearray()
+for i in range(300):
+    pairs += struct.pack("<I", base+((i*29)%0x8000))
+    pairs += struct.pack("<I", base+((i*31)%0x8000))
+    pairs += struct.pack("<I", 0xF0000000 + i)   # out of range: breaks the run
+wf("pairs", bytes(pairs))
+# Make the MTF SEARCH BOUND falsifiable. Distinct targets alone do not: every
+# one is a miss, find_mtf never returns a hit, and 255-vs-254 cannot matter.
+# The bound only shows on a lookup that lands at exactly index 254.
+#
+# add_mtf pushes to the front, so after inserting t0..t299 in order the table
+# holds mtf[k] == t(299-k), putting t45 at index 254. Referencing t45 as the
+# next entry is therefore found with the real bound (searches 0..=254) and
+# missed with a bound one smaller -- which changes the output, because a miss
+# emits a full 32-bit address instead of a one-byte index.
+many=bytearray()
+for i in range(300):
+    many += struct.pack("<I", base+(i*4))
+many += struct.pack("<I", base+(45*4))    # sits at index 254 by the above
+wf("mtf_boundary", bytes(many))
+wf("noise",   prng(2,200000))
+wf("zeros",   b"\x00"*100000)
+wf("text",    b"the quick brown fox jumps over the lazy dog. "*3000)
+for n in (0,1,4,5,14,15,16,64,4096,65536):
+    wf(f"n_{n}", prng(4,n))
+PY
+
+[ -f "$W/HAVE_CODE" ] || echo "  WARNING: no i386 compiler -- the code corpus is absent and the interesting paths are NOT covered"
+
+fail=0; n=0
+for origin in 0x401000 0x00400000 0x10000000 0x0; do
+  d=0; c=0
+  for f in "$W"/in/*; do
+    [ -f "$f" ] || continue
+    bn=$(basename "$f"); c=$((c+1)); n=$((n+1))
+    rm -f "$W/ec" "$W/er"
+    "$W/t" c  "$origin" < "$f" >| "$W/ec" 2>/dev/null || { echo "  [org=$origin] $bn: C-filter FAILED"; fail=$((fail+1)); d=$((d+1)); continue; }
+    "$W/t" rs "$origin" < "$f" >| "$W/er" 2>/dev/null || { echo "  [org=$origin] $bn: RUST-filter FAILED"; fail=$((fail+1)); d=$((d+1)); continue; }
+    cmp -s "$W/ec" "$W/er" || { echo "  [org=$origin] $bn: differs from the C ($(wc -c < "$W/ec") vs $(wc -c < "$W/er") bytes)"; fail=$((fail+1)); d=$((d+1)); }
+  done
+  echo "  [origin=$origin] $c inputs, $d differing"
+done
+
+[ "$n" -gt 0 ] || { echo "no inputs were filtered -- harness reached nothing"; exit 1; }
+echo "dispack forward filter: $fail differing over $n comparisons"
+[ "$fail" -eq 0 ] && echo "DisPack encoder matches the C original byte for byte" || exit 1

--- a/rust/difftest/dispack_filter_ref.cpp
+++ b/rust/difftest/dispack_filter_ref.cpp
@@ -1,0 +1,72 @@
+/* Reference driver for the DisPack FORWARD filter.
+ *
+ *     dispack_filter_ref c  <origin> <in >out    C DisFilter
+ *     dispack_filter_ref rs <origin> <in >out    the Rust port
+ *
+ * The existing dispack_ref.cpp drives the archiver's chunked compress/decompress
+ * wrapper. This one exposes the raw block transform instead, because that is
+ * the piece being ported and the piece that must be byte-exact: DisPack is one
+ * of DArc's own formats, so "format-valid" does not apply.
+ *
+ * `origin` matters and is a parameter rather than a constant: DisFilter turns
+ * relative call/jump targets into absolute ones, so the same bytes at a
+ * different load address legitimately produce a different filtered stream.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../Compression/Compression.h"
+
+typedef unsigned char sU8;
+typedef int sInt;
+typedef unsigned int sU32;
+
+// Defined in DisPack.cpp, which C_DisPack.cpp includes textually.
+sU8 *DisFilter (sU8 *src, sInt size, sU32 origin, sU32 &outputSize);
+
+extern "C" int darc_rs_dispack_filter (const unsigned char *src, int srcSize,
+                                       unsigned origin, unsigned char *dst, int dstCap);
+
+static int read_all (unsigned char **buf)
+{
+  size_t cap = 1 << 20, len = 0;
+  unsigned char *p = (unsigned char *) malloc (cap);
+  for (;;) {
+    if (len == cap) { cap *= 2; p = (unsigned char *) realloc (p, cap); }
+    size_t n = fread (p + len, 1, cap - len, stdin);
+    if (n == 0) break;
+    len += n;
+  }
+  *buf = p;
+  return (int) len;
+}
+
+int main (int argc, char **argv)
+{
+  if (argc < 3) { fprintf (stderr, "usage: %s c|rs <origin> <in >out\n", argv[0]); return 2; }
+  unsigned origin = (unsigned) strtoul (argv[2], NULL, 0);
+
+  unsigned char *in = NULL;
+  int inSize = read_all (&in);
+
+  if (!strcmp (argv[1], "c")) {
+    sU32 outSize = 0;
+    sU8 *out = DisFilter (in, inSize, origin, outSize);
+    if (out == NULL) { fprintf (stderr, "C DisFilter returned NULL\n"); return 1; }
+    fwrite (out, 1, outSize, stdout);
+    free (out);
+    return 0;
+  }
+  if (!strcmp (argv[1], "rs")) {
+    // Worst case: every byte escapes to two, plus the ST_MAX header words.
+    int cap = inSize * 2 + 4096;
+    unsigned char *out = (unsigned char *) malloc (cap > 0 ? cap : 1);
+    int n = darc_rs_dispack_filter (in, inSize, origin, out, cap);
+    if (n < 0) { fprintf (stderr, "Rust dis_filter returned %d\n", n); return 1; }
+    fwrite (out, 1, n, stdout);
+    return 0;
+  }
+  fprintf (stderr, "bad mode %s\n", argv[1]);
+  return 2;
+}


### PR DESCRIPTION
Ports `DisFilter`, `DisFilterCtx` (`DetectJumpTable`, `ProcessInstr`, `Flush`) and the driver's checkpoint/undo tail — `DisPack.cpp:328-654` — plus `find_mtf`, which the decoder never needed because it reconstructs by index and only the encoder searches. The opcode tables were already ported for decode, so the new work is the transform itself.

**Byte-identical to the C over 76 comparisons across four load origins**, and the `dispack` fingerprint `6a46351e39373082` is unchanged, so archives are the same end to end.

## Endianness is asymmetric, and a round-trip test cannot see it

| | |
|---|---|
| instruction operands | read **little**-endian (x86) |
| stream payload | written **big**-endian (`Store16B`/`Store32B`) |
| `ST_MAX` header sizes | written **little**-endian (`Write32`) |

Big-endian payload groups the slowly-varying high bytes of nearby addresses together, which is the point of the whole transform. I confirmed this against the ported decoder rather than reading it off the C — and `filter.rs`'s own comment visibly corrects itself mid-sentence (*"The header is `ST_MAX` big-endian... no -- little-endian"*), so someone hit this before.

## The harness

`dispack-filter-check.sh` varies the **load origin**, because `DisFilter` turns relative call/jump targets into absolute ones — origin is part of the transform, not a formality. The corpus compiles real i386 code on the spot and rewrites `E8` placeholders into backward calls; random bytes exercise only the escape path. It warns loudly when no i386 compiler is available, so an empty-corpus pass can't masquerade as a real one.

## Seven sabotages, all caught — two only after fixing the corpus

| mutation | failing comparisons |
|---|---:|
| payload BE→LE (`put32`) | 56 |
| payload BE→LE (`put16`) | 28 |
| header LE→BE (`flush`) | 64 |
| disp8 not per-register | 56 |
| fDR target drops instr length | 28 |
| jump-table threshold 3→2 | 1 |
| MTF search 255→254 | 1 |

The last two were **blind**, for reasons worth recording:

- **Threshold 3→2** was unobservable against a run of 64 *consecutive* in-range dwords, which both thresholds accept identically. Only a run of **exactly two** distinguishes them.
- **MTF search bound** survived my first fix, which just threw 400 distinct targets at it. Every distinct target is a **miss**, so `find_mtf` never returns a hit and the bound is unreachable. It only matters on a lookup landing at index 254. `add_mtf` pushes to the front, so inserting `t0..t299` leaves `mtf[k] == t(299-k)`, putting `t45` at 254; referencing `t45` next is found with the real bound and missed with a smaller one. The catch confirms the mechanism exactly — **1581 vs 1585 bytes**, the four extra bytes of a full address where a one-byte index belonged.

That's the difference between "add more data" and working out why a mutation is unobservable. My first attempt was the former, and it failed.

Also refreshes `dispack/mod.rs`, whose header still described the decoder as unported.

## Verified

24/24 fingerprints · `nm` shows `C_DisPack.o` referencing `_darc_rs_dispack_filter` · `-mdispack` and `-mdispack+lzma` round-trip a real 4.5 MB executable

🤖 Generated with [Claude Code](https://claude.com/claude-code)