### PR TITLE
SREP: copy the block header out before releasing the buffer, not after

### DIFF
--- a/Compression/SREP/srep.cpp
+++ b/Compression/SREP/srep.cpp
@@ -627,11 +627,21 @@ int main (int argc, char **argv)
         header[1] = len;
         header[2] = (INDEX_LZ? 0 : stat_size);
 
-        // Write compressed block to output file(s)
-        bg_thread.write (header[2], stat, literal_bytes);
-        if (bg_thread.errcode)  {errcode = bg_thread.errcode; goto cleanup;}
-
-        // Store matches in memory
+        // Store matches in memory.
+        //
+        // This MUST happen before bg_thread.write() below. write() signals
+        // WriteReady, which hands header[] and statbuf[] back to the background
+        // thread -- and they are rotating buffers, only BUFFERS(=2) deep.
+        // Copying out of them afterwards is a use-after-release: the producer
+        // refills the slot while this thread is still reading it.
+        //
+        // The symptom was a block header carrying the hash digest of the block
+        // TWO positions later (exactly the ring size), so decompression failed
+        // its own checksum -- intermittently, and only under scheduling
+        // pressure. No memory-error tool finds this: every byte written is
+        // in-bounds, initialised and mutex-free. It is a LIFETIME bug, not a
+        // memory bug. ASan, TSan, malloc poisoning and MallocScribble were all
+        // clean; the corrupt archive itself gave it away.
         if (FUTURE_LZ || INDEX_LZ)
         {
           total_blocks++;
@@ -660,6 +670,11 @@ int main (int argc, char **argv)
           if (INDEX_LZ)
             compsize += sizeof(STAT);   // accounting for the future write of statsize_buf[]
         }
+
+        // Write compressed block to output file(s). Everything above has
+        // finished reading header[]/statbuf[]; this hands the slot back.
+        bg_thread.write (header[2], stat, literal_bytes);
+        if (bg_thread.errcode)  {errcode = bg_thread.errcode; goto cleanup;}
 
         // Update statistics
         total_stat_size += stat_size;


### PR DESCRIPTION
The intermittent `srep-check.sh` failure is a **use-after-release**, and this closes it.

```c
bg_thread.write (header[2], stat, literal_bytes);   // signals WriteReady -> slot released
...
memcpy(block->header,  header,  header_size);       // still reading the released slot
memcpy(block->statbuf, statbuf, stat_size);         // statbuf too
```

`header[]` and `statbuf[]` are rotating buffers only `BUFFERS = 2` deep. Once `write()` signals, the background thread refills that slot while the main thread is still copying out of it. Moving the copy **above** the write closes the window; widening the ring would only have narrowed it.

## This is the same symptom as #74, which fixed a different bug

PR #74 found a **real** heap overflow in `SliceHash` (ASan-confirmed) and fixed it — but it did not eliminate this failure. Its verification was too narrow: 400 cycles of **one** input plus a single pass of the corpus, reported as though it covered the corpus. Same signature ≠ same bug.

## Why every sanitiser was clean

Every byte written is in-bounds, initialised and mutex-free. Only the buffer's **lifetime** is wrong — a class no memory-error tool detects.

| instrument | result |
|---|---|
| ASan, 144 compress+decompress pairs | 0 reports |
| TSan (verified linked: 17 symbols, dylib, banner), 36 runs | 0 reports |
| hand-poisoned `BigAlloc`, 3 fill values × 150 | 2 / 1 / 0 — noise |
| `MallocPreScribble` + `MallocScribble`, 200 each | 3 / 1 / 1 — noise |

The corrupt archive itself identified it, not the tools.

## The forensics

A captured bad archive differed from a good one in **exactly 16 bytes** — an MD5 digest. That digest was verifiably **the digest of the block ~32,812 bytes later**: exactly two blocks at `bufsize=16384`, matching the ring size. The block's own digest was absent from the archive entirely.

## Proof, not statistics

Under load: broken ≈0.6% (2/360), fixed 0/420. But at that rate a zero in 420 is ~10% likely by chance, so the mechanism was shown directly instead — insert a 3 ms delay into the gap between release and copy:

| | corrupt |
|---|---|
| **BROKEN** order + 3 ms delay | **40/40** |
| **FIXED** order + same delay, same position | **0/40** |

Note an idle machine yields 0/250 even when broken, so any comparison must run under scheduling pressure — an earlier `BUFFERS` experiment was void precisely because its control never fired.

## Impact

DArc invokes `srep` as an external compressor, so this produced `-msrep` archives that fail their own checksum on extraction. Caught at decompress time, so not silent data loss — but an unextractable archive from a compress that reported success.

Verified: `srep-check.sh` green, v1–v4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)