### PR TITLE
CI: restore the C-vs-Rust encryption cross-check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -865,14 +865,32 @@ jobs:
         test -x Tests/srep || { echo "::error::srep/compile produced no Tests/srep"; exit 1; }
         rust/difftest/srep-check.sh
 
-    # This used to run C-crypto against Rust-crypto in both directions, using
-    # the /tmp/arc-c binary from the DARC_NO_RUST build. Both are gone: the
-    # opt-out was removed and C_Encryption.cpp's #ifndef DARC_RUST fallbacks
-    # went with the last build that did not define DARC_RUST. There is no
-    # second implementation left to interoperate with, so the cross-check is
-    # not merely unwired, it is unrepresentable.
+    # The C-vs-Rust crypto cross-check, restored. It used to compare a
+    # DARC_NO_RUST `arc` against a DARC_RUST one; both the opt-out and
+    # C_Encryption.cpp's #ifndef DARC_RUST fallbacks are gone, so there is no
+    # second implementation left in the working tree. There is one in history,
+    # and this takes it from the same pinned revision every other codec harness
+    # uses -- which is strictly better than the old arrangement, since a pinned
+    # oracle cannot drift as the tree changes.
     #
-    # What remains is the round-trip, which is what actually guards the format:
+    # It compares ciphertext byte-for-byte in both directions across every
+    # cipher, mode and key size DArc can select, plus the PBKDF2 key
+    # derivation, and it tests the production forwarding shim rather than a
+    # harness-local copy of it.
+    - name: Encryption differential test (Rust vs C)
+      run: |
+        chmod +x rust/difftest/*.sh
+        rust/difftest/crypto-check.sh
+
+    # And the same question asked of it: seven one-line breaks -- CTR's counter
+    # direction, its state across docrypt's 256 KB read chunk, CFB's feedback
+    # register and IV pre-encryption, the PBKDF2 iteration count and two in the
+    # shim -- each of which the check must notice. It restores every file it
+    # touches on exit, including on failure.
+    - name: Prove the encryption differential test can fail
+      run: rust/difftest/crypto-sabotage.sh
+
+    # The round-trip is the other half, and the one that guards the format:
     # encrypted archives must still be created and read back correctly.
     # Builds the archiver itself. The deleted "archives identical with and
     # without the Rust codecs" step used to leave Tests/arc behind as a side

--- a/rust/difftest/crypto-check.sh
+++ b/rust/difftest/crypto-check.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# Differential-test the encryption port (rust/darc-crypto) against the vendored
+# LibTomCrypt it replaced.
+#
+# This is the check that went missing when the C came out. The old CI job
+# compared a DARC_NO_RUST `arc` against a DARC_RUST one; both the opt-out and
+# C_Encryption.cpp's `#ifndef DARC_RUST` fallbacks are gone, so the second
+# implementation no longer exists in the working tree. It does exist in
+# history, and that is where the oracle comes from here -- the same pinned
+# revision every other codec harness compares against (see c-reference.sh).
+#
+# Encryption has no "format-valid is enough" escape hatch. An archive written
+# with -p opens only if the key derivation and the cipher stream agree to the
+# byte, so every comparison below is byte-for-byte, in both directions, at
+# every key size and both modes.
+#
+# ── Three binaries, not two ─────────────────────────────────────────────────
+#
+#   c     the pinned C exactly as it shipped
+#   c32   the pinned C with ONE header replaced: the working tree's
+#         tomcrypt_macros.h, which types ulong32 as uint32_t
+#   rs    the working tree's DARC_RUST shim, forwarding to libdarc_crypto.a
+#
+# `c32` exists because the pinned tomcrypt_macros.h types ulong32 as `unsigned
+# long` on every LP64 target except x86_64, and serpent.c's key expansion
+# rotates it with a raw shift-or that is a rotate at 32 bits and garbage at 64.
+# So the shipped ARM64 C binaries encrypt `-ae serpent` differently from every
+# other architecture -- a C bug the port fixes by construction. On x86_64 the
+# two references are the same program; elsewhere they differ for serpent only,
+# and the harness asserts exactly that rather than skipping the cipher. A skip
+# would have been indistinguishable from the port being wrong.
+set -uo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$ROOT/rust/difftest/c-reference.sh"
+CREF="$(darc_c_reference "$ROOT")" || exit 1
+W="${TMPDIR:-/tmp}/crypto-check.$$"; mkdir -p "$W"
+trap 'rm -rf "$W"' EXIT
+
+( cd "$ROOT/rust" && cargo build --release -p darc-crypto ) >/dev/null 2>&1 \
+  || { echo "cargo build failed" >&2; exit 1; }
+LIB="$ROOT/rust/target/release/libdarc_crypto.a"
+
+DEFS="-DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT"
+
+# The C side compiles the PINNED C_Encryption.cpp without -DDARC_RUST, so the
+# vendored LibTomCrypt is what runs. The Rust side compiles the WORKING TREE's
+# C_Encryption.cpp with -DDARC_RUST, so what is tested is the production
+# forwarding shim itself and not a harness-local copy of it -- an argument
+# swapped in that shim would corrupt every encrypted archive while a harness
+# that called darc_rs_docrypt directly stayed green.
+build_c() { # <output> <tree>
+  local out="$1" tree="$2"
+  clang++ -std=c++17 -O2 -w $DEFS \
+    -I"$tree" -I"$tree/Compression" -I"$tree/Compression/_Encryption/headers" \
+    "$tree/rust/difftest/crypto_ref.cpp" "$tree/rust/difftest/crypto_ccodec.cpp" \
+    "$tree/Compression/Common.cpp" -o "$out"
+}
+
+build_c "$W/c" "$CREF" || { echo "building the pinned C reference failed" >&2; exit 1; }
+
+# The 32-bit-ulong32 reference: a copy of the pinned tree with one header
+# overlaid. Everything else, including C_Encryption.cpp itself, is still the
+# pinned source.
+CREF32="$W/cref32"
+cp -R "$CREF" "$CREF32" || exit 1
+cp "$ROOT/Compression/_Encryption/headers/tomcrypt_macros.h" \
+   "$CREF32/Compression/_Encryption/headers/tomcrypt_macros.h" || exit 1
+grep -q 'typedef uint32_t ulong32' "$CREF32/Compression/_Encryption/headers/tomcrypt_macros.h" \
+  || { echo "the working tree's tomcrypt_macros.h no longer types ulong32 as uint32_t;" >&2
+       echo "the c32 reference would be identical to c and would prove nothing" >&2; exit 1; }
+build_c "$W/c32" "$CREF32" || { echo "building the 32-bit-ulong32 reference failed" >&2; exit 1; }
+
+# The staticlib goes AFTER the sources that reference it: GNU ld resolves an
+# archive only against the undefined symbols it has already seen.
+clang++ -std=c++17 -O2 -w $DEFS -DDARC_RUST \
+  -I"$ROOT" -I"$ROOT/Compression" \
+  "$ROOT/rust/difftest/crypto_ref.cpp" "$ROOT/rust/difftest/crypto_ccodec.cpp" \
+  "$ROOT/Compression/Common.cpp" "$LIB" -o "$W/rs" \
+  || { echo "building the Rust-backed shim failed" >&2; exit 1; }
+
+fail=0
+
+# ── The cipher id table ─────────────────────────────────────────────────────
+# Cipher ids are not part of the archive format; they are positions in
+# LibTomCrypt's registration table, which the Rust side hard-codes to match.
+# A silent shift here would decrypt every archive with the wrong algorithm, so
+# it is checked before anything else and through each side's own find_cipher.
+for name in aes blowfish serpent twofish nope; do
+  ic=$("$W/c" info "$name"); ir=$("$W/rs" info "$name")
+  if [ "$ic" != "$ir" ]; then
+    echo "  cipher table: '$name' is '$ic' in the C and '$ir' in the Rust shim"
+    fail=$((fail+1))
+  fi
+done
+[ "$fail" -eq 0 ] || { echo "crypto: cipher id/geometry tables disagree"; exit 1; }
+
+# ── Corpus ──────────────────────────────────────────────────────────────────
+# Sizes clustered around the two boundaries a stateful mode can desynchronize
+# at: the cipher block (8 or 16 bytes) and docrypt's LARGE_BUFFER_SIZE read
+# chunk (256 KB). CTR and CFB carry state across chunks, so a port that reset
+# it per read would pass every input below 256 KB.
+python3 - "$W/in" <<'PY'
+import os,sys
+d=sys.argv[1]; os.makedirs(d,exist_ok=True)
+def prng(seed,n):
+    s=seed; o=bytearray()
+    for _ in range(n): s=(s*1103515245+12345)&0xffffffff; o.append((s>>16)&0xff)
+    return bytes(o)
+for n in (0,1,8,15,16,17,255,4096,262143,262144,262145,300000):
+    open(f"{d}/n_{n}","wb").write(prng(n+1,n))
+PY
+
+# Keys and IVs are built byte by byte rather than from a small integer padded
+# with zeroes. A 56-byte blowfish key that is 54 zeros and two data bytes is
+# satisfied by an implementation that reads only part of it, and a counter
+# starting at zero never carries -- both are exactly the mistakes this is
+# looking for.
+genhex() { python3 -c '
+import sys
+kind, n, extra = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+if kind == "key":
+    b = bytes((0x5a + 7*i + extra) & 0xff for i in range(n))
+else:
+    # The two low-order bytes are 0xff, so the little-endian counter carries out
+    # of byte 0 on the very first increment and out of byte 1 soon after.
+    b = bytes([0xff, 0xff] + [(0xa3 + 11*i) & 0xff for i in range(2, n)])
+print(b.hex())
+' "$1" "$2" "$3"; }
+
+# Key sizes per cipher: every length DArc can select with -ae CIPHER-BITS, plus
+# each cipher's maximum (what parse_ENCRYPTION uses when no size is given).
+# Blowfish's 56 is that maximum and the only one over 32 bytes.
+CASES="aes:16,24,32 blowfish:8,32,56 serpent:16,24,32 twofish:16,24,32"
+
+tested=0; cases=0
+serpent_c_diffs=0; serpent_cases=0; other_c_diffs=0
+# A plain string rather than an array: `${arr[@]}` on an empty array is an
+# unbound-variable error under `set -u` in bash 3.2, which is what /bin/bash
+# still is on macOS.
+trivial=""
+
+for spec in $CASES; do
+  cipher="${spec%%:*}"
+  ivlen=$("$W/c" info "$cipher" | cut -d' ' -f2)
+  iv=$(genhex iv "$ivlen" 0)
+  for keylen in $(echo "${spec##*:}" | tr ',' ' '); do
+    key=$(genhex key "$keylen" "$keylen")
+    for mode in ctr cfb; do
+      nontrivial=0
+      for f in "$W"/in/*; do
+        bn=$(basename "$f"); tag="[$cipher-$((keylen*8))/$mode] $bn"
+        cases=$((cases+1))
+
+        "$W/c"   e "$cipher" "$mode" "$key" "$iv" < "$f" >| "$W/ec"   2>/dev/null \
+          || { echo "  $tag: pinned C driver failed";  fail=$((fail+1)); continue; }
+        "$W/c32" e "$cipher" "$mode" "$key" "$iv" < "$f" >| "$W/ec32" 2>/dev/null \
+          || { echo "  $tag: 32-bit-ulong32 C driver failed"; fail=$((fail+1)); continue; }
+        "$W/rs"  e "$cipher" "$mode" "$key" "$iv" < "$f" >| "$W/er"   2>/dev/null \
+          || { echo "  $tag: Rust driver failed"; fail=$((fail+1)); continue; }
+        tested=$((tested+1))
+
+        # The bar: the port reproduces a correctly-built C, byte for byte.
+        # Both stdouts carry the result code ahead of the payload, so this
+        # also catches one side refusing a key size the other accepted.
+        cmp -s "$W/ec32" "$W/er" || { echo "  $tag: ciphertext differs from the C"; fail=$((fail+1)); }
+
+        # Track the pinned C separately: it is the same program as c32 except
+        # for serpent on non-x86_64, and that expectation is asserted below.
+        if ! cmp -s "$W/ec" "$W/ec32"; then
+          if [ "$cipher" = serpent ]; then serpent_c_diffs=$((serpent_c_diffs+1))
+          else
+            other_c_diffs=$((other_c_diffs+1))
+            echo "  $tag: the ulong32 width changes the output of a cipher that should not care"
+            fail=$((fail+1))
+          fi
+        fi
+        # Only non-empty inputs count towards the serpent expectation below:
+        # an empty input yields an empty ciphertext from every build, so those
+        # cases agree no matter how badly the key schedule is miscompiled.
+        [ "$cipher" = serpent ] && [ -s "$f" ] && serpent_cases=$((serpent_cases+1))
+
+        # A cipher that returned its input unchanged would satisfy every
+        # comparison above on both sides at once.
+        if [ -s "$f" ] && ! cmp -s <(tail -c +5 "$W/er") "$f"; then nontrivial=$((nontrivial+1)); fi
+
+        # Both decryption directions. CFB is not symmetric, so decrypt is a
+        # genuinely separate code path rather than the same call twice.
+        "$W/rs"  d "$cipher" "$mode" "$key" "$iv" < <(tail -c +5 "$W/ec32") >| "$W/dr" 2>/dev/null
+        "$W/c32" d "$cipher" "$mode" "$key" "$iv" < <(tail -c +5 "$W/er")   >| "$W/dc" 2>/dev/null
+        cmp -s <(tail -c +5 "$W/dr") "$f" || { echo "  $tag: Rust could not decrypt the C's ciphertext"; fail=$((fail+1)); }
+        cmp -s <(tail -c +5 "$W/dc") "$f" || { echo "  $tag: the C could not decrypt the Rust ciphertext"; fail=$((fail+1)); }
+      done
+      [ "$nontrivial" -gt 0 ] || trivial="$trivial $cipher-$((keylen*8))/$mode"
+    done
+  done
+done
+
+# ── PBKDF2 ──────────────────────────────────────────────────────────────────
+# The key derivation is checked on its own because a wrong key produces a
+# perfectly well-formed archive that simply never opens again. Empty password
+# and empty salt are included: they are what a caller passing nothing produces,
+# and the two implementations are free to disagree there.
+kdf=0
+# `-` stands for the empty string: a bare empty field cannot be written in a
+# whitespace-separated table, and both are cases the two implementations are
+# free to disagree on.
+while read -r pwd salt iters outlen; do
+  [ -n "$pwd$salt$iters$outlen" ] || continue
+  [ "$pwd"  = - ] && pwd=""
+  [ "$salt" = - ] && salt=""
+  "$W/c"  kdf "$pwd" "$salt" "$iters" "$outlen" >| "$W/kc" || { echo "  kdf C driver failed"; fail=$((fail+1)); continue; }
+  "$W/rs" kdf "$pwd" "$salt" "$iters" "$outlen" >| "$W/kr" || { echo "  kdf Rust driver failed"; fail=$((fail+1)); continue; }
+  kdf=$((kdf+1))
+  cmp -s "$W/kc" "$W/kr" || { echo "  kdf('$pwd','$salt',$iters,$outlen): derived keys differ"; fail=$((fail+1)); }
+done <<'KDF'
+password - 1 32
+password 0011223344556677 1000 32
+password 0011223344556677 1 1
+password 0011223344556677 2 64
+correct-horse-battery-staple 00112233445566778899aabbccddeeff 4096 32
+p 0f 10000 16
+KDF
+
+# ── The one input the two implementations legitimately disagree on ──────────
+# An EMPTY password. LibTomCrypt's hmac_init returns CRYPT_INVALID_KEYSIZE when
+# keylen==0 (mac/hmac/hmac_init.c:48); pkcs_5_alg2 propagates it, and
+# Pbkdf2Hmac is declared `void`, so the C never writes the key at all and the
+# caller keeps whatever was in the buffer -- an uninitialised allocaBytes, in
+# EncryptionLib.hs:29. The Rust pbkdf2 derives a real key instead.
+#
+# DArc cannot reach it: ArcvProcessCompress.hs:82 encrypts only when
+# `password > ""`, and Encryption.hs:92 abandons decryption on an empty
+# password rather than deriving from it. So this is a divergence on input no
+# archive can contain, and the port is right not to reproduce a C error path.
+#
+# It is asserted rather than dropped: if the C ever starts writing a key here,
+# or the Rust stops, that is a change worth seeing. The driver zeroes its key
+# buffer before the call, so "the C wrote nothing" reads as all zeros.
+"$W/c"  kdf "" "0011223344556677" 1 32 >| "$W/kc"
+"$W/rs" kdf "" "0011223344556677" 1 32 >| "$W/kr"
+zeros=$(python3 -c "import sys;d=open(sys.argv[1],'rb').read()[4:];print(int(d==bytes(len(d))))" "$W/kc")
+if [ "$zeros" != 1 ]; then
+  echo "empty-password KDF: the C now writes a key where it used to fail; the"
+  echo "divergence documented above no longer holds and should be re-examined."
+  fail=$((fail+1))
+fi
+if cmp -s "$W/kc" "$W/kr"; then
+  echo "empty-password KDF: the Rust side now returns the C's empty result too."
+  echo "Either pbkdf2 started refusing zero-length passwords or the driver changed."
+  fail=$((fail+1))
+fi
+
+# ── Assertions ──────────────────────────────────────────────────────────────
+[ "$tested" -gt 0 ]  || { echo "no cases ran -- the harness reached nothing"; exit 1; }
+[ "$tested" -eq "$cases" ] || { echo "$((cases-tested)) of $cases cases were skipped"; fail=$((fail+1)); }
+[ "$kdf" -eq 6 ]     || { echo "$kdf key-derivation cases ran, expected the 6 in the table"; fail=$((fail+1)); }
+[ -z "$trivial" ] || {
+  echo "these configurations returned the plaintext unchanged:$trivial"; fail=$((fail+1)); }
+[ "$other_c_diffs" -eq 0 ] || fail=$((fail+1))
+
+# The serpent expectation, stated per architecture rather than skipped.
+arch=$(uname -m)
+if [ "$arch" = x86_64 ] || [ "$arch" = amd64 ]; then
+  if [ "$serpent_c_diffs" -ne 0 ]; then
+    echo "serpent: the pinned C and the 32-bit-ulong32 build differ on x86_64, where"
+    echo "the pinned tomcrypt_macros.h already picks a 32-bit ulong32. Something other"
+    echo "than the known typedef bug is at work."
+    fail=$((fail+1))
+  fi
+  serpent_note="identical to the pinned C (x86_64: ulong32 is already 32-bit there)"
+else
+  if [ "$serpent_c_diffs" -ne "$serpent_cases" ]; then
+    echo "serpent: expected all $serpent_cases cases to differ between the pinned C and the"
+    echo "32-bit-ulong32 build on $arch, but $serpent_c_diffs did. Either the pin was moved past"
+    echo "the ulong32 fix -- in which case delete this branch -- or the bug's reach changed."
+    fail=$((fail+1))
+  fi
+  serpent_note="differs from the pinned C on all $serpent_cases cases, which is the known"
+  serpent_note="$serpent_note ulong32 bug in the shipped $arch binaries; the port matches correct Serpent"
+fi
+
+[ "$fail" -eq 0 ] || { echo "crypto: $fail failures"; exit 1; }
+echo "crypto: $tested cipher cases + $kdf key derivations byte-identical to the C"
+echo "crypto: serpent $serpent_note"

--- a/rust/difftest/crypto-sabotage.sh
+++ b/rust/difftest/crypto-sabotage.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Does crypto-check.sh actually exercise the encryption port?
+#
+# It went green on its first complete run, which is the situation in which a
+# check has most often turned out here to be passing without reaching the code
+# it names. So each path gets a deliberate one-line break and the harness has
+# to notice. A sabotage that survives means the corpus does not reach it.
+#
+# The mutations are chosen to be independently reachable: one breaks CTR from
+# the first block, one breaks it only past docrypt's 256 KB read chunk, one
+# breaks CFB in the decrypt direction alone, one breaks the key derivation, and
+# two break the production forwarding shim rather than the algorithms.
+#
+# Discipline this harness enforces on itself, learned the hard way:
+#   * the baseline copy must exist before anything is edited, or a failed
+#     restore silently corrupts the tree;
+#   * every edit must be confirmed to have applied, or a no-op patch reports
+#     "not caught" while nothing was ever broken;
+#   * a build failure must be reported as INCONCLUSIVE, not as a catch -- the
+#     check exits non-zero for that too.
+set -u
+
+cd "$(dirname "$0")/.." || exit 1   # rust/
+CHECK="difftest/crypto-check.sh"
+SRC=darc-crypto/src
+FILES="ctr.rs cfb.rs lib.rs exports.rs"
+BACKUP=$(mktemp -d)
+FAILED=0
+
+for f in $FILES; do
+    cp "$SRC/$f" "$BACKUP/$f" || { echo "FATAL: cannot back up $f"; exit 1; }
+    [ -s "$BACKUP/$f" ] || { echo "FATAL: backup of $f is empty"; exit 1; }
+done
+
+restore() {
+    for f in $FILES; do
+        cp "$BACKUP/$f" "$SRC/$f" || { echo "FATAL: restore of $f failed"; exit 1; }
+        cmp -s "$BACKUP/$f" "$SRC/$f" || { echo "FATAL: $f differs after restore"; exit 1; }
+    done
+}
+trap 'restore; rm -rf "$BACKUP"' EXIT
+
+# sabotage <name> <file> <from> <to>
+sabotage() {
+    local name=$1 file=$2 from=$3 to=$4
+    restore
+    # Confirm the target text is present before editing, so a stale pattern
+    # cannot masquerade as an uncaught sabotage.
+    if ! grep -qF -- "$from" "$SRC/$file"; then
+        echo "BROKEN HARNESS: [$name] pattern not found in $file:"
+        echo "    $from"
+        FAILED=1
+        return
+    fi
+    python3 - "$SRC/$file" "$from" "$to" <<'PY'
+import sys, pathlib
+p = pathlib.Path(sys.argv[1]); s = p.read_text()
+n = s.count(sys.argv[2])
+assert n == 1, f"pattern occurs {n} times, need exactly 1"
+p.write_text(s.replace(sys.argv[2], sys.argv[3]))
+PY
+    if [ $? -ne 0 ]; then
+        echo "BROKEN HARNESS: [$name] edit did not apply cleanly"
+        FAILED=1
+        return
+    fi
+    if ! grep -qF -- "$to" "$SRC/$file"; then
+        echo "BROKEN HARNESS: [$name] replacement text absent after edit"
+        FAILED=1
+        return
+    fi
+
+    local out rc
+    out=$("$CHECK" 2>&1); rc=$?
+    # A crate that no longer compiles also makes the check exit non-zero, so
+    # that case is separated before the exit status is trusted.
+    if echo "$out" | grep -q "cargo build failed"; then
+        echo "INCONCLUSIVE: [$name] the crate did not compile (sabotage was not testable)"
+        FAILED=1
+    elif [ $rc -ne 0 ]; then
+        echo "caught:     [$name]"
+    else
+        echo "SURVIVED:   [$name]  <-- crypto-check.sh does not reach this code"
+        FAILED=1
+    fi
+}
+
+echo "=== baseline ==="
+if ! "$CHECK" >/dev/null 2>&1; then
+    echo "FATAL: clean tree does not pass crypto-check.sh; nothing below is meaningful"
+    exit 1
+fi
+echo "clean tree passes"
+
+echo "=== sabotages ==="
+
+# CTR's counter is incremented little-endian (CTR_COUNTER_LITTLE_ENDIAN in
+# ctr_start). Carrying from the wrong end is the classic CTR porting mistake
+# and changes the keystream from the second block onwards.
+sabotage "ctr: big-endian counter" ctr.rs \
+    "    for byte in counter.iter_mut() {" \
+    "    for byte in counter.iter_mut().rev() {"
+
+# docrypt reads in 256 KB chunks and the mode state has to survive the boundary.
+# Clearing `started` per call makes the first block of every chunk after the
+# first reuse the previous counter value -- invisible on any input under 256 KB.
+sabotage "ctr: state reset at each read chunk" ctr.rs \
+    "        for byte in data.iter_mut() {" \
+    "        self.started = false; for byte in data.iter_mut() {"
+
+# The CFB register accumulates ciphertext in BOTH directions. Feeding back the
+# byte in hand instead is a no-op while encrypting (it has just been overwritten
+# with the ciphertext) and wrong while decrypting -- so this one is caught only
+# if the corpus decrypts as well as encrypts.
+sabotage "cfb: plaintext fed back when decrypting" cfb.rs \
+    "            self.feedback[self.pos] = cipher_byte;" \
+    "            self.feedback[self.pos] = *byte;"
+
+# cfb_start encrypts the IV before any data is processed, so the first keystream
+# block is E(IV) rather than the IV itself.
+sabotage "cfb: IV not pre-encrypted" cfb.rs \
+    "        encrypt_in_place(cipher, &mut keystream);" \
+    "        if false { encrypt_in_place(cipher, &mut keystream); }"
+
+# The iteration count is recorded in the archive and must be honoured exactly;
+# one extra round derives a key nothing can reproduce.
+sabotage "pbkdf2: one extra iteration" lib.rs \
+    "    pbkdf2::pbkdf2::<Hmac<Sha512>>(password, salt, iterations, out)" \
+    "    pbkdf2::pbkdf2::<Hmac<Sha512>>(password, salt, iterations + 1, out)"
+
+# Cipher ids are positions in LibTomCrypt's registration table, hard-coded on
+# the Rust side. Nothing in the type system ties them together.
+sabotage "shim: cipher id 2 dispatches to the wrong cipher" exports.rs \
+    "        2 => run::<serpent::Serpent>(key, iv, mode, encrypting, &io)," \
+    "        2 => run::<twofish::Twofish>(key, iv, mode, encrypting, &io),"
+
+# The direction flag crosses the FFI boundary as an int. CTR does not care;
+# CFB does, so this is caught only by the decrypt half of the corpus.
+sabotage "shim: direction flag ignored" exports.rs \
+    "    let encrypting = do_encryption == ENCRYPT;" \
+    "    let encrypting = true;"
+
+restore
+echo "=== restored ==="
+for f in $FILES; do
+    cmp -s "$BACKUP/$f" "$SRC/$f" || { echo "FATAL: $f not restored"; exit 1; }
+done
+echo "working tree is byte-identical to the baseline"
+
+[ "$FAILED" -eq 0 ] || { echo "crypto-sabotage: some mutations were not caught"; exit 1; }
+echo "crypto-sabotage: every mutation was caught"

--- a/rust/difftest/crypto_ccodec.cpp
+++ b/rust/difftest/crypto_ccodec.cpp
@@ -1,0 +1,54 @@
+/* The encryption layer for the differential harness, compiled once per side.
+ *
+ * Both sides include the SAME source file, C_Encryption.cpp -- the C side from
+ * the pinned tree without -DDARC_RUST (so the vendored LibTomCrypt is what
+ * runs), the Rust side from the working tree, where only the DARC_RUST branch
+ * survives and forwards to libdarc_crypto.a. That is deliberate: it makes the
+ * harness test the production forwarding shim rather than a copy of it, so a
+ * mistake in the shim's argument order shows up here rather than in an archive.
+ *
+ * C_Encryption.cpp registers itself as a compression method at static-init
+ * time, which is the only thing it needs from outside its own translation
+ * unit. Rather than link CompressionLibrary.cpp -- which would drag in every
+ * codec in the tree -- the two symbols involved are stubbed below. Neither is
+ * reached: the harness calls docrypt/Pbkdf2Hmac directly and never constructs
+ * an ENCRYPTION_METHOD.
+ */
+#include "../../Compression/_Encryption/C_Encryption.cpp"
+
+// Cipher ids are NOT a constant of the format -- they are whatever position a
+// cipher ended up at in LibTomCrypt's registration table, and the Rust side
+// hard-codes 0=aes 1=blowfish 2=serpent 3=twofish to match. That agreement is
+// exactly the kind of thing that can silently diverge, so the driver resolves
+// names through each side's own find_cipher and the harness compares the ids.
+//
+// `cipher_descriptor` is LibTomCrypt's ltc_cipher_descriptor[] on the C side
+// and the four-entry darc_cipher_desc[] on the Rust side; the two field names
+// used here are common to both, which is why this compiles unchanged for each.
+extern "C" int ref_find_cipher_id (const char *name)
+{
+    return find_cipher (name);
+}
+
+extern "C" int ref_cipher_block_length (int id)
+{
+    return cipher_descriptor[id].block_length;
+}
+
+extern "C" int ref_cipher_max_key_length (int id)
+{
+    return cipher_descriptor[id].max_key_length;
+}
+
+// ── Stubs standing in for CompressionLibrary.cpp ────────────────────────────
+int AddCompressionMethod (CM_PARSER parser)
+{
+    (void) parser;
+    return 0;
+}
+
+int COMPRESSION_METHOD::doit (char *what, int param, void *data, CALLBACK_FUNC *callback)
+{
+    (void) what; (void) param; (void) data; (void) callback;
+    return FREEARC_ERRCODE_NOT_IMPLEMENTED;
+}

