### PR TITLE
MM: port the encoder and detector to Rust, and finish ':r1'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -889,6 +889,38 @@ jobs:
         fi
         echo "archives identical across $(wc -l < /tmp/fp-c.txt) configurations"
 
+    # Encryption had NO CI coverage at all until now: enc-roundtrip.sh existed
+    # but was referenced by no workflow, and run-tests.sh has no -p/-ae case.
+    # That is why a known ARM64 Serpent miscompile survived two releases -- the
+    # bug was even documented, by exact file and line, in enc-roundtrip.sh's own
+    # header, where it read as an expected caveat rather than a defect.
+    #
+    # This runs the two binaries the step above already built, each reading what
+    # the other wrote. A SAME-binary round-trip cannot catch this class: a broken
+    # build round-trips its own archives perfectly, which is precisely how the
+    # Serpent bug hid. Only cross-implementation agreement distinguishes
+    # "self-consistent" from "correct".
+    #
+    # It covers what the LibTomCrypt self-tests cannot: AES has no runnable
+    # self-test here (ENCRYPT_ONLY omits the decrypt half, so rijndael_test is
+    # commented out upstream), and hmac/ctr/cfb are likewise commented out. Those
+    # primitives are reachable ONLY through this check. Proven to bite: reversing
+    # the Rust CTR carry direction -- the documented hazard, since every -p
+    # archive ever written uses a little-endian counter -- fails 5 configurations
+    # here, and exactly the CTR-mode ones, leaving CFB green.
+    #
+    # </dev/null is required, not cosmetic: on a failed decrypt the archiver
+    # prompts for a password and would otherwise block until the job times out
+    # instead of reporting a failure.
+    - name: Encrypted archives interoperate between the C and Rust crypto
+      run: |
+        chmod +x Tests/enc-roundtrip.sh
+        test -x /tmp/arc-c || { echo "::error::the C-crypto binary from the previous step is missing"; exit 1; }
+        echo "--- C-crypto writes, Rust-crypto reads ---"
+        Tests/enc-roundtrip.sh /tmp/arc-c Tests/arc < /dev/null
+        echo "--- Rust-crypto writes, C-crypto reads ---"
+        Tests/enc-roundtrip.sh Tests/arc /tmp/arc-c < /dev/null
+
   # ── AddressSanitizer on x86-64 ──────────────────────────────────────────────
   # Added to diagnose a double free that only appeared on this runner. It found
   # that one and an out-of-bounds read in Dict/phase1 on its first two runs, and

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,6 +161,19 @@ jobs:
         chmod +x Tests/*.sh
         Tests/run-tests.sh Tests/arc
 
+    # MM's ':r1' byte reordering, which run-tests.sh does not reach: its edges
+    # are at BLOCK boundaries, not file boundaries, so a normal corpus walks
+    # past them. The transpose is parameterised by the block length, and only a
+    # final short block can carry a partial sample -- which needs an input just
+    # over the 1 MB first-block cut to reach at all. Sweeps every tail remainder
+    # across nine channel/word geometries, plus inputs autodetection refuses (no
+    # flags byte, so no length prefix may be written).
+    - name: Test MM ':r1' reordering (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        chmod +x Tests/mm-reorder-check.sh
+        Tests/mm-reorder-check.sh
+
     # ── macOS steps ────────────────────────────────────────────────────────────
     # macOS is in the matrix so the portability work stays honest. The README
     # has claimed macOS support for a long time while the build did not

--- a/Compression/MM/C_MM.cpp
+++ b/Compression/MM/C_MM.cpp
@@ -74,17 +74,13 @@ COMPRESSION_METHOD* parse_MM (char** parameters)
         case 'c':  p->num_chan    = parseInt (param+1, &error); continue;
         case 'w':  p->word_size   = parseInt (param+1, &error); continue;
         case 'o':  p->offset      = parseInt (param+1, &error); continue;
-        // ':r' is REJECTED rather than parsed. The encoder writes
-        // header[0] = 1 + reorder*2, and both decoders reject any flag bit
-        // above bit 0 (mm.cpp:287) -- so -mmm:r1 and -mmm:r2 produced archives
-        // that could be created successfully and then never extracted.
-        // Verified: both round-trip as "CREATED BUT CANNOT BE EXTRACTED".
-        //
-        // The feature was never finished: reorder_words() is a stub that
-        // returns its argument, so :r2 did not even transform the data, it just
-        // set an unreadable flag. Failing the method string is strictly better
-        // than accepting it and emitting an archive nobody can open.
-        case 'r':  error = 1;                                   continue;
+        // ':r1' is byte reordering, now implemented in both directions. ':r2'
+        // was reorder_words, whose C implementation is `return buf;` -- it
+        // transformed nothing and only set a flag no decoder accepted, so it is
+        // rejected rather than resurrected as a no-op.
+        case 'r':  p->reorder = parseInt (param+1, &error);
+                   if (!error && p->reorder != 0 && p->reorder != 1)  error = 1;
+                   continue;
       }
       // We end up here when the parameter has no name given
       // If this parameter can be parsed as c*w,

--- a/Compression/MM/C_MM.cpp
+++ b/Compression/MM/C_MM.cpp
@@ -74,7 +74,17 @@ COMPRESSION_METHOD* parse_MM (char** parameters)
         case 'c':  p->num_chan    = parseInt (param+1, &error); continue;
         case 'w':  p->word_size   = parseInt (param+1, &error); continue;
         case 'o':  p->offset      = parseInt (param+1, &error); continue;
-        case 'r':  p->reorder     = parseInt (param+1, &error); continue;
+        // ':r' is REJECTED rather than parsed. The encoder writes
+        // header[0] = 1 + reorder*2, and both decoders reject any flag bit
+        // above bit 0 (mm.cpp:287) -- so -mmm:r1 and -mmm:r2 produced archives
+        // that could be created successfully and then never extracted.
+        // Verified: both round-trip as "CREATED BUT CANNOT BE EXTRACTED".
+        //
+        // The feature was never finished: reorder_words() is a stub that
+        // returns its argument, so :r2 did not even transform the data, it just
+        // set an unreadable flag. Failing the method string is strictly better
+        // than accepting it and emitting an archive nobody can open.
+        case 'r':  error = 1;                                   continue;
       }
       // We end up here when the parameter has no name given
       // If this parameter can be parsed as c*w,

--- a/Compression/MM/C_MM.h
+++ b/Compression/MM/C_MM.h
@@ -2,7 +2,17 @@
 #include "../Compression.h"
 #include "mmdet.h"
 
-int mm_compress   (int skip_header, int is_float, int num_chan, int byte_size, int offset, int reorder, CALLBACK_FUNC *callback, void *auxdata);
+// `mode` was missing here, and the parameter after num_chan is word_size, not
+// byte_size. The declaration therefore never matched the definition in mm.cpp:
+// C_MM.cpp pulls this header in inside `extern "C"`, so the intent is that the
+// definition inherit C linkage -- but with a different arity it simply declared
+// a second, never-defined overload, and the real mm_compress stayed C++-mangled
+// (__Z11mm_compressiiiiiiiPFiPKcPviS1_ES1_). Harmless while both sides were C,
+// since the call site resolved to the definition either way. It stops being
+// harmless the moment a Rust drop-in wants the symbol: an extern "C"
+// mm_compress would not have replaced anything, and the C would have kept
+// running with no sign that the port was inert.
+int mm_compress   (int mode, int skip_header, int is_float, int num_chan, int word_size, int offset, int reorder, CALLBACK_FUNC *callback, void *auxdata);
 int mm_decompress (CALLBACK_FUNC *callback, void *auxdata);
 
 

--- a/Compression/MM/mm.cpp
+++ b/Compression/MM/mm.cpp
@@ -177,6 +177,20 @@ void undiff4 (void *buf, int bufsize, int N, void *_base)
 // COMPRESSION METHOD IMPLEMENTATION **************************************************************
 
 #ifndef FREEARC_DECOMPRESS_ONLY
+// DARC_RUST=1 selects the Rust port of the encoder (rust/darc-codecs, mm.rs +
+// mmdet.rs), excluded rather than redeclared for the same reason as the decoder
+// below: both are C-linkage and GNU ld reports a multiple definition.
+//
+// mmdet.cpp stays compiled. It is #included above and tta.cpp calls
+// autodetect_wav_header/autodetect_by_entropy directly (tta.cpp:322-324), so
+// the detector cannot go until TTA's encoder is ported too. Only this function
+// leaves. The diff routines above stay for the same reason they always did --
+// plain non-static globals costing a few unreferenced bytes.
+//
+// Verified byte-identical to the C encoder over the same matrix the decoder
+// uses, including all four autodetection modes; see rust/difftest/mm-check.sh,
+// which now compares the produced STREAM, not just the round-trip.
+#ifndef DARC_RUST
 // Multimedia detector and preprocessor
 int mm_compress (int mode, int skip_header, int is_float, int num_chan, int word_size, int offset, int reorder, CALLBACK_FUNC *callback, void *auxdata)
 {
@@ -296,6 +310,7 @@ finished:
     FreeAndNil(buf);
     return errcode;         // 0 if everything is fine, otherwise the error code
 }
+#endif  // !defined (DARC_RUST)
 #endif  // !defined (FREEARC_DECOMPRESS_ONLY)
 
 

--- a/Compression/MM/mm.cpp
+++ b/Compression/MM/mm.cpp
@@ -77,13 +77,30 @@ void diff4 (void *buf, int bufsize, int N, void *_base)
 }
 
 // Reorder buffer contents so that data for each byte of each channel are placed continuosly
+//
+// The destination index is R*i, NOT i*bufsize/X. Those differ: C evaluates the
+// latter as (i*bufsize)/X, which exceeds i*(bufsize/X) by floor(i*s/X) once the
+// trailing remainder s = bufsize%X is 2 or more. The rows then drift past the
+// end of the transposed region, so a byte is dropped into the tail area and
+// overwritten by the copy loop below, while an earlier slot is never written at
+// all and keeps whatever malloc returned. The result is lossy AND
+// nondeterministic -- an mm:r1 stream built over such a block fails its CRC.
+//
+// s=0 and s=1 come out identical either way (i*s/X < 1 for every i < X when
+// s <= 1), which is why this survived: the encoder rounds the FIRST block down
+// to a whole number of samples, so only a final short block can hit it, and
+// only when it is both at least one sample long and 2+ bytes past a sample
+// boundary. Reproduced with a 1048582-byte input at c2:w16.
 BYTE* reorder_bytes (BYTE *buf, int bufsize, int N, int width)
 {
-    BYTE *newbuf = (BYTE*) malloc(bufsize);
     int X = N*width;
+    if (X <= 0 || bufsize < X)  return buf;   // nothing to transpose (X==0 would divide by zero)
+    BYTE *newbuf = (BYTE*) malloc(bufsize);
+    if (!newbuf)  return buf;
+    int R = bufsize/X;
     for (int i=0; i<X; i++)
-        for (int j=0; j<bufsize/X; j++)
-            newbuf[i*bufsize/X+j] = buf[i+j*X];
+        for (int j=0; j<R; j++)
+            newbuf[i*R+j] = buf[i+j*X];
     for (int i=bufsize-(bufsize%X); i<bufsize; i++)
         newbuf[i] = buf[i];
     memcpy (buf, newbuf, bufsize);
@@ -100,6 +117,27 @@ BYTE* reorder_words (BYTE *buf, int bufsize, int N, int width)
 #endif  // !defined (FREEARC_DECOMPRESS_ONLY)
 
 // Run through buffer undiffing 8-bit elements
+// Inverse of reorder_bytes. The forward transform sends buf[i+j*X] to
+// out[i*R+j] with X = N*width and R = bufsize/X, gathering the k-th byte of
+// every sample into one run; the trailing bufsize%X bytes pass through
+// untransposed. This undoes exactly that.
+BYTE* unreorder_bytes (BYTE *buf, int bufsize, int N, int width)
+{
+    int X = N*width;
+    if (X <= 0 || bufsize < X)  return buf;      // nothing was transposed
+    BYTE *newbuf = (BYTE*) malloc(bufsize);
+    if (!newbuf)  return NULL;
+    int R = bufsize/X;
+    for (int i=0; i<X; i++)
+        for (int j=0; j<R; j++)
+            newbuf[i+j*X] = buf[i*R+j];
+    for (int i=bufsize-(bufsize%X); i<bufsize; i++)
+        newbuf[i] = buf[i];
+    memcpy (buf, newbuf, bufsize);
+    free (newbuf);
+    return buf;
+}
+
 void undiff1 (void *buf, int bufsize, int N, void *_base)
 {
     char *base=(char*)_base;
@@ -210,10 +248,24 @@ int mm_compress (int mode, int skip_header, int is_float, int num_chan, int word
         case 3 : diff3 (ptr, bytes, num_chan, base);  break;
         case 4 : diff4 (ptr, bytes, num_chan, base);  break;
         }
-        switch (reorder) {
-        case 1 : reorder_bytes (ptr, bytes, num_chan, byte_size);  break;
-        case 2 : reorder_words (ptr, bytes, num_chan, byte_size);  break;
-        }
+        // reorder_words is gone: it was `return buf;`, so :r2 set a flag no
+        // decoder accepted while transforming nothing.
+        if (N && reorder == 1)  reorder_bytes (ptr, bytes, num_chan, byte_size);
+
+        // The transpose is parameterised by the block length, and the blocks
+        // are NOT a fixed size -- the first is up to BUFSIZE minus the header
+        // offset, later ones roundDown(BUFFER_SIZE,N), the last whatever is
+        // left. Nothing in the old stream recorded that, which is why the flag
+        // could be written but never inverted. Prefixing each block with its
+        // length is what makes the reorder path decodable at all.
+        //
+        // Both are conditional on N, not on `reorder` alone. When autodetection
+        // gives up, N is 0 and the header above is a bare '\0' with no flags
+        // byte to carry bit1 -- the decoder for that stream copies to EOF and
+        // would swallow the prefixes as data. `-mmm:r1` on anything the
+        // detectors refuse (text, already-compressed data) hit exactly that and
+        // produced an archive that failed its CRC.
+        if (N && reorder)  WRITE4 (bytes);
         WRITE (ptr, bytes);
 
         // Move unprocessed rest of data into buffer beginning
@@ -284,7 +336,11 @@ int mm_decompress (CALLBACK_FUNC *callback, void *auxdata)
     } else {
         // Check that bits other than bit0-bit2 are not set (these should be used for future extensions)
         // Well, just now we don't support even bits1&2 enabled (i.e. we don't support restoring proper byte order)
-        if (header[0] & ~1)  {errcode=FREEARC_ERRCODE_BAD_COMPRESSED_DATA; goto finished;}
+        // bit0 = diff, bit1 = byte reordering. bit2 was reorder_words, which
+        // never existed (`return buf;`), so it stays rejected rather than being
+        // accepted as a no-op. Anything above is reserved.
+        if (header[0] & ~3)  {errcode=FREEARC_ERRCODE_BAD_COMPRESSED_DATA; goto finished;}
+        int reorder = (header[0] & 2) != 0;
         // Read the remaining two header bytes
         READ (header+1, 2);
 
@@ -302,22 +358,49 @@ int mm_decompress (CALLBACK_FUNC *callback, void *auxdata)
         int byte_size = (word_size+7)/8;              // bytes per word
         int N         = num_chan*byte_size;           // bytes per sample
         int chunk     = roundDown (BUFFER_SIZE, N);   // size of data processing chunks
+        int bufsize   = BUFFER_SIZE;                 // current capacity of buf[], grown by the reorder path
         base = calloc (num_chan, byte_size==3? 4:byte_size);  // room for previous values for all channels what will be substracted from next ones
         READ (base, roundUp(3+4+offset,N) - (3+4+offset));  // skip alignment bytes
 
-        // Process data in chunks
-        while ( (errcode = bytes = callback ("read", buf, chunk, auxdata)) > 0 )
+        // Process data in chunks. With reordering the block length is explicit,
+        // because the transpose is parameterised by it and the encoder's blocks
+        // are not a fixed size.
+        for (;;)
         {
+            if (reorder) {
+                BYTE lenbuf[4];
+                errcode = callback ("read", lenbuf, 4, auxdata);
+                if (errcode == 0)  break;                 // clean end of stream
+                if (errcode < 0)   goto finished;
+                if (errcode != 4)  {errcode=FREEARC_ERRCODE_BAD_COMPRESSED_DATA; goto finished;}
+                bytes = value32(lenbuf);
+                // The encoder's FIRST reorder block is up to BUFSIZE (1 MB)
+                // minus the header offset; later ones are chunk-sized. So this
+                // buffer has to grow -- bounded, so a declared length cannot
+                // choose the allocation size.
+                if (bytes < 0 || bytes > 1*mb)  {errcode=FREEARC_ERRCODE_BAD_COMPRESSED_DATA; goto finished;}
+                if (bytes > bufsize) {
+                    BYTE *nb = (BYTE*) realloc (buf, bytes+1);
+                    if (!nb)  {errcode=FREEARC_ERRCODE_NOT_ENOUGH_MEMORY; goto finished;}
+                    buf = nb;  bufsize = bytes;
+                }
+                READ (buf, bytes);
+            } else {
+                errcode = bytes = callback ("read", buf, chunk, auxdata);
+                if (errcode <= 0)  break;
+            }
+
+            // Undo the transpose BEFORE the deltas: the encoder diffed first and
+            // reordered second, so decode runs the inverse order. The
+            // commented-out original had these the wrong way round.
+            if (reorder)  unreorder_bytes (buf, bytes, num_chan, byte_size);
+
             switch (byte_size) {
             case 1 : undiff1 (buf, bytes, num_chan, base);  break;
             case 2 : undiff2 (buf, bytes, num_chan, base);  break;
             case 3 : undiff3 (buf, bytes, num_chan, base);  break;
             case 4 : undiff4 (buf, bytes, num_chan, base);  break;
-            }                     /*
-            switch (reorder) {
-            case 1 : unreorder_bytes (buf, bytes, num_chan, byte_size);  break;  // temporary!
-            case 2 : unreorder_words (buf, bytes, num_chan, byte_size);  break;
-            }             */
+            }
             WRITE (buf, bytes);
         }
     }

