### PR TITLE
TTA: port the encoder to Rust

### DIFF
--- a/Compression/MM/tta.cpp
+++ b/Compression/MM/tta.cpp
@@ -291,6 +291,25 @@ void combine_float (long frame_len, long num_chan, long **buffer)
 
 
 #ifndef FREEARC_DECOMPRESS_ONLY
+// DARC_RUST=1 selects the Rust port of the encoder (rust/darc-codecs, tta.rs +
+// mmdet.rs), excluded rather than redeclared for the same reason as the decoder
+// below: both have C linkage, so GNU ld would report a multiple definition.
+//
+// Unlike C_MM.h, ttaenc.h declares this with the SAME signature as the
+// definition, so the definition really does inherit the C linkage that
+// C_TTA.cpp's `extern "C"` block intends -- which is what lets the drop-in take
+// the symbol. C_TTA::compress reaches it through LoadFromDLL's fallback, so the
+// replacement applies there too.
+//
+// read_wave/split_int/split_float above and the encode halves of entropy.cpp
+// and filters.cpp are now unreferenced, but stay: they are compiled into this
+// same translation unit and cost only a few unused bytes, while removing them
+// would widen the exclusion for no gain.
+//
+// Verified byte-identical to the C encoder across levels 1-3, 8/16/24-bit,
+// mono/stereo, float, raw mode, the storing path and autodetection; see
+// rust/difftest/tta-check.sh, which now compares the produced STREAM.
+#ifndef DARC_RUST
 int tta_compress (int level, int skip_header, int is_float, int num_chan, int word_size, int offset, int raw_data, CALLBACK_FUNC *callback, void *auxdata)
 {
     long            *data=NULL, **buffer=NULL;
@@ -436,6 +455,7 @@ finished:
 
     return errcode;
 }
+#endif  // !defined (DARC_RUST)
 #endif
 
 // DARC_RUST=1 selects the Rust port of the decoder (rust/darc-codecs).

--- a/rust/darc-codecs/src/exports.rs
+++ b/rust/darc-codecs/src/exports.rs
@@ -291,6 +291,54 @@ pub unsafe extern "C" fn tta_decompress(
     darc_rs_tta_decompress(callback, auxdata)
 }
 
+/// TTA encoder. `level` 0 stores; 1-3 select the adaptive filter set. The
+/// channel count and word size are autodetected when left at 0, exactly as for
+/// MM -- TTA calls the same detector, with a looser entropy threshold.
+///
+/// # Safety
+/// `callback` and `auxdata` must be what the C caller supplied.
+#[no_mangle]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn darc_rs_tta_compress(
+    level: c_int,
+    skip_header: c_int,
+    is_float: c_int,
+    num_chan: c_int,
+    word_size: c_int,
+    offset: c_int,
+    raw_data: c_int,
+    callback: CALLBACK_FUNC,
+    auxdata: *mut c_void,
+) -> c_int {
+    match Io::new(callback, auxdata) {
+        Some(io) => tta::compress(
+            &io, level, skip_header, is_float, num_chan, word_size, offset, raw_data,
+        ),
+        None => FREEARC_ERRCODE_GENERAL,
+    }
+}
+
+/// # Safety
+/// `callback` and `auxdata` must be what the C caller supplied.
+#[cfg(feature = "dropin")]
+#[no_mangle]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn tta_compress(
+    level: c_int,
+    skip_header: c_int,
+    is_float: c_int,
+    num_chan: c_int,
+    word_size: c_int,
+    offset: c_int,
+    raw_data: c_int,
+    callback: CALLBACK_FUNC,
+    auxdata: *mut c_void,
+) -> c_int {
+    darc_rs_tta_compress(
+        level, skip_header, is_float, num_chan, word_size, offset, raw_data, callback, auxdata,
+    )
+}
+
 /// MM decoder. Like TTA it takes no tuning parameters -- the channel count and
 /// word size the encoder settled on travel in the stream header.
 ///

--- a/rust/darc-codecs/src/tta.rs
+++ b/rust/darc-codecs/src/tta.rs
@@ -42,6 +42,7 @@
 use crate::ffi::{Io, FREEARC_ERRCODE_BAD_COMPRESSED_DATA, FREEARC_ERRCODE_IO,
                  FREEARC_ERRCODE_NOT_ENOUGH_MEMORY, OK};
 use core::ffi::c_int;
+use crate::mmdet;
 
 const BAD: c_int = FREEARC_ERRCODE_BAD_COMPRESSED_DATA as c_int;
 const IO: c_int = FREEARC_ERRCODE_IO as c_int;
@@ -654,4 +655,691 @@ fn alloc2d(num: usize, len: usize) -> Result<Vec<Vec<i64>>, c_int> {
         return Err(NOMEM);
     }
     Ok(vec![vec![0i64; len]; num])