--- a/rust/difftest/crypto_ref.cpp
+++ b/rust/difftest/crypto_ref.cpp
@@ -1,0 +1,147 @@
+/* Reference driver for differential-testing the encryption port.
+ *
+ *     crypto_ref info CIPHER                              -> id/block/maxkey
+ *     crypto_ref e|d  CIPHER MODE KEYHEX IVHEX  <in >out   -> docrypt
+ *     crypto_ref kdf  PWD SALTHEX ITER OUTLEN      >out    -> Pbkdf2Hmac
+ *
+ * Built twice from the same source: once against the pinned C (vendored
+ * LibTomCrypt) and once against the working tree's DARC_RUST shim, which
+ * forwards to rust/darc-crypto. Both builds call docrypt/Pbkdf2Hmac by the
+ * same names, so the driver itself needs no conditionals at all -- the two
+ * binaries differ only in what those names resolve to.
+ *
+ * Encryption is the one place where a "close enough" port is worthless: an
+ * archive written with -p is readable only if the key derivation and the
+ * cipher stream agree to the byte, so every comparison here is byte-for-byte.
+ *
+ * stdout is the RESULT CODE as a 4-byte little-endian int followed by the
+ * payload, and the process exits 0 either way. That makes a single `cmp` of
+ * the two stdouts cover both the bytes and the outcome: a port that refuses a
+ * key size the C accepts differs here just as loudly as one that encrypts it
+ * differently, which a plain "exit nonzero on error" driver would have hidden
+ * behind two equally empty outputs.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+// C_Encryption.h declares docrypt at file scope, and C_Encryption.cpp includes
+// it from inside an `extern "C" {` that spans the whole file -- so docrypt and
+// Pbkdf2Hmac are defined with C linkage. The wrapper here matches that; without
+// it the driver names the C++-mangled symbols and nothing links.
+extern "C" {
+#include "../../Compression/_Encryption/C_Encryption.h"
+}
+
+extern "C" {
+int ref_find_cipher_id       (const char *name);
+int ref_cipher_block_length  (int id);
+int ref_cipher_max_key_length(int id);
+}
+
+struct Buffers {
+  const unsigned char *in; size_t in_len, in_pos;
+  unsigned char *out; size_t out_len, out_cap;
+};
+static int io_callback (const char *what, void *data, int size, void *aux) {
+  Buffers *b = (Buffers*) aux;
+  if (size < 0) return FREEARC_ERRCODE_GENERAL;
+  if (strcmp(what,"read")==0) {
+    size_t avail=b->in_len-b->in_pos, n=(size_t)size<avail?(size_t)size:avail;
+    memcpy(data,b->in+b->in_pos,n); b->in_pos+=n; return (int)n;
+  }
+  if (strcmp(what,"write")==0) {
+    if (b->out_len+(size_t)size>b->out_cap) {
+      size_t cap=b->out_cap?b->out_cap:65536;
+      while (cap<b->out_len+(size_t)size) cap*=2;
+      unsigned char *g=(unsigned char*)realloc(b->out,cap);
+      if(!g) return FREEARC_ERRCODE_NOT_ENOUGH_MEMORY;
+      b->out=g; b->out_cap=cap;
+    }
+    memcpy(b->out+b->out_len,data,(size_t)size); b->out_len+=(size_t)size; return size;
+  }
+  if (strcmp(what,"quasiwrite")==0)  return 0;
+  return FREEARC_ERRCODE_NOT_IMPLEMENTED;
+}
+
+// Hex is how the archive itself stores keys, IVs and salts (see decode16 in
+// C_Encryption.cpp), so the harness passes them the same way rather than
+// inventing an encoding the real caller never uses.
+static int unhex (const char *src, unsigned char *dst, int cap) {
+  int n = 0;
+  for ( ; src[0] && src[1]; src += 2) {
+    if (n >= cap) return -1;
+    int hi = 0, lo = 0;
+    if (sscanf(src, "%1x%1x", &hi, &lo) != 2) return -1;
+    dst[n++] = (unsigned char)(hi*16 + lo);
+  }
+  return src[0] ? -1 : n;   // an odd number of digits is a harness bug, not input
+}
+
+static void emit (int rc, const unsigned char *payload, size_t len) {
+  unsigned char hdr[4] = { (unsigned char)( (unsigned)rc        & 0xff),
+                           (unsigned char)(((unsigned)rc >>  8) & 0xff),
+                           (unsigned char)(((unsigned)rc >> 16) & 0xff),
+                           (unsigned char)(((unsigned)rc >> 24) & 0xff) };
+  fwrite (hdr, 1, 4, stdout);
+  if (len)  fwrite (payload, 1, len, stdout);
+}
+
+int main (int argc, char **argv) {
+  if (argc < 2) {
+    fprintf(stderr,"usage: %s info CIPHER | e|d CIPHER MODE KEYHEX IVHEX | kdf PWD SALTHEX ITER OUTLEN\n",argv[0]);
+    return 2;
+  }
+
+  if (strcmp(argv[1],"info")==0) {
+    if (argc<3) return 2;
+    int id = ref_find_cipher_id (argv[2]);
+    if (id < 0) { printf("-1 0 0\n"); return 0; }
+    printf ("%d %d %d\n", id, ref_cipher_block_length(id), ref_cipher_max_key_length(id));
+    return 0;
+  }
+
+  if (strcmp(argv[1],"kdf")==0) {
+    if (argc<6) return 2;
+    unsigned char salt[MAXKEYSIZE]; int saltSize = unhex (argv[3], salt, sizeof salt);
+    if (saltSize < 0) { fprintf(stderr,"bad salt hex\n"); return 2; }
+    int iterations = atoi (argv[4]);
+    int outLen     = atoi (argv[5]);
+    if (outLen < 0 || outLen > MAXKEYSIZE) { fprintf(stderr,"bad out length\n"); return 2; }
+    unsigned char key[MAXKEYSIZE];
+    memset (key, 0, sizeof key);
+    // Pbkdf2Hmac returns void on both sides, so 0 stands in for the code.
+    Pbkdf2Hmac ((const BYTE*)argv[2], (int)strlen(argv[2]), salt, saltSize, iterations, key, outLen);
+    emit (0, key, (size_t)outLen);
+    return 0;
+  }
+
+  if ((argv[1][0]!='e' && argv[1][0]!='d') || argc < 6) {
+    fprintf(stderr,"usage: %s e|d CIPHER MODE KEYHEX IVHEX\n",argv[0]); return 2; }
+
+  int cipher = ref_find_cipher_id (argv[2]);
+  if (cipher < 0) { fprintf(stderr,"unknown cipher %s\n",argv[2]); return 2; }
+  int mode = strcmp(argv[3],"ctr")==0 ? 0 : strcmp(argv[3],"cfb")==0 ? 1 : -1;
+  if (mode < 0) { fprintf(stderr,"unknown mode %s\n",argv[3]); return 2; }
+
+  unsigned char key[MAXKEYSIZE]; int keysize = unhex (argv[4], key, sizeof key);
+  unsigned char iv [MAXKEYSIZE]; int ivsize  = unhex (argv[5], iv,  sizeof iv);
+  if (keysize < 0 || ivsize < 0) { fprintf(stderr,"bad key/iv hex\n"); return 2; }
+  if (ivsize != ref_cipher_block_length(cipher)) {
+    fprintf(stderr,"iv is %d bytes, cipher block is %d\n",ivsize,ref_cipher_block_length(cipher));
+    return 2;
+  }
+
+  size_t cap=1<<20, len=0; unsigned char *in=(unsigned char*)malloc(cap); if(!in) return 3;
+  for(;;){ if(len==cap){cap*=2; unsigned char*g=(unsigned char*)realloc(in,cap); if(!g){free(in);return 3;} in=g;}
+    size_t n=fread(in+len,1,cap-len,stdin); if(n==0)break; len+=n; }
+
+  Buffers b={in,len,0,NULL,0,0};
+  // rounds is always 0 in DArc (parse_ENCRYPTION's default, never overridden by
+  // the archiver), which means "the cipher's own default"; the Rust side only
+  // implements that case, so passing anything else would compare nothing real.
+  int rc = docrypt (argv[1][0]=='e' ? ENCRYPT : DECRYPT, cipher, mode,
+                    key, keysize, 0, iv, io_callback, &b);
+  emit (rc, b.out, b.out_len);
+  free(in); free(b.out);
+  return 0;
+}


### PR DESCRIPTION
Restores the encryption cross-implementation check that disappeared when `DARC_NO_RUST` and `C_Encryption.cpp`'s `#ifndef DARC_RUST` fallbacks were removed. Since then the only encryption check has been a round-trip, which proves DArc reads its own output and nothing about matching the C.

## How

The C comes from the same pinned revision (`5c2c6ce`) every other codec harness uses, not from the working tree — a fixed oracle cannot drift, and it survives the C being deleted.

`crypto-check.sh` compiles `C_Encryption.cpp` **twice**: the pinned copy without `-DDARC_RUST` (vendored LibTomCrypt runs) and the **working tree's** copy with it (so the production forwarding shim is what gets tested, not a harness-local imitation). It then requires byte-identical ciphertext in both directions across every cipher, mode and key size DArc can select — 288 cases — plus 6 PBKDF2 derivations. Inputs cluster around the cipher block and around `docrypt`'s 256 KB read chunk, because CTR and CFB carry state across both.

## Three things found by running it

- **Serpent.** The pinned `tomcrypt_macros.h` types `ulong32` as `unsigned long` on every LP64 target but x86_64, and `serpent.c`'s key expansion rotates it with a raw shift-or — a rotate at 32 bits, garbage at 64. The shipped ARM64 binaries therefore encrypt `-ae serpent` differently from everything else. Rather than skip it there, the harness builds a **third** binary: the pinned tree with only that header replaced. The port must match it on every arch; the pinned build must *differ* from it on non-x86_64 and *agree* on x86_64. Both asserted — a skip would have read the same as the port being wrong. Verified by measurement: swapping the header alone makes the arm64 mismatch vanish.
- **Empty password.** LibTomCrypt's `hmac_init` returns `CRYPT_INVALID_KEYSIZE` for `keylen==0`; `Pbkdf2Hmac` is `void`, so the C leaves the caller's uninitialised `allocaBytes` untouched while the Rust derives a real key. Unreachable in DArc (`ArcvProcessCompress.hs:82` encrypts only when `password > ""`, `Encryption.hs:92` abandons decryption on an empty one), so the port is right not to copy the error path. Asserted in both directions.
- Keys and IVs are built byte by byte, not zero-padded from a small integer — a 56-byte blowfish key that is 54 zeros is satisfied by an implementation reading only part of it, and a counter starting at zero never carries.

## Proving it can fail

`crypto-sabotage.sh` applies seven one-line breaks — CTR's counter direction and its state across the read chunk, CFB's feedback register and IV pre-encryption, the PBKDF2 iteration count, and two in the shim — and requires the check to notice each. All seven are caught, and the chunk-boundary one is caught **only** by the two inputs past 256 KB, which is how we know those inputs are load-bearing.

## Verified

Both scripts green locally on arm64 (the branch that expects the serpent divergence). CI is the first x86_64 run, which exercises the other branch of that assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)