--- a/RUST_PORT_PROGRESS.md
+++ b/RUST_PORT_PROGRESS.md
@@ -40,7 +40,7 @@ remains, because `DARC_NO_RUST=1` still builds them.
 | GRZip | `grzip` | yes | no |
 | LZ4 | `lz4` (`lz4_flex`) + `lz4hc` (own HC port) | yes (decode + both encoders) | **YES — 6,319 lines deleted** |
 | LZP | `lzp` | yes (both directions) | **YES — 259 lines deleted** |
-| MM | `mm` | yes | no |
+| MM | `mm`, `mmdet` (both directions) | yes (encode + decode) | partly — `mm_compress` excluded; `mmdet.cpp` stays for TTA |
 | REP | `rep` | yes (both directions, byte-exact) | **YES** |
 | SREP | `srep` (decode only) | external binary, no `DARC_RUST` wiring | no — see §14 before porting the encoder |
 | Tornado | `tornado` | yes | no |

--- a/Tests/mm-reorder-check.sh
+++ b/Tests/mm-reorder-check.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+# mm ':r1' byte-reordering round-trip, over the block-boundary edge cases.
+#
+# The reorder path transposes each block, and the transpose is parameterised by
+# the BLOCK LENGTH -- so its edges live at block boundaries, not at file
+# boundaries, and a plain corpus round-trip walks straight past them. Two
+# properties matter and neither is visible on a "nice" input:
+#
+#   * the encoder's FIRST block is up to BUFSIZE (1 MB) while later ones are
+#     roundDown(BUFFER_SIZE,N) = 64 KB, so the decoder's buffer must grow;
+#   * the encoder rounds the first block down to a whole number of samples, so
+#     ONLY a final short block can carry a partial sample.
+#
+# That second one hid a real bug: reorder_bytes indexed its output with
+# `i*bufsize/X`, i.e. (i*bufsize)/X, which drifts past i*(bufsize/X) by
+# floor(i*s/X) once the tail s = bufsize%X reaches 2. Remainders 0 and 1 are
+# identical either way, so the whole failure lived in "final block is at least
+# one sample long AND 2+ bytes past a sample boundary" -- which needs an input
+# just over 1 MB to reach at all. It failed its CRC when it fired.
+#
+# So this sweeps s across every residue for each geometry, and pins sizes just
+# above the 1 MB first-block cut. Run from Tests/ with ./arc already built.
+set -e
+cd "$(dirname "$0")"
+ARC=./arc
+[ -x "$ARC" ] || { echo "no ./arc -- build first"; exit 1; }
+
+WORK=/tmp/mm-reorder-check.$$
+mkdir -p "$WORK"
+trap 'rm -rf "$WORK"' EXIT
+
+BUFSIZE=1048576
+fail=0
+total=0
+
+# num_chan word_size   (X = num_chan * ceil(word_size/8))
+for cfg in "1 8" "1 16" "2 8" "2 16" "2 32" "3 24" "4 16" "6 8" "5 16"; do
+  set -- $cfg
+  ch=$1; ws=$2
+  bs=$(( (ws + 7) / 8 ))
+  X=$(( ch * bs ))
+  s=0
+  while [ $s -lt $X ]; do
+    # final block = two whole samples plus an s-byte partial one
+    n=$(( BUFSIZE + X * 2 + s ))
+    f="$WORK/in.raw"
+    python3 -c "
+import sys, math
+n = $n
+b = bytearray()
+for i in range(n):
+    b.append((int(30000*math.sin(i/50.0)) >> (8*(i%2))) & 0xff)
+sys.stdout.buffer.write(bytes(b))
+" > "$f"
+    a="$WORK/t.arc"
+    rm -f "$a"
+    ( cd "$WORK" && "$OLDPWD/$ARC" a -m"mm:c$ch:w$ws:o0:r1" -mc- t.arc in.raw ) >/dev/null 2>&1
+    total=$(( total + 1 ))
+    if "$ARC" t "$a" 2>&1 | grep -q "All OK"; then
+      :
+    else
+      echo "  FAILED  c$ch w$ws  X=$X  tail=$s  size=$n"
+      fail=$(( fail + 1 ))
+    fi
+    s=$(( s + 1 ))
+  done
+done
+
+# And the case with no geometry at all. When autodetection refuses the input,
+# N is 0, the header is a bare '\0' and there is no flags byte to carry the
+# reorder bit -- so the encoder must not emit block-length prefixes either. It
+# did, and `-mmm:r1` on any text or already-compressed file produced an archive
+# that failed its CRC. These run with autodetection ON (no :c/:w) so the refusal
+# is real rather than forced.
+for kind in text random; do
+  f="$WORK/nomm.raw"
+  python3 -c "
+import sys
+if '$kind' == 'text':
+    sys.stdout.buffer.write(b'the quick brown fox jumps over the lazy dog. ' * 30000)
+else:
+    s = 12345; o = bytearray()
+    for _ in range(1350000):
+        s = (s * 1103515245 + 12345) & 0xffffffff
+        o.append((s >> 16) & 0xff)
+    sys.stdout.buffer.write(bytes(o))
+" > "$f"
+  a="$WORK/t.arc"
+  rm -f "$a"
+  ( cd "$WORK" && "$OLDPWD/$ARC" a -m"mm:r1" -mc- t.arc nomm.raw ) >/dev/null 2>&1
+  total=$(( total + 1 ))
+  if "$ARC" t "$a" 2>&1 | grep -q "All OK"; then
+    :
+  else
+    echo "  FAILED  autodetect-refused ($kind) with :r1"
+    fail=$(( fail + 1 ))
+  fi
+done
+
+echo "mm:r1 reorder: $(( total - fail ))/$total passed"
+[ $fail -eq 0 ] || exit 1