+}
+
+// ---------------------------------------------------------------------------
+// Encoder -- the port of `tta_compress` (tta.cpp:294) and the encode halves of
+// entropy.cpp and filters.cpp.
+//
+// Every stage is the exact mirror of the decoder above, and the two differ in
+// ways that are easy to get backwards, so they are spelled out where they occur:
+// `filter_compress` subtracts where `filter_decompress` adds, stores the INPUT
+// into the history where decode stores the OUTPUT, and tests the sign of the
+// OUTPUT where decode tests the input.
+// ---------------------------------------------------------------------------
+
+/// `BASE_SIZE`/`STEP_SIZE` (entropy.h:34-35) are byte counts for C's realloc
+/// policy. The growth schedule is not observable -- only the bits written are --
+/// so this grows a word vector instead, which cannot leave an uninitialised
+/// word behind. (In C that is safe only by an argument about `fbit`: a freshly
+/// grown word is always first touched with fbit == 0, where `*s &= bit_mask32[0]`
+/// clears it.)
+struct BitWriter {
+    words: Vec<u32>,
+    bits: u64,
+}
+
+impl BitWriter {
+    fn new() -> Self {
+        BitWriter {
+            words: vec![0u32; (1 << 20) / 4],
+            bits: 0,
+        }
+    }
+
+    /// `get_len`: the byte length, rounding a partial byte up.
+    fn len(&self) -> usize {
+        ((self.bits >> 3) + if self.bits & 7 != 0 { 1 } else { 0 }) as usize
+    }
+
+    #[inline]
+    fn reserve(&mut self, word: usize) {
+        if word + 2 > self.words.len() {
+            self.words.resize(word + 2 + (1 << 18), 0);
+        }
+    }
+
+    /// `put_binary` (entropy.cpp:115).
+    #[inline]
+    fn put_binary(&mut self, value: u64, bits: u64) {
+        let fbit = self.bits & 0x1F;
+        let rbit = 32 - fbit;
+        let pos = (self.bits >> 5) as usize;
+        self.reserve(pos);
+
+        // Clear everything at or above the current bit, then lay the field in.
+        self.words[pos] &= BIT_MASK32[fbit as usize] as u32;
+        self.words[pos] |= ((value & BIT_MASK32[bits as usize]) << fbit) as u32;
+        if bits > rbit {
+            self.words[pos + 1] = (value >> rbit) as u32;
+        }
+        self.bits += bits;
+    }
+
+    /// `put_unary` (entropy.cpp:134): `value` one-bits then a zero.
+    #[inline]
+    fn put_unary(&mut self, value: u64) {
+        let fbit = self.bits & 0x1F;
+        let rbit = 32 - fbit;
+        let mut pos = (self.bits >> 5) as usize;
+        self.reserve(pos + (value >> 5) as usize + 1);
+
+        self.words[pos] &= BIT_MASK32[fbit as usize] as u32;
+        if value < rbit {
+            self.words[pos] |= (BIT_MASK32[value as usize] << fbit) as u32;
+        } else {
+            let mut unary = value;
+            self.words[pos] |= (BIT_MASK32[rbit as usize] << fbit) as u32;
+            pos += 1;
+            unary -= rbit;
+            // `> 32`, not `>= 32`: the loop leaves a remainder of exactly 32 to
+            // the tail assignment below, which writes a full word of ones.
+            while unary > 32 {
+                self.words[pos] = BIT_MASK32[32] as u32;
+                pos += 1;
+                unary -= 32;
+            }
+            if unary != 0 {
+                self.words[pos] = BIT_MASK32[unary as usize] as u32;
+            }
+        }
+        self.bits += value + 1;
+    }
+
+    /// The bytes to emit: the word vector reinterpreted little-endian, which is
+    /// what C's `(tta_word*)bit_array_write` aliasing produces on every target
+    /// this builds for.
+    fn bytes(&self) -> Vec<u8> {
+        let n = self.len();
+        let mut out = Vec::with_capacity(n);
+        for w in self.words.iter() {
+            if out.len() >= n {
+                break;
+            }
+            out.extend_from_slice(&w.to_le_bytes());
+        }
+        out.truncate(n);
+        out
+    }
+}
+
+/// `ENC` (entropy.h:37): fold a signed residual onto the unsigned line.
+#[inline]
+fn enc(x: i64) -> i64 {
+    if x > 0 {
+        (x << 1) - 1
+    } else {
+        (-x) << 1
+    }
+}
+
+/// `encode_frame` (entropy.cpp:216): adaptive Rice coding with two parameter
+/// tracks, exactly mirroring `decode_frame`'s adaptation -- including the clamp
+/// at 32, which both sides must apply or they fall out of lock-step.
+fn encode_frame(bw: &mut BitWriter, data: &[i64]) {
+    let mut k0: u64 = 10;
+    let mut k1: u64 = 10;
+    let mut sum0: u64 = shift_16(k0 as usize);
+    let mut sum1: u64 = shift_16(k1 as usize);
+
+    for &sample in data {
+        let mut value = enc(sample) as u64;
+        let mut k = k0;
+
+        sum0 = sum0.wrapping_add(value.wrapping_sub(sum0 >> 4));
+        if k0 > 0 && sum0 < shift_16(k0 as usize) {
+            k0 -= 1;
+        } else if k0 < 32 && sum0 > shift_16(k0 as usize + 1) {
+            k0 += 1;
+        }
+
+        let unary;
+        if value >= BIT_SHIFT[k as usize] {
+            value -= BIT_SHIFT[k as usize];
+            k = k1;
+
+            sum1 = sum1.wrapping_add(value.wrapping_sub(sum1 >> 4));
+            if k1 > 0 && sum1 < shift_16(k1 as usize) {
+                k1 -= 1;
+            } else if k1 < 32 && sum1 > shift_16(k1 as usize + 1) {
+                k1 += 1;
+            }
+
+            unary = 1 + (value >> k);
+        } else {
+            unary = 0;
+        }
+
+        // An escape at 50: longer runs go out as a 50-run plus a 32-bit literal.
+        if unary >= 50 {
+            bw.put_unary(50);
+            bw.put_binary(unary, 32);
+        } else {
+            bw.put_unary(unary);
+        }
+        if k != 0 {
+            bw.put_binary(value & BIT_MASK32[k as usize], k);
+        }
+    }
+}
+
+impl Filter {
+    /// `filter_compress` (filters.cpp:64). Three differences from `decompress`,
+    /// all of them silent if transposed:
+    ///   * `out = in - (sum >> shift)`, where decode adds;
+    ///   * the history takes the INPUT, where decode stores the output;
+    ///   * the adaptation tests the sign of the OUTPUT, where decode tests the
+    ///     input.
+    /// In both directions the history holds the original-domain sample and the
+    /// sign test looks at the residual-domain one -- they are the same rule
+    /// seen from opposite sides.
+    fn compress(&mut self, sample: &mut i64) {
+        let order = self.order;
+
+        let mut sum: i32 = self.round;
+        for j in 0..order {
+            sum = sum.wrapping_add(self.dl[self.pl + j].wrapping_mul(self.qm[j]));
+        }
+
+        let inv = *sample;
+        let out: i32 = (inv as i32).wrapping_sub(sum >> self.shift);
+
+        self.dl[self.pl + order] = inv as i32;
+
+        if self.mode == 0 {
+            let base = self.pl + order - 1;
+            for n in 0..3 {
+                self.dl[base - n] = self.dl[base + 1 - n].wrapping_sub(self.dl[base - n]);
+            }
+        }
+
+        if out < 0 {
+            for j in 0..order {
+                self.qm[j] = self.qm[j].wrapping_add(self.dx[self.px + j]);
+            }
+        } else if out > 0 {
+            for j in 0..order {
+                self.qm[j] = self.qm[j].wrapping_sub(self.dx[self.px + j]);
+            }
+        }
+
+        let pxo = self.px + order;
+        let plo = self.pl + order;
+        self.dx[pxo] = ((self.dl[plo] >> 28) & 8) - 4;
+        self.dx[pxo - 1] = ((self.dl[plo - 1] >> 29) & 4) - 2;
+        self.dx[pxo - 2] = ((self.dl[plo - 2] >> 29) & 4) - 2;
+        self.dx[pxo - 3] = ((self.dl[plo - 3] >> 30) & 2) - 1;
+
+        if self.px + order == BUF_SIZE - 1 {
+            self.dx.copy_within(self.px + 1..self.px + 1 + order, 0);
+            self.px = 0;
+        } else {
+            self.px += 1;
+        }
+        if self.pl + order == BUF_SIZE - 1 {
+            self.dl.copy_within(self.pl + 1..self.pl + 1 + order, 0);
+            self.pl = 0;
+        } else {
+            self.pl += 1;
+        }
+
+        *sample = out as i64;
+    }
+}
+
+/// `filters_compress` (filters.cpp:243): the fixed order-1 predictor first, then
+/// the three adaptive stages in ASCENDING order -- decode runs them descending.
+fn filters_compress(data: &mut [i64], level: usize, byte_size: usize) {
+    let f1 = FLT_SET[0][level - 1][byte_size - 1];
+    let f2 = FLT_SET[1][level - 1][byte_size - 1];
+    let f3 = FLT_SET[2][level - 1][byte_size - 1];
+    let mut fst1 = Filter::new(f1[0], f1[1], f1[2]);
+    let mut fst2 = Filter::new(f2[0], f2[1], f2[2]);
+    let mut fst3 = Filter::new(f3[0], f3[1], f3[2]);
+
+    let mut last: i64 = 0;
+    for v in data.iter_mut() {
+        let tmp = *v;
+        match byte_size {
+            1 => *v = v.wrapping_sub(predictor1(last, 4)),
+            2 | 3 => *v = v.wrapping_sub(predictor1(last, 5)),
+            4 => *v = v.wrapping_sub(last),
+            _ => {}
+        }
+        last = tmp;
+
+        if fst1.order != 0 {
+            fst1.compress(v);
+        }
+        if fst2.order != 0 {
+            fst2.compress(v);
+        }
+        if fst3.order != 0 {
+            fst3.compress(v);
+        }
+    }
+}
+
+/// `split_int` (tta.cpp:227): de-interleave, then inter-channel decorrelation.
+fn split_int(data: &[i64], frame_len: usize, num_chan: usize, buffer: &mut [Vec<i64>]) {
+    for i in 0..frame_len {
+        for j in 0..num_chan {
+            buffer[j][i] = data[i * num_chan + j];
+        }
+    }
+    if num_chan > 1 {
+        let n = num_chan - 1;
+        for i in 0..frame_len {
+            for j in 0..n {
+                buffer[j][i] = buffer[j + 1][i].wrapping_sub(buffer[j][i]);
+            }
+            buffer[n][i] = buffer[n][i].wrapping_sub(buffer[n - 1][i] / 2);
+        }
+    }
+}
+
+/// `split_float` (tta.cpp:258): split each IEEE-754 single into an exponent-ish
+/// high half and a byte-swapped mantissa, doubling the channel count.
+fn split_float(data: &[i64], frame_len: usize, num_chan: usize, buffer: &mut [Vec<i64>]) {
+    for i in 0..frame_len {
+        for j in 0..num_chan {
+            let t = data[i * num_chan + j] as u64;
+            // C computes this as `unsigned long negative = (t & 0x80000000)? -1:1`
+            // -- i.e. all-ones on LP64 -- and multiplies, so the effect is a
+            // two's-complement negation of the 64-bit product.
+            let negative: i64 = if t & 0x8000_0000 != 0 { -1 } else { 1 };
+            let data_hi = (t & 0x7FFF_0000) >> 16;
+            let data_lo = t & 0x0000_FFFF;
+
+            buffer[j][i] = (data_hi as i64).wrapping_sub(0x3F80);
+            buffer[j + num_chan][i] =
+                ((swap16(data_lo as u32) as i64).wrapping_add(1)).wrapping_mul(negative);
+        }
+    }
+}
+
+/// `read_wave` (tta.cpp:118): fill `data` with sign-extended samples, keep the
+/// trailing partial sample in `rest`, and hand back the raw bytes so the
+/// incompressible path can store them verbatim.
+///
+/// Returns the byte count read, or the callback's error.
+#[allow(clippy::too_many_arguments)]
+fn read_wave(
+    io: &Io,
+    data: &mut [i64],
+    rest: &mut Vec<u8>,
+    prev: &[u8],
+    byte_size: usize,
+    num_chan: usize,
+    len: usize,
+) -> Result<(usize, Vec<u8>), c_int> {
+    let sample = num_chan * byte_size;
+    let wanted = len * sample;
+    let mut buffer = vec![0u8; (len + 2) * sample];
+
+    let use_prev = prev.len().min(wanted);
+    buffer[..use_prev].copy_from_slice(&prev[..use_prev]);
+
+    // Note the asymmetry in C: it copies min(prevsize,wanted) bytes but reads at
+    // offset `prevsize`. They differ only when prevsize > wanted, and in that
+    // case no read happens at all, so the offset is unused.
+    let mut bytes_read = if wanted <= prev.len() {
+        0
+    } else {
+        let n = io.read(&mut buffer[prev.len()..wanted]);
+        if n < 0 {
+            return Err(n);
+        }
+        n as usize
+    };
+    bytes_read += use_prev;
+
+    let rest_bytes = bytes_read % sample;
+    rest.clear();
+    rest.extend_from_slice(&buffer[bytes_read - rest_bytes..bytes_read]);
+
+    let elements = (bytes_read / sample) * num_chan;
+    match byte_size {
+        1 => {
+            for i in 0..elements {
+                data[i] = buffer[i] as i64 - 0x80;
+            }
+        }
+        2 => {
+            for i in 0..elements {
+                data[i] = i16::from_le_bytes([buffer[2 * i], buffer[2 * i + 1]]) as i64;
+            }
+        }
+        3 => {
+            // Three bytes sign-extended through 32 bits. C dereferenced a `long`
+            // here once, which on LP64 read five bytes past each sample.
+            for i in 0..elements {
+                let q = &buffer[i * 3..i * 3 + 3];
+                let t = (q[0] as u32) | ((q[1] as u32) << 8) | ((q[2] as u32) << 16);
+                data[i] = (((t << 8) as i32) >> 8) as i64;
+            }
+        }
+        4 => {
+            for i in 0..elements {
+                data[i] = i32::from_le_bytes([
+                    buffer[4 * i],
+                    buffer[4 * i + 1],
+                    buffer[4 * i + 2],
+                    buffer[4 * i + 3],
+                ]) as i64;
+            }
+        }
+        _ => {}
+    }
+    Ok((bytes_read, buffer))
+}
+
+/// TTA's OWN candidate sets (tta.cpp:49,52) -- NOT mmdet's.
+///
+/// `mmdet.cpp` has file-static `channels[] = {1,2,3,4}` / `bitvalues[] =
+/// {8,16,24,32}`, and `tta.cpp` has its own file-static arrays of the same
+/// names holding {1,2} and {8,16}. Both call `autodetect_by_entropy`, so which
+/// set it sees depends purely on which translation unit the caller is in. The
+/// difference is not cosmetic: on 32-bit table data the wider set wins with
+/// `1 channel x 32 bits`, which TTA then REFUSES (`byte_size >= 4` and not
+/// float) and stores, while the narrow set picks `2 x 16` and compresses it
+/// 6.7x. Passing mmdet's arrays here stored a 32 KB file that the C compressed
+/// to 4,763 bytes.
+const TTA_CHANNELS: [c_int; 2] = [1, 2];
+const TTA_BITVALUES: [c_int; 2] = [8, 16];
+
+/// `tta_compress` (tta.cpp:294).
+#[allow(clippy::too_many_arguments)]
+fn encode(
+    io: &Io,
+    level: c_int,
+    skip_header: bool,
+    is_float_in: c_int,
+    num_chan_in: c_int,
+    word_size_in: c_int,
+    offset_in: c_int,
+    raw_data: c_int,
+) -> Result<(), c_int> {
+    // Samples per chunk. Not part of the format -- each block records its own
+    // byte count -- but the decoder sizes its buffers from the recorded count,
+    // so keeping it identical keeps the stream identical.
+    const FRAME_SIZE: usize = 1 << 18;
+
+    let level = level.min(3);
+    let mut is_float = is_float_in != 0;
+    let mut num_chan = num_chan_in;
+    let mut word_size = word_size_in;
+    let mut offset = offset_in;
+
+    // `prev` holds the megabyte read for autodetection; it is consumed by the
+    // first frames before any further reads happen.
+    let mut prev: Vec<u8> = Vec::new();
+    let mut detected = true;
+
+    if level == 0 {
+        detected = false;
+    } else if is_float || num_chan != 0 || word_size != 0 {
+        if num_chan == 0 {
+            num_chan = 1;
+        }
+        if word_size == 0 {
+            // NOTE: 4 and 1, not 32 and 8 -- unlike mm_compress, whose identical
+            // looking line means BITS. Here the value is fed to (word_size+7)/8
+            // all the same, so `4` yields byte_size 1 for floats. Transliterated,
+            // not corrected: it is what the C writes into the header.
+            word_size = if is_float { 4 } else { 1 };
+        }
+    } else {
+        prev = vec![0u8; MB];
+        let n = io.read(&mut prev);
+        if n <= 0 {
+            return if n < 0 { Err(n) } else { Ok(()) };
+        }
+        prev.truncate(n as usize);
+
+        let wav = if skip_header {
+            None
+        } else {
+            mmdet::autodetect_wav_header(&prev)
+        };
+        // TTA uses a LOOSER entropy threshold than MM: 0.50 against MM's 0.80.
+        let d = wav.or_else(|| {
+            mmdet::autodetect_by_entropy(&prev, &TTA_CHANNELS, &TTA_BITVALUES, 0.50)
+        });
+        match d {
+            Some(d) => {
+                is_float = d.is_float;
+                num_chan = d.num_chan;
+                word_size = d.word_size;
+                offset = d.offset;
+            }
+            None => detected = false,
+        }
+    }
+
+    let byte_size = ((word_size + 7) / 8) as usize;
+
+    // TTA handles neither 32-bit integers nor non-32-bit floats.
+    if detected && ((is_float && byte_size != 4) || (!is_float && byte_size >= 4)) {
+        detected = false;
+    }
+
+    if !detected {
+        // Header of 0, then the input verbatim.
+        io.write_all(&0u32.to_le_bytes())?;
+        loop {
+            if !prev.is_empty() {
+                io.write_all(&prev)?;
+            }
+            prev.resize(MB, 0);
+            let n = io.read(&mut prev);
+            if n < 0 {
+                return Err(n);
+            }
+            if n == 0 {
+                return Ok(());
+            }
+            prev.truncate(n as usize);
+        }
+    }
+
+    let num_chan = num_chan as usize;
+    io.write_all(&[
+        level as u8,
+        (raw_data * 2) as u8 + is_float as u8,
+        num_chan as u8,
+        word_size as u8,
+    ])?;
+
+    // The original file header, passed through uncompressed. If autodetection
+    // never ran there is nothing buffered, so it has to be read now.
+    let offset = offset.max(0) as usize;
+    if offset > 0 && prev.is_empty() {
+        prev = vec![0u8; offset];
+        read_exact(io, &mut prev)?;
+    }
+    io.write_all(&(offset as u32).to_le_bytes())?;
+    let head = offset.min(prev.len());
+    io.write_all(&prev[..head])?;
+    let mut prev_pos = head; // the rest of `prev` still feeds the frames
+
+    let rows = num_chan << is_float as usize;
+    let mut data = vec![0i64; num_chan * FRAME_SIZE];
+    let mut buffer = alloc2d(rows, FRAME_SIZE)?;
+    let mut rest: Vec<u8> = Vec::new();
+
+    loop {
+        let (bytes_read, origdata) = read_wave(
+            io,
+            &mut data,
+            &mut rest,
+            &prev[prev_pos.min(prev.len())..],
+            byte_size,
+            num_chan,
+            FRAME_SIZE,
+        )?;
+        let sample = num_chan * byte_size;
+        let frame_len = bytes_read / sample;
+
+        if bytes_read >= prev.len() - prev_pos.min(prev.len()) {
+            prev.clear();
+            prev_pos = 0;
+        } else {
+            prev_pos += bytes_read;
+        }
+        if bytes_read == 0 {
+            return Ok(());
+        }
+
+        io.write_all(&(bytes_read as u32).to_le_bytes())?;
+
+        if is_float {
+            split_float(&data, frame_len, num_chan, &mut buffer);
+        } else {
+            split_int(&data, frame_len, num_chan, &mut buffer);
+        }
+
+        let mut bw = BitWriter::new();
+        for row in buffer.iter_mut().take(rows) {
+            filters_compress(&mut row[..frame_len], level as usize, byte_size);
+
+            if raw_data == 0 {
+                encode_frame(&mut bw, &row[..frame_len]);
+            } else {
+                if raw_data == 2 {
+                    for v in row[..frame_len].iter_mut() {
+                        *v = if *v >= 0 { v.wrapping_mul(2) } else { v.wrapping_neg().wrapping_mul(2).wrapping_sub(1) };
+                    }
+                }
+                // C writes frame_len*sizeof(long) bytes straight out of the
+                // buffer -- EIGHT bytes per sample on LP64, four on Win32. This
+                // path is a debugging aid (`:r1`/`:r2`), never produced by the
+                // archiver's defaults, and its stream was never portable across
+                // word sizes. Matched to the LP64 build this replaces.
+                let mut out = Vec::with_capacity(frame_len * 8);
+                for &v in row[..frame_len].iter() {
+                    out.extend_from_slice(&v.to_le_bytes());
+                }
+                io.write_all(&out)?;
+            }
+        }
+
+        if raw_data == 0 {
+            let size = bw.len();
+            if size >= bytes_read {
+                // The coded frame came out no smaller than the input: store it.
+                io.write_all(&0u32.to_le_bytes())?;
+                io.write_all(&origdata[..bytes_read])?;
+                continue; // NB: skips the `rest` write -- origdata already has it
+            }
+            io.write_all(&(size as u32).to_le_bytes())?;
+            io.write_all(&bw.bytes())?;
+        }
+        io.write_all(&rest)?;
+    }
+}
+
+/// `tta_compress`.
+#[allow(clippy::too_many_arguments)]
+pub fn compress(
+    io: &Io,
+    level: c_int,
+    skip_header: c_int,
+    is_float: c_int,
+    num_chan: c_int,
+    word_size: c_int,
+    offset: c_int,
+    raw_data: c_int,
+) -> c_int {
+    match encode(
+        io,
+        level,
+        skip_header != 0,
+        is_float,
+        num_chan,
+        word_size,
+        offset,
+        raw_data,
+    ) {
+        Ok(()) => OK,
+        Err(e) => e,
+    }
+}
+
+#[cfg(test)]
+mod rice_tests {
+    use super::*;
+
+    /// Drive the Rice parameter to its ceiling and back.
+    ///
+    /// The clamp at 32 cannot be reached from the differential corpus: it needs
+    /// `sum0 > 2^31`, i.e. residuals near 2^30, and audio-shaped input never
+    /// produces those. It is still load-bearing, and in a way the C's own
+    /// symptom hid -- `shift_16` SATURATES (`BIT_SHIFT[36] == BIT_SHIFT[37] ==
+    /// 0x80000000`), so the threshold for 32 -> 33 is identical to the one for
+    /// 31 -> 32. Once the parameter reaches the top it would climb forever,
+    /// indexing `BIT_MASK32[33]` and beyond off the end of a 33-entry table.
+    ///
+    /// Removing the clamp leaves the whole differential test green, so this is
+    /// the only thing standing between that edit and an out-of-bounds index.
+    #[test]
+    fn rice_parameter_saturates_instead_of_running_off_the_table() {
+        // Residuals large enough to push both adaptive tracks to the ceiling,
+        // then small ones so they wind back down.
+        let mut data: Vec<i64> = Vec::new();
+        for _ in 0..600 {
+            data.push(1 << 30);
+        }
+        for i in 0..600 {
+            data.push(if i % 2 == 0 { 3 } else { -4 });
+        }
+
+        let mut bw = BitWriter::new();
+        encode_frame(&mut bw, &data);
+        let bytes = bw.bytes();
+        assert!(!bytes.is_empty());
+
+        // And the decoder must recover exactly what went in -- the two sides
+        // adapt in lock-step only if both clamp.
+        let mut br = BitReader::new(&bytes);
+        let mut out = vec![0i64; data.len()];
+        decode_frame(&mut br, &mut out);
+        assert_eq!(out, data, "encode/decode disagree at the Rice ceiling");
+    }
+
+    /// The 50-run escape: anything longer goes out as a 50 unary run plus a
+    /// 32-bit literal, and the reader has to take the same branch.
+    #[test]
+    fn long_unary_runs_take_the_escape_and_round_trip() {
+        let data: Vec<i64> = (0..400).map(|i| (i as i64 % 7) * (1 << 20)).collect();
+        let mut bw = BitWriter::new();
+        encode_frame(&mut bw, &data);
+        let bytes = bw.bytes();
+        let mut br = BitReader::new(&bytes);
+        let mut out = vec![0i64; data.len()];
+        decode_frame(&mut br, &mut out);
+        assert_eq!(out, data);
+    }
+
+    /// `put_unary` writes `value` ones then a zero, across word boundaries at
+    /// every starting bit offset. The word-spanning branch is the one with the
+    /// `> 32` loop bound.
+    #[test]
+    fn unary_round_trips_at_every_bit_offset() {
+        for pad in 0..33u64 {
+            for value in [0u64, 1, 31, 32, 33, 63, 64, 65, 100] {
+                let mut bw = BitWriter::new();
+                if pad > 0 {
+                    bw.put_binary(0, pad);
+                }
+                bw.put_unary(value);
+                let bytes = bw.bytes();
+                let mut br = BitReader::new(&bytes);
+                if pad > 0 {
+                    br.get_binary(pad);
+                }
+                assert_eq!(br.get_unary(), value, "pad={pad} value={value}");
+            }
+        }
+    }
 }