--- a/rust/darc-codecs/src/exports.rs
+++ b/rust/darc-codecs/src/exports.rs
@@ -321,6 +321,62 @@ pub unsafe extern "C" fn mm_decompress(
     darc_rs_mm_decompress(callback, auxdata)
 }
 
+/// MM encoder. Unlike the decoder this takes the full parameter set, because
+/// the caller may pin the model (`-mmm:c2:w16`) instead of letting the
+/// autodetector choose it -- and what it chooses lands in the stream header.
+///
+/// # Safety
+/// `callback` and `auxdata` must be what the C caller supplied.
+#[no_mangle]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn darc_rs_mm_compress(
+    mode: c_int,
+    skip_header: c_int,
+    is_float: c_int,
+    num_chan: c_int,
+    word_size: c_int,
+    offset: c_int,
+    reorder: c_int,
+    callback: CALLBACK_FUNC,
+    auxdata: *mut c_void,
+) -> c_int {
+    match Io::new(callback, auxdata) {
+        Some(io) => mm::compress(
+            &io, mode, skip_header, is_float, num_chan, word_size, offset, reorder,
+        ),
+        None => FREEARC_ERRCODE_GENERAL,
+    }
+}
+
+/// # Safety
+/// `callback` and `auxdata` must be what the C caller supplied.
+#[cfg(feature = "dropin")]
+#[no_mangle]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn mm_compress(
+    mode: c_int,
+    skip_header: c_int,
+    is_float: c_int,
+    num_chan: c_int,
+    word_size: c_int,
+    offset: c_int,
+    reorder: c_int,
+    callback: CALLBACK_FUNC,
+    auxdata: *mut c_void,
+) -> c_int {
+    darc_rs_mm_compress(
+        mode,
+        skip_header,
+        is_float,
+        num_chan,
+        word_size,
+        offset,
+        reorder,
+        callback,
+        auxdata,
+    )
+}
+
 /// # Safety
 /// `callback` and `auxdata` must be what the C caller supplied.
 #[no_mangle]

--- a/rust/darc-codecs/src/lib.rs
+++ b/rust/darc-codecs/src/lib.rs
@@ -17,6 +17,7 @@ pub mod lz4;
 pub mod lz4hc;
 pub mod lzp;
 pub mod mm;
+pub mod mmdet;
 pub mod rep;
 pub mod srep;
 pub mod tornado;

--- a/rust/darc-codecs/src/mm.rs
+++ b/rust/darc-codecs/src/mm.rs
@@ -124,6 +124,81 @@ fn round_up(a: usize, b: usize) -> usize {
 // pointer conditions in C do (`p+N <= buf+bufsize`).
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Forward filters -- diff1..diff4 (`mm.cpp:19-77`), the exact mirrors of the
+// undiff family below.
+//
+// Each replaces every element with its difference from the previous element in
+// the SAME channel, so `base` carries one running value per channel and
+// persists across calls for the whole stream. The order matters and is easy to
+// get subtly wrong: the C does `x = p[i]; p[i] -= base[i]; base[i] = x;` -- the
+// ORIGINAL value becomes the new base, not the difference just written.
+//
+// Every arithmetic op wraps. In C these are unsigned types where overflow is
+// defined; a Rust `-` would panic in debug, so `wrapping_sub` is required for
+// equivalence rather than as a style choice.
+//
+// The loop bound mirrors the C pointer condition `p + N <= buf + bufsize`, so a
+// trailing partial element is left untouched -- not rounded up, not padded.
+// ---------------------------------------------------------------------------
+
+fn diff1(buf: &mut [u8], n: usize, base: &mut [u8]) {
+    let mut p = 0;
+    while p + n <= buf.len() {
+        for i in 0..n {
+            let x = buf[p + i];
+            buf[p + i] = x.wrapping_sub(base[i]);
+            base[i] = x;
+        }
+        p += n;
+    }
+}
+
+fn diff2(buf: &mut [u8], n: usize, base: &mut [u8]) {
+    let mut p = 0; // in 16-bit words
+    while (p + n) * 2 <= buf.len() {
+        for i in 0..n {
+            let at = (p + i) * 2;
+            let x = u16::from_le_bytes([buf[at], buf[at + 1]]);
+            let prev = u16::from_le_bytes([base[i * 2], base[i * 2 + 1]]);
+            buf[at..at + 2].copy_from_slice(&x.wrapping_sub(prev).to_le_bytes());
+            base[i * 2..i * 2 + 2].copy_from_slice(&x.to_le_bytes());
+        }
+        p += n;
+    }
+}
+
+fn diff3(buf: &mut [u8], n: usize, base: &mut [u8]) {
+    let mut p = 0; // in bytes
+    while p + n * 3 <= buf.len() {
+        for i in 0..n {
+            let at = p + i * 3;
+            let b = i * 4;
+            let x = u32::from_le_bytes([buf[at], buf[at + 1], buf[at + 2], 0]);
+            let prev = u32::from_le_bytes([base[b], base[b + 1], base[b + 2], base[b + 3]]);
+            // setvalue24 writes three bytes; the fourth is not ours to touch.
+            buf[at..at + 3].copy_from_slice(&x.wrapping_sub(prev).to_le_bytes()[..3]);
+            base[b..b + 4].copy_from_slice(&x.to_le_bytes());
+        }
+        p += n * 3;
+    }
+}
+
+fn diff4(buf: &mut [u8], n: usize, base: &mut [u8]) {
+    let mut p = 0; // in 32-bit words
+    while (p + n) * 4 <= buf.len() {
+        for i in 0..n {
+            let at = (p + i) * 4;
+            let b = i * 4;
+            let x = u32::from_le_bytes([buf[at], buf[at + 1], buf[at + 2], buf[at + 3]]);
+            let prev = u32::from_le_bytes([base[b], base[b + 1], base[b + 2], base[b + 3]]);
+            buf[at..at + 4].copy_from_slice(&x.wrapping_sub(prev).to_le_bytes());
+            base[b..b + 4].copy_from_slice(&x.to_le_bytes());
+        }
+        p += n;
+    }
+}
+
 fn undiff1(buf: &mut [u8], n: usize, base: &mut [u8]) {
     let mut p = 0;
     while p + n <= buf.len() {
@@ -282,5 +357,63 @@ fn copy_to_eof(io: &Io, buf: &mut [u8]) -> Result<(), c_int> {
             return Ok(());
         }
         write_out(io, &buf[..got as usize])?;
+    }
+}
+
+#[cfg(test)]
+mod diff_tests {
+    use super::*;
+
+    /// diff then undiff must be the identity for every width and channel count,
+    /// INCLUDING inputs with a trailing partial element -- the loop bound leaves
+    /// those untouched, and an off-by-one there would corrupt the tail.
+    #[test]
+    fn diff_and_undiff_are_inverse() {
+        for width in 1..=4usize {
+            for n in 1..=4usize {
+                for extra in 0..width * n {
+                    let len = width * n * 7 + extra;
+                    let orig: Vec<u8> = (0..len).map(|i| (i * 31 + 7) as u8).collect();
+                    let mut buf = orig.clone();
+                    let mut enc_base = [0u8; 64];
+                    match width {
+                        1 => diff1(&mut buf, n, &mut enc_base),
+                        2 => diff2(&mut buf, n, &mut enc_base),
+                        3 => diff3(&mut buf, n, &mut enc_base),
+                        _ => diff4(&mut buf, n, &mut enc_base),
+                    }
+                    let mut dec_base = [0u8; 64];
+                    match width {
+                        1 => undiff1(&mut buf, n, &mut dec_base),
+                        2 => undiff2(&mut buf, n, &mut dec_base),
+                        3 => undiff3(&mut buf, n, &mut dec_base),
+                        _ => undiff4(&mut buf, n, &mut dec_base),
+                    }
+                    assert_eq!(buf, orig, "width={width} n={n} extra={extra}");
+                }
+            }
+        }
+    }
+
+    /// The base must become the ORIGINAL value, not the difference just stored.
+    /// Getting that backwards still round-trips, so a round-trip test alone
+    /// cannot catch it -- pin the encoded bytes.
+    #[test]
+    fn base_tracks_the_original_not_the_difference() {
+        let mut buf = vec![10u8, 30, 60, 100];
+        let mut base = [0u8; 64];
+        diff1(&mut buf, 1, &mut base);
+        assert_eq!(buf, vec![10, 20, 30, 40]);
+        assert_eq!(base[0], 100, "base must hold the last ORIGINAL value");
+    }
+
+    /// Wrapping is required, not stylistic: a Rust `-` would panic in debug on
+    /// any decreasing sequence, which is most real signal data.
+    #[test]
+    fn decreasing_input_wraps_rather_than_panics() {
+        let mut buf = vec![5u8, 1, 250, 3];
+        let mut base = [0u8; 64];
+        diff1(&mut buf, 1, &mut base);
+        assert_eq!(buf[1], 252);
     }
 }

--- a/rust/darc-codecs/src/mm.rs
+++ b/rust/darc-codecs/src/mm.rs
@@ -55,6 +55,11 @@ const IO: c_int = FREEARC_ERRCODE_IO as c_int;
 /// and the decoder must ask for exactly the same amount.
 const BUFFER_SIZE: usize = 64 << 10;
 
+/// The largest reorder block the encoder can emit: `BUFSIZE` in `mm.cpp`, the
+/// size of its first read. Bounds the buffer growth in the reorder path so a
+/// declared length cannot choose the allocation size.
+const MAX_REORDER_BLOCK: usize = 1 << 20;
+
 /// The header offset is a 32-bit field read into a C `int`, so the C decoder
 /// happily takes a value that makes `malloc` fail or go negative. No encoder
 /// can emit more than the 1 MB first-block size, so anything past this is
@@ -83,6 +88,27 @@ fn read_u32(io: &Io) -> Result<u32, c_int> {
     let mut b = [0u8; 4];
     read_exact(io, &mut b)?;
     Ok(u32::from_le_bytes(b))
+}
+
+/// A 32-bit length, or `None` at a clean end of stream.
+///
+/// Distinguishing "no more blocks" from "a truncated length" matters here: the
+/// reorder path reads an explicit block length, so a stream that simply ends is
+/// normal while one that ends mid-length is corrupt.
+fn read_u32_or_eof(io: &Io) -> Result<Option<u32>, c_int> {
+    let mut b = [0u8; 4];
+    let mut got = 0usize;
+    while got < 4 {
+        let n = io.read(&mut b[got..]);
+        if n < 0 {
+            return Err(n);
+        }
+        if n == 0 {
+            return if got == 0 { Ok(None) } else { Err(BAD) };
+        }
+        got += n as usize;
+    }
+    Ok(Some(u32::from_le_bytes(b)))
 }
 
 fn write_out(io: &Io, buf: &[u8]) -> Result<(), c_int> {
@@ -141,6 +167,41 @@ fn round_up(a: usize, b: usize) -> usize {
 // The loop bound mirrors the C pointer condition `p + N <= buf + bufsize`, so a
 // trailing partial element is left untouched -- not rounded up, not padded.
 // ---------------------------------------------------------------------------
+
+/// Inverse of `reorder_bytes` (`mm.cpp:80`).
+///
+/// The forward transform is a byte transpose: with `x = n * width` bytes per
+/// sample and `r = len / x` whole samples, it sends `buf[i + j*x]` to
+/// `out[i*r + j]`, gathering the k-th byte of every sample into one run. That
+/// is what makes it pay -- the high bytes of a slowly-varying signal become long
+/// similar runs for the entropy coder. The trailing `len % x` bytes are copied
+/// straight through, not transposed.
+///
+/// **This transform is why the reorder flag needs a length prefix in the
+/// stream.** Unlike diff/undiff, which are streaming and carry their state in
+/// `base`, the permutation is parameterised by the block length: invert it with
+/// a different `len` and every byte lands in the wrong place. The encoder's
+/// blocks are not a fixed size -- the first is up to 1 MB (`BUFSIZE`) minus the
+/// header offset, later ones are `roundDown(BUFFER_SIZE, N)` = 64 KB, and the
+/// last is whatever remains -- and none of that is recoverable from the old
+/// stream. That, not the missing inverse, is why the flag was never finished.
+fn unreorder_bytes(buf: &mut [u8], n: usize, width: usize) {
+    let x = n * width;
+    if x == 0 || buf.len() < x {
+        return; // nothing transposed; the whole block is "tail"
+    }
+    let len = buf.len();
+    let r = len / x;
+    let mut out = vec![0u8; len];
+    for i in 0..x {
+        for j in 0..r {
+            out[i + j * x] = buf[i * r + j];
+        }
+    }
+    let tail = len - (len % x);
+    out[tail..].copy_from_slice(&buf[tail..]);
+    buf.copy_from_slice(&out);
+}
 
 fn diff1(buf: &mut [u8], n: usize, base: &mut [u8]) {
     let mut p = 0;
@@ -279,11 +340,14 @@ fn run(io: &Io) -> Result<(), c_int> {
         return copy_to_eof(io, &mut buf);
     }
 
-    // Bits 1-2 are the reordering that was never finished; anything above is
-    // reserved. The C decoder rejects both rather than guess.
-    if (header[0] & !1) != 0 {
+    // Bit 1 is byte reordering. Bit 2 was `reorder_words`, which never existed
+    // -- the C function is `return buf;` -- so it is rejected rather than
+    // treated as a no-op: a flag that means nothing should not be accepted.
+    // Anything above is reserved.
+    if (header[0] & !0b11) != 0 {
         return Err(BAD);
     }
+    let reorder = header[0] & 0b10 != 0;
     read_exact(io, &mut header[1..3])?;
 
     // The original file header, copied through untouched. C reads it into one
@@ -326,7 +390,30 @@ fn run(io: &Io) -> Result<(), c_int> {
 
     let chunk = round_down(BUFFER_SIZE, sample);
     loop {
-        let got = io.read(&mut buf[..chunk]);
+        // With reordering the block length is explicit: the permutation is
+        // parameterised by it, and the encoder's blocks are not a fixed size.
+        // Without it the stream is self-describing by chunk size, as before.
+        let got = if reorder {
+            let n = match read_u32_or_eof(io)? {
+                Some(n) => n as usize,
+                None => return Ok(()),
+            };
+            // The encoder's FIRST reorder block is up to BUFSIZE (1 MB) minus
+            // the header offset, while later ones are roundDown(BUFFER_SIZE,N)
+            // = 64 KB. So the decoder's fixed 64 KB buffer is not enough and
+            // has to grow -- bounded, so a hostile length cannot pick the
+            // allocation size.
+            if n > MAX_REORDER_BLOCK {
+                return Err(BAD);
+            }
+            if n > buf.len() {
+                buf.resize(n, 0);
+            }
+            read_exact(io, &mut buf[..n])?;
+            n as c_int
+        } else {
+            io.read(&mut buf[..chunk])
+        };
         if got < 0 {
             return Err(got);
         }
@@ -334,6 +421,11 @@ fn run(io: &Io) -> Result<(), c_int> {
             return Ok(());
         }
         let data = &mut buf[..got as usize];
+        // Undo the transpose before the deltas: the encoder diffed first, then
+        // reordered, so decode runs the inverse order.
+        if reorder {
+            unreorder_bytes(data, num_chan, byte_size);
+        }
         match byte_size {
             1 => undiff1(data, num_chan, &mut base),
             2 => undiff2(data, num_chan, &mut base),

--- a/rust/darc-codecs/src/mm.rs
+++ b/rust/darc-codecs/src/mm.rs
@@ -8,12 +8,16 @@
 //! channel -- which is why this module is a fraction of the size of `tta.rs`
 //! despite the two codecs sharing a directory.
 //!
-//! Only the decoder is ported, the same decode-first order used for REP, Dict,
+//! Both directions are ported, decoder first -- the order used for REP, Dict,
 //! LZP and TTA: a Rust build must *read* every existing `-mmm` archive before it
-//! may write one. None of `mmdet.cpp` is needed here -- its 1,117 lines of
-//! WAV-header and entropy autodetection sit behind
-//! `#ifndef FREEARC_DECOMPRESS_ONLY` and only ever choose the *encoder's*
-//! parameters, which then travel in the stream header.
+//! may write one. The encoder lives at the bottom of this file and its
+//! autodetection in `mmdet.rs`, which is the bulk of it: the detector chooses
+//! `num_chan`/`word_size`/`offset`, and those travel in the stream header, so
+//! it decides archive bytes rather than merely compression ratio.
+//!
+//! The C `mm_compress` is excluded under `DARC_RUST`, but `mmdet.cpp` is NOT
+//! deleted: `tta.cpp` calls its two autodetect entry points directly, so it
+//! survives until TTA's encoder is ported too.
 //!
 //! ## The stream
 //!
@@ -25,9 +29,10 @@
 //! channel. Then zero padding up to a multiple of the sample size, then the
 //! deltas, to end of stream.
 //!
-//! Bit 0 of the flags byte is the only one implemented; bits 1-2 are reserved
-//! for the unfinished byte/word reordering (`reorder_words` in mm.cpp is a
-//! stub that returns its argument), and the C decoder rejects them.
+//! Bit 0 of the flags byte is the diff, bit 1 the byte reordering (`:r1`), which
+//! this port completed in both directions -- it could previously be written but
+//! never read. Bit 2 was `reorder_words`, whose C implementation is
+//! `return buf;`, and stays rejected rather than accepted as a no-op.
 //!
 //! ## Widths, and why little-endian is exact
 //!
@@ -44,11 +49,15 @@
 //! the non-Intel path, so `from_le_bytes` here is exact rather than merely
 //! equivalent.
 
-use crate::ffi::{Io, FREEARC_ERRCODE_BAD_COMPRESSED_DATA, FREEARC_ERRCODE_IO, OK};
+use crate::ffi::{
+    Io, FREEARC_ERRCODE_BAD_COMPRESSED_DATA, FREEARC_ERRCODE_GENERAL, FREEARC_ERRCODE_IO, OK,
+};
+use crate::mmdet;
 use core::ffi::c_int;
 
 const BAD: c_int = FREEARC_ERRCODE_BAD_COMPRESSED_DATA as c_int;
 const IO: c_int = FREEARC_ERRCODE_IO as c_int;
+const GENERAL: c_int = FREEARC_ERRCODE_GENERAL as c_int;
 
 /// `BUFFER_SIZE` (Compression.h:38). Part of the format, not a tuning knob:
 /// the encoder emits its second and later blocks at `roundDown(BUFFER_SIZE,N)`,
@@ -449,6 +458,246 @@ fn copy_to_eof(io: &Io, buf: &mut [u8]) -> Result<(), c_int> {
             return Ok(());
         }
         write_out(io, &buf[..got as usize])?;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Encoder -- the port of `mm_compress` (mm.cpp:181).
+//
+// The filter itself is four `diff` routines and a header. Almost all of the
+// work is in deciding WHAT to filter: `mmdet` picks num_chan/word_size/offset,
+// and those three go into the stream header, so a detector that disagrees with
+// the C detector writes a different archive rather than a slightly worse one.
+// ---------------------------------------------------------------------------
+
+/// `BUFSIZE` (mm.cpp:183): the size of the first read, and so the largest block
+/// the filter ever emits. Later blocks are `roundDown(BUFFER_SIZE, N)`.
+const BUFSIZE: usize = 1 << 20;
+
+/// Forward byte transpose (`reorder_bytes`, mm.cpp:94). See `unreorder_bytes`
+/// for why the block length has to travel in the stream.
+fn reorder_bytes(buf: &mut [u8], n: usize, width: usize) {
+    let x = n * width;
+    if x == 0 || buf.len() < x {
+        return;
+    }
+    let len = buf.len();
+    let r = len / x;
+    let mut out = vec![0u8; len];
+    for i in 0..x {
+        for j in 0..r {
+            out[i * r + j] = buf[i + j * x];
+        }
+    }
+    let tail = len - (len % x);
+    out[tail..].copy_from_slice(&buf[tail..]);
+    buf.copy_from_slice(&out);
+}
+
+fn write_u32(io: &Io, v: u32) -> Result<(), c_int> {
+    write_out(io, &v.to_le_bytes())
+}
+
+fn encode(
+    io: &Io,
+    mode: c_int,
+    skip_header: bool,
+    is_float_in: c_int,
+    num_chan_in: c_int,
+    word_size_in: c_int,
+    offset_in: c_int,
+    reorder: c_int,
+) -> Result<(), c_int> {
+    let mut buf = vec![0u8; BUFSIZE + 1]; // +1 for diff3's 24-bit reads in C
+    let got = io.read(&mut buf[..BUFSIZE]);
+    if got <= 0 {
+        // C falls straight to `finished` and returns the read's own result, so
+        // an empty input produces an EMPTY stream -- not even a flags byte.
+        return if got < 0 { Err(got) } else { Ok(()) };
+    }
+    let bytes = got as usize;
+
+    // How much to examine, and which model sets to try. Modes 1-2 are the
+    // "fast" settings and look at less data with fewer candidate models.
+    let check_bytes = core::cmp::min(
+        if mode <= 2 {
+            64 * 1024
+        } else {
+            core::cmp::max(64 * 1024, bytes / 2)
+        },
+        bytes,
+    );
+    let (use_channels, use_bitvalues): (&[c_int], &[c_int]) = if mode <= 2 {
+        (&mmdet::FAST_CHANNELS, &mmdet::FAST_BITVALUES)
+    } else {
+        (&mmdet::CHANNELS, &mmdet::BITVALUES)
+    };
+
+    let mut is_float = is_float_in != 0;
+    let mut num_chan = num_chan_in;
+    let mut word_size = word_size_in;
+    let mut offset = offset_in;
+
+    if is_float || num_chan != 0 || word_size != 0 {
+        // Caller pinned the model; fill in whichever half they left out.
+        if num_chan == 0 {
+            num_chan = 1;
+        }
+        if word_size == 0 {
+            word_size = if is_float { 32 } else { 8 };
+        }
+    } else {
+        let detected = (if skip_header {
+            None
+        } else {
+            mmdet::autodetect_wav_header(&buf[..bytes])
+        })
+        .or_else(|| {
+            // The entropy analyser looks at a window in the MIDDLE of the
+            // block, not the start: file headers and leading silence are the
+            // least representative part of a media file.
+            let start = (bytes - check_bytes) / 2;
+            mmdet::autodetect_by_entropy(
+                &buf[start..start + check_bytes],
+                use_channels,
+                use_bitvalues,
+                0.80,
+            )
+        });
+        match detected {
+            Some(d) => {
+                is_float = d.is_float;
+                num_chan = d.num_chan;
+                word_size = d.word_size;
+                offset = d.offset;
+            }
+            // Neither detector recognised it: store the data intact.
+            None => {
+                is_float = false;
+                num_chan = 0;
+                word_size = 0;
+                offset = 0;
+            }
+        }
+    }
+    // is_float only ever picks a default word size. It is NOT recorded in the
+    // stream -- float samples are filtered as 32-bit integers.
+    let _ = is_float;
+
+    if offset > bytes as c_int {
+        offset = bytes as c_int; // else we would write a negative length
+    }
+    let offset = offset as usize;
+    let byte_size = ((word_size + 7) / 8) as usize;
+    let chan = num_chan as usize;
+    let n = chan * byte_size; // bytes per sample
+
+    // Don't filter a trailing partial sample in the first block; it is carried
+    // into the second one instead.
+    let mut blk = round_down(bytes - offset, n);
+    let mut rest = bytes - offset - blk;
+
+    // Room for the previous value of every channel. 24-bit samples accumulate
+    // in 32 bits, hence the 4.
+    let mut base = vec![0u8; chan * if byte_size == 3 { 4 } else { byte_size }];
+
+    if n == 0 {
+        // A single '\0' flags byte, then the data verbatim.
+        write_out(io, &[0u8])?;
+    } else {
+        // bit0 = diff, bit1 = reorder_bytes. num_chan is written as ONE byte,
+        // so a WAV claiming 256 channels wraps to 0 here -- the C does the same
+        // and the format has no room for more.
+        write_out(io, &[(1 + reorder * 2) as u8, num_chan as u8, word_size as u8])?;
+        write_u32(io, offset as u32)?;
+        write_out(io, &buf[..offset])?;
+        // Pad to a multiple of the sample size so the filter starts aligned.
+        // `base` is still all zeros and is what C writes these from.
+        let sofar = 3 + 4 + offset;
+        let pad = round_up(sofar, n) - sofar;
+        write_out(io, &base[..pad])?;
+    }
+
+    let mut ptr = offset; // first block skips the copied-through header
+    loop {
+        {
+            let data = &mut buf[ptr..ptr + blk];
+            match byte_size {
+                1 => diff1(data, chan, &mut base),
+                2 => diff2(data, chan, &mut base),
+                3 => diff3(data, chan, &mut base),
+                4 => diff4(data, chan, &mut base),
+                _ => {}
+            }
+            // reorder_words (:r2) is not resurrected: the C is `return buf;`.
+            if n != 0 && reorder == 1 {
+                reorder_bytes(data, chan, byte_size);
+            }
+        }
+        // The length prefix goes with the flag, and the flag only exists on the
+        // filtered path -- the stored path's header is a bare '\0' with nowhere
+        // to record it, and its decoder copies straight to EOF. Emitting a
+        // prefix there would corrupt the stream.
+        if n != 0 && reorder != 0 {
+            write_u32(io, blk as u32)?;
+        }
+        write_out(io, &buf[ptr..ptr + blk])?;
+
+        // Carry whatever did not make a whole sample into the next block.
+        buf.copy_within(ptr + blk..ptr + blk + rest, 0);
+
+        let chunk = if n > 1 {
+            round_down(BUFFER_SIZE, n)
+        } else {
+            BUFFER_SIZE
+        };
+        // A sample larger than the chunk size leaves nothing to read into. C
+        // passes the resulting negative count to the callback and gets an error
+        // back; here it would be a panic across the FFI boundary, so it is
+        // caught. Only reachable from a WAV header claiming thousands of
+        // channels.
+        if chunk <= rest {
+            return Err(GENERAL);
+        }
+        buf.resize(chunk + 1, 0);
+        ptr = 0;
+
+        let got = io.read(&mut buf[rest..chunk]);
+        if got < 0 {
+            return Err(got);
+        }
+        blk = got as usize + rest;
+        rest = 0;
+        if blk == 0 {
+            break;
+        }
+    }
+    Ok(())
+}
+
+/// `mm_compress`.
+pub fn compress(
+    io: &Io,
+    mode: c_int,
+    skip_header: c_int,
+    is_float: c_int,
+    num_chan: c_int,
+    word_size: c_int,
+    offset: c_int,
+    reorder: c_int,
+) -> c_int {
+    match encode(
+        io,
+        mode,
+        skip_header != 0,
+        is_float,
+        num_chan,
+        word_size,
+        offset,
+        reorder,
+    ) {
+        Ok(()) => OK,
+        Err(e) => e,
     }
 }
 

--- a/rust/darc-codecs/src/mmdet.rs
+++ b/rust/darc-codecs/src/mmdet.rs
@@ -1,0 +1,534 @@
+//! Multimedia autodetection -- the port of `Compression/MM/mmdet.cpp`.
+//!
+//! This decides `num_chan`, `word_size` and `offset`, and those three go
+//! straight into the MM stream header. It is therefore **archive-byte-visible**:
+//! a detector that picks a different model produces a different archive, not
+//! merely a worse one.
+//!
+//! ## What is ported, and what is not
+//!
+//! `mmdet.cpp` is 1,144 lines, but `autodetect_by_entropy` reaches only two of
+//! its scans: `run_order0()` and `diff_run`. `Model::run` for 16/24/32-bit, and
+//! the LZP/ROLZ/LZ77 models, are called only from that file's own `main()` --
+//! a standalone research tool that is not built into the archiver. They are not
+//! ported. Confirmed by sabotage: flipping the 24-bit non-diff scan from signed
+//! to unsigned reads changed no output anywhere, because nothing calls it.
+//!
+//! ## Arithmetic transliterated rather than tidied
+//!
+//! `calc_results` divides `total / count` as INTEGERS before taking the
+//! logarithm, and `result` truncates `xbits / 8` before adding it and then
+//! truncates the sum. Both are the original's and both are kept -- but neither
+//! is load-bearing in the way it first appears: for the distributions this sees,
+//! the truncation shifts the estimate by well under 0.01%, and every threshold
+//! it feeds is compared with far more margin than that. Sabotaging either one
+//! changes no archive byte across the whole differential corpus, including
+//! inputs built to sit on the order-0 gate. They are preserved because matching
+//! the C exactly is free here, not because a rounding difference is known to
+//! matter.
+//!
+//! The C is compiled into `mm.cpp` by `#include`, and is also called by
+//! `tta.cpp`, which is why the C file survives this port: TTA's encoder still
+//! needs it.
+
+use core::ffi::c_int;
+
+/// Counter slots per channel.
+const STATSIZE: usize = 1024;
+
+/// Channel counts autodetection will try, in order. Zero-terminated in C.
+pub const CHANNELS: [c_int; 4] = [1, 2, 3, 4];
+/// Word sizes autodetection will try, in order.
+pub const BITVALUES: [c_int; 4] = [8, 16, 24, 32];
+/// The reduced sets used by the fast modes (`mode <= 2`).
+pub const FAST_CHANNELS: [c_int; 2] = [1, 3];
+pub const FAST_BITVALUES: [c_int; 2] = [8, 16];
+
+/// Read an unsigned 24-bit little-endian value.
+#[inline]
+fn unsigned24(b: &[u8]) -> u32 {
+    (b[0] as u32) | ((b[1] as u32) << 8) | ((b[2] as u32) << 16)
+}
+
+#[inline]
+fn i16le(b: &[u8]) -> i16 {
+    i16::from_le_bytes([b[0], b[1]])
+}
+
+#[inline]
+fn u32le(b: &[u8]) -> u32 {
+    u32::from_le_bytes([b[0], b[1], b[2], b[3]])
+}
+
+#[inline]
+fn u16le(b: &[u8]) -> u16 {
+    u16::from_le_bytes([b[0], b[1]])
+}
+
+/// One candidate model, and the estimate of how well it would compress.
+///
+/// `stats` is dropped by `calc_results` in C (`FreeAndNil`) before the struct is
+/// ever copied into `best_model`, so the copy never carries the table. Here the
+/// table simply is not a field of the result: `finish` consumes it.
+#[derive(Clone, Copy)]
+pub struct ModelResult {
+    pub channels: c_int,
+    pub bitwidth: c_int,
+    pub offset: c_int,
+    pub result: i64,
+}
+
+struct Model {
+    channels: usize,
+    bitwidth: c_int,
+    offset: c_int,
+    /// Bits used for the small values, as a real number.
+    bits: f64,
+    /// Extra bits for values outside a single byte. `unsigned long` in C.
+    xbits: u64,
+    stats: Vec<i64>, // channels * STATSIZE, row-major
+}
+
+impl Model {
+    fn start(channels: usize, bitwidth: c_int, offset: c_int) -> Model {
+        Model {
+            channels,
+            bitwidth,
+            offset,
+            bits: 0.0,
+            // "additional space probably required for huffman tables (very
+            // estimated)" -- an int product in C, small enough never to overflow
+            // for the channel counts and widths this tries.
+            xbits: (channels as u64) * 128 * (bitwidth as u64),
+            stats: vec![0i64; channels * STATSIZE],
+        }
+    }
+
+    /// Slot an unsigned value and charge the extra bits its range costs.
+    ///
+    /// The largest value that can arrive is `2^32-1` (from `count` on a 32-bit
+    /// difference), which lands at `768 + 255 = 1023` -- exactly the last slot.
+    #[inline]
+    fn ucount(&mut self, channel: usize, x: u64) {
+        let base = channel * STATSIZE;
+        if x < (1 << 8) {
+            self.stats[base + x as usize] += 1;
+        } else if x < (1 << 16) {
+            self.stats[base + 256 + (x >> 8) as usize] += 1;
+            self.xbits += 8;
+        } else if x < (1 << 24) {
+            self.stats[base + 512 + (x >> 16) as usize] += 1;
+            self.xbits += 16;
+        } else {
+            self.stats[base + 768 + (x >> 24) as usize] += 1;
+            self.xbits += 24;
+        }
+    }
+
+    /// Zigzag a signed value onto the unsigned slots.
+    #[inline]
+    fn count(&mut self, channel: usize, x: i64) {
+        let z = if x >= 0 {
+            (x as u64).wrapping_mul(2)
+        } else {
+            ((-x) as u64).wrapping_mul(2) - 1
+        };
+        self.ucount(channel, z);
+    }
+
+    /// Estimated output size in bytes, under an order-0 arithmetic coder.
+    ///
+    /// `total / count` really is integer division in the original, before the
+    /// logarithm -- so a symbol occurring more than half the time contributes
+    /// `log2(1) = 0` bits. Likewise `xbits / 8` truncates before the addition.
+    /// Kept because matching the C exactly costs nothing here; see the module
+    /// comment for why neither turns out to change an archive byte.
+    fn finish(self) -> ModelResult {
+        let mut bits = 0.0f64;
+        for n in 0..self.channels {
+            let row = &self.stats[n * STATSIZE..(n + 1) * STATSIZE];
+            let total: i64 = row.iter().sum();
+            for &c in row.iter() {
+                if c != 0 {
+                    bits += (c as f64) * ((total / c) as f64).ln() / (2.0f64).ln();
+                }
+            }
+        }
+        let result = (bits / 8.0 + (self.xbits / 8) as f64) as i64;
+        ModelResult {
+            channels: self.channels as c_int,
+            bitwidth: self.bitwidth,
+            offset: self.offset,
+            result,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The scans. Each mirrors the C loop bound exactly, rewritten from pointer
+// arithmetic into byte offsets: the C `p + K <= bufend` is a bound on the
+// pointer AFTER K elements of the pointee type, so the byte bound depends on
+// that type, and the `_diff` variants advance by one sample while requiring two
+// to be in range.
+// ---------------------------------------------------------------------------
+
+/// The order-0 baseline, `Model::run(1, 8, 0)`.
+///
+/// This is the ONLY non-diff scan autodetection reaches. The 16/24/32-bit arms
+/// of C's `Model::run` exist for `mmdet.cpp`'s own `main()` and are not ported;
+/// see the module comment.
+fn run_order0(m: &mut Model, buf: &[u8]) {
+    for &b in buf {
+        m.ucount(0, b as u64);
+    }
+}
+
+fn diff_scan(m: &mut Model, buf: &[u8], n: usize, bitwidth: c_int) {
+    let len = buf.len();
+    match bitwidth {
+        8 => {
+            // Differences are taken in `unsigned char`, so they wrap at 8 bits
+            // -- matching diff1 in mm.cpp, which is what this estimates.
+            let mut b = 0;
+            while b + 2 * n <= len {
+                for i in 0..n {
+                    let d = buf[b + n + i].wrapping_sub(buf[b + i]);
+                    m.ucount(i, d as u64);
+                }
+                b += n;
+            }
+        }
+        16 => {
+            // C promotes both shorts to int and subtracts there: NO wrap at 16
+            // bits, unlike diff2. Preserved as written.
+            let mut b = 0;
+            while b + 4 * n <= len {
+                for i in 0..n {
+                    let hi = i16le(&buf[b + 2 * (n + i)..]) as i64;
+                    let lo = i16le(&buf[b + 2 * i..]) as i64;
+                    m.count(i, hi - lo);
+                }
+                b += 2 * n;
+            }
+        }
+        24 => {
+            // UNSIGNED here, signed in the non-diff scan. That asymmetry is the
+            // original's.
+            let mut b = 0;
+            while b + 6 * n <= len {
+                for i in 0..n {
+                    let hi = unsigned24(&buf[b + 3 * n + 3 * i..]) as i64;
+                    let lo = unsigned24(&buf[b + 3 * i..]) as i64;
+                    m.count(i, hi - lo);
+                }
+                b += 3 * n;
+            }
+        }
+        32 => {
+            // Taken unsigned and cast back, so it wraps at 32 bits the way
+            // diff4 does -- and so it stays inside what `count` can slot.
+            let mut b = 0;
+            while b + 8 * n <= len {
+                for i in 0..n {
+                    let hi = u32le(&buf[b + 4 * (n + i)..]);
+                    let lo = u32le(&buf[b + 4 * i..]);
+                    m.count(i, hi.wrapping_sub(lo) as i32 as i64);
+                }
+                b += 4 * n;
+            }
+        }
+        _ => unreachable!("diff_scan called with bitwidth {bitwidth}"),
+    }
+}
+
+fn run_model(buf: &[u8], channels: usize, bitwidth: c_int, offset: c_int, diff: bool) -> ModelResult {
+    let mut m = Model::start(channels, bitwidth, offset);
+    let off = offset as usize;
+    let tail = if off <= buf.len() { &buf[off..] } else { &buf[..0] };
+    if diff {
+        diff_scan(&mut m, tail, channels, bitwidth);
+    } else {
+        // Only ever reached as run_order0() -- channels 1, bitwidth 8.
+        run_order0(&mut m, tail);
+    }
+    m.finish()
+}
+
+// ---------------------------------------------------------------------------
+// WAV header recognition
+// ---------------------------------------------------------------------------
+
+const WAVE_FORMAT_PCM: u16 = 1;
+const WAVE_FORMAT_PCM2: u16 = 0xFFFE;
+const WAVE_FORMAT_IEEE_FLOAT: u16 = 3;
+
+const RIFF_SIGN: u32 = 0x4646_4952;
+const WAVE_SIGN: u32 = 0x4556_4157;
+const FMT_SIGN: u32 = 0x2074_6D66;
+const DATA_SIGN: u32 = 0x6174_6164;
+
+const MAX_BPS: u16 = 32;
+
+/// `sizeof(wave_hdr_t)` -- five u32, then u16,u16,u32,u32,u16,u16. All fields
+/// are naturally aligned at those offsets, so the struct is 36 bytes with no
+/// padding, and the C code indexes the file through it directly.
+const WAVE_HDR_SIZE: usize = 36;
+/// `sizeof(subchunk_hdr)`.
+const SUBCHUNK_HDR_SIZE: usize = 8;
+
+/// What autodetection concluded.
+pub struct Detected {
+    pub is_float: bool,
+    pub num_chan: c_int,
+    pub word_size: c_int,
+    pub offset: c_int,
+}
+
+/// Recognise a RIFF/WAVE header and locate the sample data.
+///
+/// Note there is NO check that `BitsPerSample` is one of 8/16/24/32, and
+/// `NumChannels` is a 16-bit field that `mm_compress` later stores in a single
+/// header BYTE. Both are the original's behaviour and both are preserved --
+/// the encoder must agree with the C encoder, defects included.
+pub fn autodetect_wav_header(buf: &[u8]) -> Option<Detected> {
+    let size = buf.len();
+    if size < WAVE_HDR_SIZE {
+        return None;
+    }
+    let chunk_id = u32le(&buf[0..]);
+    let chunk_size = u32le(&buf[4..]);
+    let format = u32le(&buf[8..]);
+    let subchunk1_id = u32le(&buf[12..]);
+    let subchunk1_size = u32le(&buf[16..]);
+    let audio_format = u16le(&buf[20..]);
+    let num_channels = u16le(&buf[22..]);
+    let bits_per_sample = u16le(&buf[34..]);
+
+    if chunk_id != RIFF_SIGN
+        || format != WAVE_SIGN
+        || subchunk1_id != FMT_SIGN
+        || subchunk1_size > chunk_size
+        || num_channels == 0
+        || bits_per_sample > MAX_BPS
+    {
+        return None;
+    }
+
+    let is_float = match audio_format {
+        WAVE_FORMAT_IEEE_FLOAT => true,
+        WAVE_FORMAT_PCM | WAVE_FORMAT_PCM2 => false,
+        _ => return None,
+    };
+
+    // p points just past the headers, at the samples.
+    let mut p = WAVE_HDR_SIZE;
+
+    if subchunk1_size > 16 {
+        let extra = (subchunk1_size - 16) as u64;
+        if extra >= (size - p) as u64 {
+            return None;
+        }
+        p += extra as usize;
+    }
+
+    if SUBCHUNK_HDR_SIZE >= size - p {
+        return None;
+    }
+
+    // Skip any subchunks before `data`. Each check keeps p inside the buffer
+    // with at least a subchunk header to spare, so the read at the top of the
+    // loop is always in range.
+    while u32le(&buf[p..]) != DATA_SIGN {
+        let skip = SUBCHUNK_HDR_SIZE as u64 + u32le(&buf[p + 4..]) as u64;
+        if skip + SUBCHUNK_HDR_SIZE as u64 >= (size - p) as u64 {
+            return None;
+        }
+        p += skip as usize;
+    }
+    p += SUBCHUNK_HDR_SIZE;
+
+    Some(Detected {
+        is_float,
+        num_chan: num_channels as c_int,
+        word_size: bits_per_sample as c_int,
+        offset: p as c_int,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Entropy-based autodetection
+// ---------------------------------------------------------------------------
+
+/// The three selection rules, applied to one candidate in iteration order.
+///
+/// They are three INDEPENDENT `if`s in the original, not a chain, and they are
+/// not mutually exclusive: a candidate can be adopted by the first and then
+/// examined again by the third within the same call. Turning them into
+/// `else if` changes the winner, so the shape is preserved exactly.
+///
+/// This is split out because the differential corpus cannot reach it. Real
+/// candidates come out near-tied -- the runner-up scores within 0.1% of the
+/// best on every input measured -- so the +/-5% bands admit or reject the same
+/// model whatever their exact value, and perturbing 0.95 or 1.05 changes no
+/// archive byte. The bands still have to be right, hence the unit tests below,
+/// which construct the near-ties that real data does not.
+fn consider(best: &mut ModelResult, m: ModelResult, model0: i64) {
+    // Better, and not narrower than what we have.
+    if m.result < best.result && m.bitwidth >= best.bitwidth {
+        *best = m;
+    }
+    // Prefer a WIDER word if it is still close enough, and actually beats
+    // order-0.
+    if m.bitwidth > best.bitwidth
+        && (m.result as f64) < best.result as f64 * 1.05
+        && (m.result as f64) < model0 as f64 * 0.95
+    {
+        *best = m;
+    }
+    // ...and the opposite: a narrower word that wins outright by 5%.
+    if (m.result as f64) < best.result as f64 * 0.95 {
+        *best = m;
+    }
+}
+
+/// Try every (channels, wordsize, offset) model and pick the best, or give up.
+///
+/// The three selection rules run in sequence and are NOT mutually exclusive --
+/// a model can be adopted by the first and then again by the third within one
+/// iteration. Written as three independent `if`s because that is what the
+/// original does, and collapsing them into `else if` changes the winner.
+pub fn autodetect_by_entropy(
+    buf: &[u8],
+    channels: &[c_int],
+    bitvalues: &[c_int],
+    min_entropy: f64,
+) -> Option<Detected> {
+    if buf.len() < 500 {
+        return None; // not enough data to decide
+    }
+
+    // Order-0 baseline: if a plain order-0 coder already shrinks this a lot,
+    // it is not multimedia.
+    let model0 = run_model(buf, 1, 8, 0, false).result;
+    if (model0 as f64) < buf.len() as f64 * min_entropy {
+        return None;
+    }
+
+    // C writes `Model best_model; best_model.result = LONG_MAX;` -- and Model's
+    // constructor sets only buf/bufsize, so `bitwidth` starts as whatever was on
+    // the stack. It does not matter: on the first candidate, either rule 1 fires
+    // (garbage width <= m's) or rule 3 does (anything beats LONG_MAX*0.95), so
+    // `best` becomes that candidate either way. Zero is the honest stand-in.
+    let mut best = ModelResult {
+        channels: 0,
+        bitwidth: 0,
+        offset: 0,
+        result: i64::MAX, // LONG_MAX; `long` is 64-bit on every build here
+    };
+
+    for &n in channels {
+        for &bits in bitvalues {
+            let mut offset = 0;
+            while offset * 8 < bits {
+                consider(&mut best, run_model(buf, n as usize, bits, offset, true), model0);
+                offset += 1;
+            }
+        }
+    }
+
+    // Only worth filtering if it beats order-0 by at least 5%.
+    if (best.result as f64) < model0 as f64 * 0.95 {
+        Some(Detected {
+            is_float: false,
+            num_chan: best.channels,
+            word_size: best.bitwidth,
+            offset: best.offset,
+        })
+    } else {
+        None
+    }
+}
+
+
+#[cfg(test)]
+mod selection_tests {
+    use super::*;
+
+    fn m(channels: c_int, bitwidth: c_int, result: i64) -> ModelResult {
+        ModelResult { channels, bitwidth, offset: 0, result }
+    }
+    fn seed() -> ModelResult {
+        m(0, 0, i64::MAX)
+    }
+
+    /// The very first candidate must always be adopted, whatever it scores.
+    /// C relies on LONG_MAX plus an uninitialised `bitwidth` for this; the port
+    /// uses 0, and the two must agree.
+    #[test]
+    fn first_candidate_is_always_adopted() {
+        for width in [8, 16, 24, 32] {
+            let mut best = seed();
+            consider(&mut best, m(1, width, 900_000), 1_000_000);
+            assert_eq!(best.bitwidth, width);
+            assert_eq!(best.result, 900_000);
+        }
+    }
+
+    /// Rule 1 is `>=`, not `>`: an equally wide model that scores better wins.
+    /// With `>` it would be rejected here and rule 3 would not save it either,
+    /// because 990 is not 5% better than 1000.
+    #[test]
+    fn equal_width_and_better_score_wins() {
+        let mut best = m(1, 16, 1000);
+        consider(&mut best, m(2, 16, 990), 10_000);
+        assert_eq!(best.channels, 2, "the >= in rule 1 is load-bearing");
+    }
+
+    /// Rule 1 refuses to go narrower even for a better score...
+    #[test]
+    fn narrower_is_refused_unless_much_better() {
+        let mut best = m(1, 16, 1000);
+        consider(&mut best, m(1, 8, 960), 10_000); // 4% better: not enough
+        assert_eq!(best.bitwidth, 16);
+    }
+
+    /// ...until rule 3's 5% margin is cleared.
+    #[test]
+    fn narrower_wins_at_five_percent() {
+        let mut best = m(1, 16, 1000);
+        consider(&mut best, m(1, 8, 940), 10_000); // 6% better
+        assert_eq!(best.bitwidth, 8, "rule 3 must override the width preference");
+    }
+
+    /// Rule 2 takes a WIDER model that is merely close, not better -- but only
+    /// if it also beats order-0 by 5%. Both halves are checked, because a
+    /// corpus cannot reach either.
+    #[test]
+    fn wider_wins_inside_the_five_percent_band() {
+        let mut best = m(1, 8, 1000);
+        consider(&mut best, m(1, 16, 1040), 2000); // 4% worse, but wider
+        assert_eq!(best.bitwidth, 16);
+
+        let mut best = m(1, 8, 1000);
+        consider(&mut best, m(1, 16, 1060), 2000); // 6% worse: outside the band
+        assert_eq!(best.bitwidth, 8);
+
+        // Wider and inside the band, but does not beat order-0 by 5%.
+        let mut best = m(1, 8, 1000);
+        consider(&mut best, m(1, 16, 1040), 1050);
+        assert_eq!(best.bitwidth, 8, "rule 2's order-0 condition is load-bearing");
+    }
+
+    /// The rules are three independent `if`s. A candidate adopted by rule 1 is
+    /// still tested by rules 2 and 3 in the same call -- which is harmless only
+    /// because `best` has become the candidate itself by then. Collapsing them
+    /// into `else if` is what this pins against.
+    #[test]
+    fn rules_are_independent_not_chained() {
+        let mut best = m(1, 16, 1000);
+        consider(&mut best, m(2, 16, 500), 10_000);
+        // Rule 1 adopts it; rule 3 then compares 500 < 500*0.95, which is false.
+        assert_eq!(best.channels, 2);
+        assert_eq!(best.result, 500);
+    }
+}

--- a/rust/difftest/mm-check.sh
+++ b/rust/difftest/mm-check.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
-# Differential-test the MM decoder port against the C original.
+# Differential-test the MM port -- BOTH directions -- against the C original.
 #
-# MM is ported decode-first, so the C compressor is the only encoder: filter
-# each input with C (over a matrix of channel counts, word sizes, header
-# offsets and detector modes), unfilter with both C and the Rust port, and
-# require both to reproduce the original. Byte-for-byte equality is the bar
-# because MM defines an archive format.
+# Over a matrix of channel counts, word sizes, header offsets and detector
+# modes: filter each input with BOTH encoders and require the two streams to be
+# identical, then unfilter with both decoders and require both to reproduce the
+# original. Byte-for-byte equality is the bar in both directions because MM
+# defines an archive format -- for the encoder that means the autodetector must
+# pick the same model, since its choice travels in the stream header.
 #
 # Inputs are deliberately larger than 1 MB: mm_compress reads a first block of
 # up to 1 MB and then switches to 64 KB blocks, while the decoder always reads
@@ -79,6 +80,98 @@ w("text",     (b"the quick brown fox jumps over the lazy dog. " * 30000))
 # about. The Rust port's behaviour on it is pinned by tests/mm.rs instead.
 for n in (1,3,7,8,63, (1<<20)-1, 1<<20, (1<<20)+1, (1<<20)+7):
     w(f"n_{n}", (pcm*8)[:n])
+
+# --- inputs where the detector's DECISION is marginal ------------------------
+# Everything above is unambiguous multimedia or unambiguous noise, so the
+# winning model wins by a wide margin and the scoring arithmetic can be
+# perturbed without changing the answer. Sabotaging the entropy estimator --
+# making `total/count` a real ratio instead of the original's integer division,
+# or rounding xbits/8 instead of truncating it -- left this corpus fully green,
+# which means it was testing that the detector does not crash, not that it
+# agrees.
+#
+# These blend a clean signal into noise across the range, so some land inside
+# the 5% bands the selection rules actually use (`result < best*0.95`,
+# `result < best*1.05`, and the final `best < model0*0.95` gate). Near those
+# boundaries a small change in the estimate flips the chosen model, and the
+# choice travels in the stream header.
+M=60000                                       # ~240 KB stereo 16-bit: enough for
+for k in range(0, 12):                        # detection, small enough to stay quick
+    amp = 1.0 - k/12.0
+    noise = prng(1000+k, 4*M)
+    w(f"blend16_{k:02d}", s16([
+        (amp*12000*math.sin(i*0.031) + (1-amp)*((noise[(2*i) % len(noise)]-128)*90))
+        for i in range(2*M) ]))
+# Ambiguous between 8- and 16-bit: a 16-bit signal whose low byte carries almost
+# as much structure as the high one, so the two models score close together.
+w("amb8_16", bytes([ v for i in range(500000) for v in
+                     ((i*13)%251, (128+int(60*math.sin(i*0.02)))&0xff) ]))
+# 24-bit samples with the top bit SET, so signed and unsigned readings of them
+# differ. _24bit_run measures signed values while _24bit_diff_run measures
+# differences of unsigned ones -- an asymmetry that is invisible unless the
+# values actually cross 2^23.
+w("hi24", b"".join(struct.pack("<I", (0xC00000 + int(200000*math.sin(i*0.02))) & 0xffffff)[:3]
+                   for i in range(200000)))
+
+# --- inputs sitting ON the order-0 gate --------------------------------------
+# autodetect_by_entropy's first act is an ABSOLUTE threshold:
+#
+#     if (model0_result < bufsize*min_entropy) return 0;    // min_entropy=0.80
+#
+# i.e. "if a plain order-0 coder already gets this below 0.80 bytes/byte, it is
+# not multimedia". That gate is the one place a change in the entropy ESTIMATE
+# flips the output wholesale, from a filtered stream to a stored one. It sits at
+# 6.4 bits/byte.
+#
+# Uniform data will not do it. calc_results scores a slot as
+# `count * log2(total/count)` with total/count computed as an INTEGER division,
+# and for a uniform alphabet of k symbols that quotient is exactly k, so the
+# truncation is a no-op and the quirk is invisible. The distribution has to be
+# skewed for floor() to bite. These are geometric over 256 symbols, with the
+# rate bisected to land the entropy either side of 6.4.
+def geometric_bytes(target_bits, n, seed):
+    import bisect
+    def ent(r):
+        p = [r**i for i in range(256)]
+        s = sum(p); p = [x/s for x in p]
+        return -sum(x*math.log2(x) for x in p if x > 0), p
+    lo, hi = 0.5, 0.99999          # entropy rises with r
+    for _ in range(60):
+        mid = (lo+hi)/2
+        if ent(mid)[0] < target_bits: lo = mid
+        else: hi = mid
+    _, p = ent((lo+hi)/2)
+    cum = []; acc = 0.0
+    for x in p: acc += x; cum.append(acc)
+    s = seed; o = bytearray()
+    for _ in range(n):
+        s = (s*1103515245+12345) & 0xffffffff
+        o.append(min(255, bisect.bisect_left(cum, ((s>>8)&0xffffff)/0x1000000)))
+    return bytes(o)
+
+for j, tb in enumerate([6.20, 6.30, 6.35, 6.38, 6.40, 6.42, 6.45, 6.50, 6.60]):
+    w(f"gate8_{j}", geometric_bytes(tb, 200000, 7000+j))
+
+# Skewed noise alone is not enough to exercise that gate: it lands on the right
+# side of 0.80 but is then refused by the SECOND gate (`best < model0*0.95`),
+# because differencing noise never beats order-0. An input has to fail one gate
+# and pass the other, which means quiet multimedia -- low order-0 entropy AND a
+# large diff advantage.
+#
+# Amplitude is the knob. Measured on stereo 16-bit sine (order-0 bytes/byte,
+# then best-model/order-0):
+#
+#     amp  700 -> 0.7643, 0.43      amp 1400 -> 0.8244, 0.47
+#     amp 1000 -> 0.7932, 0.46      amp 2200 -> 0.8580, 0.50
+#
+# So ~1000 sits inside the gate's band while compressing 54% better than
+# order-0. Note what that means for the codec: this data is EXCELLENT for MM and
+# the detector stores it anyway, because the gate asks "is order-0 already good"
+# rather than "would MM help". That is the original's behaviour, and pinning it
+# is the point.
+for amp in (700, 850, 950, 1000, 1050, 1150, 1400, 2200):
+    w(f"quiet16_a{amp}", s16([ v for i in range(2*60000) for v in
+                               (amp*math.sin(i*0.03), amp*0.75*math.sin(i*0.041)) ][:2*60000]))
 PY
 
 stored=0 filtered=0          # which decoder branch each stream actually took
@@ -90,6 +183,12 @@ decode_case () {   # $1=tag  $2..=encoder args (MODE SKIPHDR ISFLOAT NUMCHAN WOR
   for f in "$W"/in/*; do
     n=$((n+1)); local name; name=$(basename "$f")
     "$W/c"  c $ec < "$f"        >| "$W/stream" 2>/dev/null || { echo "  [$tag] $name: C-compress FAILED"; fail=$((fail+1)); continue; }
+    # The encoder is held to BYTE equality with the C, not merely to producing
+    # something decodable: MM is one of DArc's own formats, so a stream that
+    # differs is a different archive. This is also the only check that reaches
+    # the autodetector's model-scoring arithmetic, which decides the header.
+    "$W/rs" c $ec < "$f"        >| "$W/stream_rs" 2>/dev/null || { echo "  [$tag] $name: RUST-compress FAILED"; fail=$((fail+1)); continue; }
+    cmp -s "$W/stream" "$W/stream_rs" || { echo "  [$tag] $name: RUST-encode != C-encode"; fail=$((fail+1)); continue; }
     "$W/c"  d     < "$W/stream" >| "$W/oc"     2>/dev/null || { echo "  [$tag] $name: C-decode FAILED";   fail=$((fail+1)); continue; }
     "$W/rs" d     < "$W/stream" >| "$W/ors"    2>/dev/null || { echo "  [$tag] $name: RUST-decode FAILED"; fail=$((fail+1)); continue; }
     cmp -s "$f" "$W/oc"  || { echo "  [$tag] $name: C-decode != original (harness bug)"; fail=$((fail+1)); continue; }
@@ -127,7 +226,7 @@ decode_case "2*16 off44"     9 0 0 2 16 44; total=$((total+$?))
 decode_case "3*8 off1"       9 0 0 3 8  1 ; total=$((total+$?))
 decode_case "4*16 off13"     9 0 0 4 16 13; total=$((total+$?))
 
-echo "mm decode: $total total differing ($filtered filtered streams, $stored stored)"
+echo "mm: $total total differing ($filtered filtered streams, $stored stored)"
 [ "$stored"   -gt 0 ] || { echo "corpus never reached the stored branch"; exit 1; }
 [ "$filtered" -gt 0 ] || { echo "corpus never reached the filtered branch"; exit 1; }
-[ "$total"    -eq 0 ] && echo "MM decoder matches the C original byte for byte" || exit 1
+[ "$total"    -eq 0 ] && echo "MM matches the C original byte for byte, both directions" || exit 1

--- a/rust/difftest/mm_ref.cpp
+++ b/rust/difftest/mm_ref.cpp
@@ -3,20 +3,27 @@
  *     mm_ref c MODE SKIPHDR ISFLOAT NUMCHAN WORDSIZE OFFSET  <in >stream
  *     mm_ref d                                               <stream >out
  *
- * Built a second time with -DUSE_RUST so `d` drives the Rust port instead. MM
- * is ported decode-first (like REP, Dict, LZP and TTA), so there is no Rust
- * encoder: the stream always comes from the C compressor, and the test is that
- * the Rust decoder reproduces the original bytes from it.
+ * Built a second time with -DUSE_RUST so BOTH directions drive the Rust port
+ * instead. Decode was ported first (like REP, Dict, LZP and TTA); the encoder
+ * followed, so `c` now has two implementations to compare and the bar for it is
+ * byte-exact stream equality, not merely round-trippability. MM defines an
+ * archive format: a stream that differs from the C's would still decode through
+ * our own decoder while making archives other builds read differently.
  *
  * Both explicit parameters and autodetection are worth exercising, so the
  * encoder arguments are passed straight through: leave NUMCHAN/WORDSIZE at 0
  * and mm_compress runs its WAV-header and entropy detectors, which is how real
  * archives get their header -- and, on input it cannot classify, is how the
- * "stored" branch of the decoder gets reached.
+ * "stored" branch of the decoder gets reached. Autodetection is the substance
+ * of the encoder port (~600 of its ~730 lines), and it is *only* reached with
+ * those two left at 0.
  *
- * `reorder` is deliberately not exposed: mm.cpp's decoder rejects those flag
- * bits (the unreorder side was never written), so an encoder run with -r1
- * produces a stream nothing can decode.
+ * `reorder` is deliberately not exposed here. It is the one part of MM that
+ * cannot be pinned against the reference: the C reorder path is being changed
+ * in the same work that ports it -- it wrote a flag no decoder accepted, and
+ * gains a block-length prefix to become decodable -- so the pinned C is not an
+ * oracle for it. Tests/mm-reorder-check.sh covers that path by round-trip
+ * instead, across every tail remainder.
  */
 #include <stdio.h>
 #include <stdlib.h>
@@ -30,6 +37,7 @@ int mm_compress   (int, int, int, int, int, int, int, CALLBACK_FUNC*, void*);
 int mm_decompress (CALLBACK_FUNC*, void*);
 #ifdef USE_RUST
 extern "C" int darc_rs_mm_decompress (CALLBACK_FUNC*, void*);
+extern "C" int darc_rs_mm_compress   (int, int, int, int, int, int, int, CALLBACK_FUNC*, void*);
 #endif
 
 struct Buffers {
@@ -71,7 +79,11 @@ int main (int argc, char **argv) {
     int num_chan    = argc>5? atoi(argv[5]) : 0;
     int word_size   = argc>6? atoi(argv[6]) : 0;
     int offset      = argc>7? atoi(argv[7]) : 0;
+#ifdef USE_RUST
+    rc = darc_rs_mm_compress (mode, skip_header, is_float, num_chan, word_size, offset, 0, io_callback, &b);
+#else
     rc = mm_compress (mode, skip_header, is_float, num_chan, word_size, offset, 0, io_callback, &b);
+#endif
   } else {
 #ifdef USE_RUST
     rc = darc_rs_mm_decompress (io_callback, &b);


### PR DESCRIPTION
Completes MM in both directions, and adds the encryption interop check that
started this branch.

## MM is now Rust end to end

`mm_compress` and the part of `mmdet.cpp` it actually reaches are ported, and
the C `mm_compress` is excluded under `DARC_RUST`. Archives are unchanged: the
three MM fingerprints hold, and archives built by the `DARC_RUST` and
`DARC_NO_RUST` binaries are byte-identical across `-mmm`, `:c2:w16`, `:r1`,
`:c1:w8` and `:c3:w24`.

The detector, not the filter, is the substance. It picks
`num_chan`/`word_size`/`offset`, and those travel in the stream header — so a
detector that chooses differently writes a *different archive*, not a slightly
worse one.

**`mmdet.cpp` is deliberately NOT deleted.** `tta.cpp:322-324` calls both
autodetect entry points directly, so it survives until TTA's encoder is ported.
Only `mm_compress` leaves the C.

**Only what autodetection reaches is ported.** `Model::run` for 16/24/32-bit and
the LZP/ROLZ/LZ77 models are called solely from `mmdet.cpp`'s own `main()`, a
research tool not built into the archiver. A sabotage of the 24-bit non-diff
scan changed no output anywhere, because nothing calls it — so ~200 lines were
left behind rather than transliterated blind.

## A latent bug that would have made the port inert

`C_MM.h` declared `mm_compress` with **eight** parameters against a nine-
parameter definition (no `mode`; `byte_size` where it is really `word_size`).
`C_MM.cpp` includes that header inside `extern "C"` precisely so the definition
inherits C linkage — but the arity mismatch made it a second, never-defined
overload, leaving the real function C++-mangled as
`__Z11mm_compressiiiiiiiPFiPKcPviS1_ES1_`.

Harmless while both sides were C. Not harmless here: an `extern "C"` drop-in
would have replaced nothing, the C would have kept running, and **every test
would still have passed**. Caught with `nm`, not by a test.

## ':r1' byte reordering, which could be written but never read

The encoder set `header[0] = 1 + reorder*2` and both decoders rejected any flag
bit above bit 0, so `-mmm:r1` produced archives that were created successfully
and then failed to extract. Three things were missing, not one:

* **The block length.** The transpose is parameterised by it, and the encoder's
  blocks are not fixed — first up to 1 MB, then 64 KB, then whatever remains.
  Nothing recorded it, so the permutation could not be inverted even with a
  correct inverse in hand. Each reorder block now carries a 4-byte prefix.
* **The order.** Encode diffs then reorders, so decode must un-reorder *before*
  undiffing. The abandoned stub had it backwards.
* **Buffer growth**, bounded by `MAX_REORDER_BLOCK` so a declared length cannot
  choose the allocation size.

A deliberate format extension: no such archive was ever extractable, so there is
nothing to stay compatible with. `:r2` stays rejected — `reorder_words()` is
`return buf;`, a flag that means nothing.

Gain end to end: `-mmm+lzma` 50,774 bytes → `-mmm:r1+lzma` 20,613 (59% smaller).

Two bugs found on the way, both in code that already round-tripped green:

* `reorder_bytes` indexed its output `i*bufsize/X`, which C evaluates as
  `(i*bufsize)/X` — drifting past `i*(bufsize/X)` by `floor(i*s/X)` once the
  tail `s = bufsize%X` reaches 2. One byte was dropped into the tail region and
  overwritten while an earlier slot kept whatever `malloc` returned: lossy *and*
  nondeterministic. Tails of 0 and 1 are identical either way and the first
  block is rounded to whole samples, so only a final short block can reach it —
  it needs an input just over 1 MB (1048582 bytes at `c2:w16` fails its CRC).
* My own length prefix was written whenever `reorder` was set, including when
  autodetection gives up. There `N` is 0, the header is a bare `\0` with no
  flags byte, and that decoder copies to EOF — so `-mmm:r1` on any text or
  already-compressed file failed its CRC. Both are now conditional on `N`.

## Testing, including what it does not cover

`rust/difftest/mm-check.sh` now compares the produced **stream** between the C
and Rust encoders, not just the round-trip: 645 comparisons over 43 inputs and
15 parameter sets, 0 differing.

The old corpus could not fail. It is all clean sine and clean noise, where the
winning model wins by so much that the scoring arithmetic can be perturbed
freely. The order-0 gate in particular needed an input that fails it while
passing the *second* gate — quiet multimedia. Measured amplitude-1000 stereo
sine at 0.7932 bytes/byte against the 0.80 gate, compressing 54% better than
order-0; moving the gate to 0.78 now flips 16 streams.

The three ±5% selection rules and the `>=` bitwidth tie-break **still cannot be
reached from any corpus** — real candidates come out tied to within 0.1%, so
those bands admit or reject the same model whatever their value. They are
extracted into `consider()` and unit-tested against constructed near-ties
instead; five rule sabotages each fail exactly one test. Differential test for
agreement, unit test for the branch semantics it provably cannot reach.

`Tests/mm-reorder-check.sh` (new, wired into CI) sweeps every tail remainder
across nine geometries plus two autodetect-refused inputs — 52 cases. Verified
to fail when sabotaged: the C index bug 33/52, a reversed Rust inverse 51/52, a
skipped un-reorder 51/52 (the survivor in both is `c1:w8`, where X=1 makes the
transpose the identity), the stored-path guard exactly the 2 new cases.

## Also here

`Tests/enc-roundtrip.sh` in CI: encrypted archives must interoperate between the
C and Rust crypto, both directions, across AES/Blowfish/Serpent/Twofish and CFB.
Verified to fail when the CTR carry direction is reversed.

## Local results

* `mm-check.sh` 645 comparisons, 0 differing
* 133/133 Rust tests
* `run-tests.sh` 24/24 on **both** build configurations, MM fingerprints unchanged
* `mm-reorder-check.sh` 52/52 on both

🤖 Generated with [Claude Code](https://claude.com/claude-code)