--- a/rust/difftest/tta-check.sh
+++ b/rust/difftest/tta-check.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
-# Differential-test the TTA decoder port against the C original.
+# Differential-test the TTA port -- BOTH directions -- against the C original.
 #
-# TTA is ported decode-first, so the C compressor is the only encoder: compress
-# each input with C (over a matrix of channel counts / word sizes / levels),
-# decompress with both C and the Rust port, and require both to reproduce the
-# original. Byte-for-byte equality is the bar because TTA defines an archive
-# format.
+# Over a matrix of channel counts / word sizes / levels: compress each input
+# with BOTH encoders and require the two streams to be identical, then decompress
+# with both decoders and require both to reproduce the original. Byte-for-byte
+# equality is the bar in both directions because TTA defines an archive format --
+# and for the encoder that means autodetection must choose the same model, since
+# its choice travels in the stream header.
 set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 # The C reference comes from a pinned revision, not the working tree -- see
@@ -60,6 +61,20 @@ w("sine8_mono",   bytes([ (128+int(100*math.sin(i*0.05)))&0xff for i in range(2*
 w("noise8",       prng(9, 2*N))
 for n in (0,1,3,4,8, 1<<18, (1<<18)+1, (1<<18)-1):
     w(f"n16_{n}", s16([ int(9000*math.sin(i*0.03)) for i in range(n) ]))
+# A table of ascending 32-bit little-endian integers -- NOT audio, and the shape
+# that separates TTA's candidate model set from MM's.
+#
+# TTA has its own file-static channels[]={1,2} / bitvalues[]={8,16} in tta.cpp;
+# mmdet.cpp has same-named statics holding {1,2,3,4} / {8,16,24,32}. Both call
+# autodetect_by_entropy, so the set it sees depends only on the calling
+# translation unit. Audio-shaped input scores about the same under either, which
+# is why nothing above distinguishes them. On this input the wide set picks
+# 1 channel x 32 bits, which TTA REFUSES (byte_size >= 4, not float) and stores;
+# the narrow set picks 2 x 16 and compresses it ~6.7x. Passing the wrong array
+# stored 32 KB that the C reduced to 4,763 bytes -- and every case above stayed
+# green while it did.
+w("table32", b"".join(struct.pack("<I", i*3) for i in range(8000)))
+w("table32_wide", b"".join(struct.pack("<I", (i*2654435761)&0xffff) for i in range(8000)))
 PY
 
 decode_case () {   # $1=tag  $2..=encoder args ("LEVEL NUMCHAN WORDSIZE ISFLOAT [RAW]")
@@ -69,6 +84,23 @@ decode_case () {   # $1=tag  $2..=encoder args ("LEVEL NUMCHAN WORDSIZE ISFLOAT 
   for f in "$W"/in/*; do
     n=$((n+1)); local name; name=$(basename "$f")
     "$W/c"  c $ec < "$f"        >| "$W/stream" 2>/dev/null || { echo "  [$tag] $name: C-compress FAILED"; fail=$((fail+1)); continue; }
+    # Byte equality of the STREAM, not just a successful round-trip: TTA is one
+    # of DArc's own formats, so an encoder that differs writes a different
+    # archive. This is also the only check that reaches the encode halves of
+    # entropy.cpp (the Rice coder's two adaptive parameter tracks) and
+    # filters.cpp, whose compress path differs from decompress in three places
+    # that are individually silent if transposed.
+    "$W/rs" c $ec < "$f"        >| "$W/stream_rs" 2>/dev/null || { echo "  [$tag] $name: RUST-compress FAILED"; fail=$((fail+1)); continue; }
+    cmp -s "$W/stream" "$W/stream_rs" || { echo "  [$tag] $name: RUST-encode != C-encode"; fail=$((fail+1)); continue; }
+    # An EMPTY input under autodetection yields an EMPTY stream: the encoder
+    # reads for detection, hits EOF, and returns before writing even the flags
+    # word. There is no stream to decode, and no decoder accepts one -- the same
+    # property mm-check.sh documents for MM. Both encoders agreeing that the
+    # output is nothing is the whole of what can be checked here.
+    if [ ! -s "$W/stream" ]; then
+      [ -s "$f" ] && { echo "  [$tag] $name: empty stream for a NON-empty input"; fail=$((fail+1)); }
+      continue
+    fi
     "$W/c"  d     < "$W/stream" >| "$W/oc"     2>/dev/null || { echo "  [$tag] $name: C-decode FAILED";   fail=$((fail+1)); continue; }
     "$W/rs" d     < "$W/stream" >| "$W/ors"    2>/dev/null || { echo "  [$tag] $name: RUST-decode FAILED"; fail=$((fail+1)); continue; }
     cmp -s "$f" "$W/oc"  || { echo "  [$tag] $name: C-decode != original (harness bug)"; fail=$((fail+1)); continue; }
@@ -86,6 +118,19 @@ decode_case "L3 1*16"  3 1 16 0; total=$((total+$?))
 decode_case "L3 1*8"   3 1 8  0; total=$((total+$?))
 decode_case "L3 2*8"   3 2 8  0; total=$((total+$?))
 decode_case "raw 2*16" 3 2 16 0 1; total=$((total+$?))
+# Every case above pins num_chan and word_size, which means autodetection --
+# the branch that decides the stream header -- was never reached, nor was the
+# storing path, nor 24-bit, nor float. Those are the encoder's remaining arms.
+decode_case "auto"     3 0 0  0; total=$((total+$?))
+decode_case "auto L1"  1 0 0  0; total=$((total+$?))
+# level 0 goes straight to storing without reading anything for detection.
+decode_case "L0"       0 0 0  0; total=$((total+$?))
+decode_case "L3 1*24"  3 1 24 0; total=$((total+$?))
+decode_case "L3 2*24"  3 2 24 0; total=$((total+$?))
+# is_float with a 32-bit word is the only float geometry TTA accepts; every
+# other combination falls through to storing, which is itself worth covering.
+decode_case "float32"  3 1 32 1; total=$((total+$?))
+decode_case "float-bad" 3 1 16 1; total=$((total+$?))
 
-echo "tta decode: $total total differing"
-[ "$total" -eq 0 ] && echo "TTA decoder matches the C original byte for byte" || exit 1
+echo "tta: $total total differing"
+[ "$total" -eq 0 ] && echo "TTA matches the C original byte for byte, both directions" || exit 1

--- a/rust/difftest/tta_ref.cpp
+++ b/rust/difftest/tta_ref.cpp
@@ -25,6 +25,7 @@ int tta_compress   (int, int, int, int, int, int, int, CALLBACK_FUNC*, void*);
 int tta_decompress (CALLBACK_FUNC*, void*);
 #ifdef USE_RUST
 extern "C" int darc_rs_tta_decompress (CALLBACK_FUNC*, void*);
+extern "C" int darc_rs_tta_compress   (int, int, int, int, int, int, int, CALLBACK_FUNC*, void*);
 #endif
 
 struct Buffers {
@@ -65,7 +66,11 @@ int main (int argc, char **argv) {
     int word_size= argc>4? atoi(argv[4]) : 16;
     int is_float = argc>5? atoi(argv[5]) : 0;
     int raw_data = argc>6? atoi(argv[6]) : 0;
+#ifdef USE_RUST
+    rc = darc_rs_tta_compress (level, 0, is_float, num_chan, word_size, 0, raw_data, io_callback, &b);
+#else
     rc = tta_compress (level, 0, is_float, num_chan, word_size, 0, raw_data, io_callback, &b);
+#endif
   } else {
 #ifdef USE_RUST
     rc = darc_rs_tta_decompress (io_callback, &b);


### PR DESCRIPTION
Completes TTA in both directions. `tta_compress`, the encode halves of
`entropy.cpp` (the adaptive Rice coder) and `filters.cpp`, plus
`read_wave`/`split_int`/`split_float`, are now Rust; the C `tta_compress` is
excluded under `DARC_RUST`.

Archives are unchanged: the `tta` fingerprint holds, and archives built by the
`DARC_RUST` and `DARC_NO_RUST` binaries are identical across `-mtta`, `:m0`
through `:m3`, `:s`, `:r1`, `2*16` and `1*8`.

Unlike `C_MM.h` (fixed in #80), `ttaenc.h` declares `tta_compress` with the
signature it actually has, so the definition really does inherit the C linkage
`C_TTA.cpp`'s `extern "C"` intends and the drop-in takes the symbol. Verified
with `nm` rather than assumed: `C_TTA.o` now has `U _tta_compress`.

## TTA has its own candidate model sets

This cost a fingerprint drift before it was found, and it is the interesting
part of the change.

`tta.cpp:49,52` declares file-static `channels[] = {1,2}` and
`bitvalues[] = {8,16}`. `mmdet.cpp` declares **same-named** statics holding
`{1,2,3,4}` and `{8,16,24,32}`. Both call `autodetect_by_entropy`, so which set
it sees depends only on the calling translation unit.

Passing mmdet's -- the obvious assumption, since the *function* is shared --
makes the wide set win on 32-bit table data with `1 channel x 32 bits`, which
TTA then **refuses** (`byte_size >= 4` and not float) and stores.
`Tests/corpus/binary/table32.bin` went from 4,763 bytes to 32,004.

The differential corpus could not see it: audio-shaped throughout, and audio
scores about the same under either set. Two tables of 32-bit integers now cover
it, and reverting the fix produces **4 differing streams**.

## Coverage the harness did not have

Every existing case pinned `num_chan` and `word_size`, so autodetection -- the
branch that decides the stream header -- was never reached, nor was the storing
path, nor 24-bit, nor float. All are cases now, which is what made `table32`
reachable at all.

An empty input under autodetection is handled explicitly: the encoder reads for
detection, hits EOF and returns before writing even the flags word, so the
stream is empty and no decoder accepts one. Both encoders agreeing on "nothing"
is all that can be checked -- the same property `mm-check.sh` documents for MM.

`tta-check.sh` now compares the produced **stream**, not just the round-trip:
14 parameter sets over 17 inputs, 0 differing.

## Sabotage results

Eight tried; six caught outright:

| sabotage | streams differing |
|---|---|
| sign test on input rather than output | 77 |
| history stores the output, not the input | 84 |
| filter adds instead of subtracting | 84 |
| filter stages in reverse order | 61 |
| `split_int` decorrelation reversed | 55 |
| `ENC` zigzag boundary | 76 |

Two survived, for different reasons, and only one is a coverage gap:

* **The Rice parameter clamp at 32** is unreachable from audio input -- it needs
  `sum0 > 2^31`. It still matters, and worse than it first looks: `shift_16`
  **saturates** (`BIT_SHIFT[36] == BIT_SHIFT[37]`), so the threshold to leave 32
  is identical to the one to reach it. Without the clamp the parameter climbs
  forever and indexes `BIT_MASK32[33]` off a 33-entry table. Now pinned by a unit
  test that drives it there; removing the clamp panics on the out-of-bounds
  index.
* **`put_unary`'s `> 32` vs `>= 32`** is not a defect at all: at `unary == 32`
  one branch writes a full word and exits, the other falls through to the tail
  and writes `bit_mask32[32]` -- same word, same output. Recorded so the next
  reader does not go hunting for the missing coverage.

## Note on mmdet.cpp

This does **not** unlock deleting `mmdet.cpp`, contrary to what the MM PR
implied. `ArhiveFileList.hs:588-599` imports `detect_datatype`,
`detect_mm_bytes`, `detect_mm` and `detect_mm_header` by FFI -- the
`$text`/`$exe`/`$compressed` classification behind solid-block grouping. It goes
when the Haskell layer does.

## Local results

* `tta-check.sh` 14 parameter sets x 17 inputs, 0 differing
* `mm-check.sh` unaffected, 0 differing
* 136/136 Rust tests
* `run-tests.sh` 24/24 on **both** build configurations, `tta` and all three MM
  fingerprints unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
