### PR TITLE
BSC: port the LZP encoder — all six bodies, 576/576 byte-identical

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -846,6 +846,13 @@ jobs:
         rust/difftest/bsc-bwt-check.sh
         rust/difftest/bsc-st-check.sh
         rust/difftest/bsc-full-check.sh
+        # The BSC ENCODER, starting with LZP -- the compressor's first stage.
+        # Byte-identity, not round-tripping: LZP output is what the block sorter
+        # and the entropy coder consume, so a merely-legal encoding would change
+        # every -mbsc archive while decoding perfectly. 576 (parameter, input)
+        # pairs, covering all six of the C's encoder bodies -- they emit
+        # DIFFERENT bytes from each other, so the grid is not redundant.
+        rust/difftest/bsc-lzp-encode-check.sh
         # LZ4-HC is the one ENCODER-side harness: it requires the Rust encoder
         # to be byte-identical to the C for every level DArc can select (1-9),
         # and decodes each block with the C decoder rather than lz4_flex.

--- a/rust/darc-codecs/src/bsc/lzp_enc.rs
+++ b/rust/darc-codecs/src/bsc/lzp_enc.rs
@@ -273,9 +273,17 @@ pub const DEFAULT_LZP_HASH_SIZE: u32 = 15;
 /// `LIBBSC_DEFAULT_LZPMINLEN` (`libbsc.h:79`).
 pub const DEFAULT_LZP_MIN_LEN: u32 = 72;
 
-/// `bsc_lzp_encode_large_fast_path` (:469): the body reached for exactly the
-/// default parameters, and therefore the one every ordinary `-mbsc` archive
-/// goes through. **Not** an optimisation of [`encode_block`] -- it finds
+/// `bsc_lzp_encode_large<unsigned long long>` (:362) **and**
+/// `bsc_lzp_encode_large_fast_path` (:469), which are one function.
+///
+/// The C spells them separately -- the fast path hard-codes
+/// `LIBBSC_DEFAULT_LZPHASHSIZE` and `LIBBSC_DEFAULT_LZPMINLEN` so the compiler
+/// can fold them -- but after substituting those constants and `T = unsigned
+/// long long` the two bodies are textually identical, line for line. Checked by
+/// diffing them rather than by reading: they are 107 and 114 lines of nearly
+/// the same goto-threaded code, which is exactly the shape an eye skims.
+///
+/// This body is **not** an optimisation of [`encode_generic`]. It finds
 /// different match lengths and so emits different bytes; see the module header.
 ///
 /// Four positions are examined per iteration. The four literal bytes are
@@ -283,21 +291,21 @@ pub const DEFAULT_LZP_MIN_LEN: u32 = 72;
 /// per-position paths advance over bytes that are already in the output rather
 /// than writing them -- including the `MATCH_NOT_FOUND` path, which *reads back*
 /// the byte it just committed to decide whether it needs escaping.
-pub fn encode_large_fast_path(input: &[u8], output: &mut [u8]) -> i32 {
-    const MIN_LEN: usize = DEFAULT_LZP_MIN_LEN as usize;
-    let mask = ((1u32 << DEFAULT_LZP_HASH_SIZE) - 1) as u64;
+pub fn encode_large(input: &[u8], output: &mut [u8], hash_size: u32, min_len: u32) -> i32 {
+    let min_len_u = min_len as usize;
+    let mask = ((1u64 << hash_size) - 1) as u64;
 
     let n = input.len();
-    if (n as i64) - (MIN_LEN as i64) < 32 {
+    if (n as i64) - (min_len_u as i64) < 32 {
         return LIBBSC_NOT_COMPRESSIBLE;
     }
     if output.len() < 9 {
         return LIBBSC_NOT_COMPRESSIBLE;
     }
 
-    let mut lookup = vec![0i32; 1usize << DEFAULT_LZP_HASH_SIZE];
+    let mut lookup = vec![0i32; 1usize << hash_size];
     let output_eob = output.len() - 8;
-    let input_min_len_end = n - MIN_LEN - 32;
+    let input_min_len_end = n - min_len_u - 32;
 
     let mut ip = 0usize;
     let mut op = 0usize;
@@ -339,7 +347,7 @@ pub fn encode_large_fast_path(input: &[u8], output: &mut [u8]) -> i32 {
             lookup[index] = (ip + k) as i32;
             if value > 0 {
                 let reference = value as usize;
-                if u64_at(input, ip + MIN_LEN - 8 + k) == u64_at(input, reference + MIN_LEN - 8)
+                if u64_at(input, ip + min_len_u - 8 + k) == u64_at(input, reference + min_len_u - 8)
                     && u64_at(input, ip + k) == u64_at(input, reference)
                 {
                     good = Some((k, reference));
@@ -390,13 +398,13 @@ pub fn encode_large_fast_path(input: &[u8], output: &mut [u8]) -> i32 {
                 len += 8;
             }
 
-            if len < MIN_LEN {
+            if len < min_len_u {
                 heuristic = ip + len;
                 heuristic_v = u64_at(input, heuristic);
                 not_found = true;
             } else {
                 ip += len;
-                let mut rem = len - MIN_LEN;
+                let mut rem = len - min_len_u;
                 output[op] = MATCH_FLAG;
                 op += 1;
                 while rem >= 254 {
@@ -469,10 +477,22 @@ pub fn encode_large_fast_path(input: &[u8], output: &mut [u8]) -> i32 {
 /// specialisations fall through to the generic one, where
 /// `bsc-lzp-encode-check.sh` reports them as mismatches until they land.
 pub fn encode_block(input: &[u8], output: &mut [u8], hash_size: u32, min_len: u32) -> i32 {
-    if hash_size <= 17 && hash_size == DEFAULT_LZP_HASH_SIZE && min_len == DEFAULT_LZP_MIN_LEN {
-        return encode_large_fast_path(input, output);
+    if hash_size <= 17 {
+        // The C's chain, in order. Each arm is `result = (cond && result ==
+        // NOT_ENOUGH_MEMORY) ? f(...) : result`, and none of these ever returns
+        // NOT_ENOUGH_MEMORY, so the first matching condition wins.
+        match min_len {
+            //  4 => encode_small<unsigned int>          not ported yet
+            //  8 => encode_small<unsigned long long>    not ported yet
+            // 16 => encode_small2x<unsigned long long>  not ported yet
+            //  5..=7  => encode_medium<unsigned int>          not ported yet
+            //  9..=15 => encode_medium<unsigned long long>    not ported yet
+            4..=16 => encode_generic(input, output, hash_size, min_len),
+            _ => encode_large(input, output, hash_size, min_len),
+        }
+    } else {
+        encode_generic(input, output, hash_size, min_len)
     }
-    encode_generic(input, output, hash_size, min_len)
 }
 
 /// `bsc_lzp_compress_serial` (:829) -- and therefore `bsc_lzp_compress`, since

--- a/rust/darc-codecs/src/bsc/lzp_enc.rs
+++ b/rust/darc-codecs/src/bsc/lzp_enc.rs
@@ -291,12 +291,59 @@ pub const DEFAULT_LZP_MIN_LEN: u32 = 72;
 /// per-position paths advance over bytes that are already in the output rather
 /// than writing them -- including the `MATCH_NOT_FOUND` path, which *reads back*
 /// the byte it just committed to decide whether it needs escaping.
-pub fn encode_large(input: &[u8], output: &mut [u8], hash_size: u32, min_len: u32) -> i32 {
+/// Which of the four unrolled bodies to run. They share one skeleton and differ
+/// in exactly four places, which is why they are one function here rather than
+/// four transcriptions of the same 100 lines of goto-threaded code.
+///
+/// | body | `end_slack` | second probe | `len` from | `len -=` | heuristic |
+/// |---|---|---|---|---|---|
+/// | `small<T>`   | `T`      | none              | `T`      | `T`      | no |
+/// | `small2x<T>` | `2T`     | `T`               | `2T`     | `2T`     | no |
+/// | `medium<T>`  | `2T`     | `minLen - T`      | `minLen` | `minLen` | no |
+/// | `large<u64>` | `minLen` | `minLen - 8`      | `8`      | `minLen` | **yes** |
+///
+/// `large` is the only one that carries the `heuristic` short-circuit; the other
+/// three take a match whenever the probe passes, because their `len` already
+/// starts at or above the length they require.
+#[derive(Clone, Copy)]
+struct Unrolled {
+    /// `sizeof(T)`: the width of the match probes, 4 or 8.
+    t_size: usize,
+    /// `inputEnd - end_slack - 32` is where the unrolled loop stops.
+    end_slack: usize,
+    /// Offset of the second, earlier-rejecting probe, or `None` for `small`,
+    /// which has only one.
+    probe: Option<usize>,
+    len_start: usize,
+    len_sub: usize,
+    heuristic: bool,
+}
+
+/// The four unrolled encoder bodies of `lzp.cpp` (`encode_small` :74,
+/// `encode_small2x` :170, `encode_medium` :266, `encode_large` :362) --
+/// and `encode_large_fast_path` (:469), which is `encode_large<u64>` with the
+/// default constants folded in. Established by diffing them under the
+/// substitution, not by reading: they are ~100 lines each of nearly-the-same
+/// goto-threaded code with four unrolled positions and eight labels, exactly the
+/// shape an eye skims and calls equivalent while missing a shift.
+///
+/// None of them is an optimisation of [`encode_generic`]; they find different
+/// match lengths and emit different bytes. See the module header.
+///
+/// Four positions are examined per iteration. The four literal bytes are
+/// written up-front by the C's `*(unsigned int *)output = ...` store, so the
+/// per-position paths advance over bytes already in the output rather than
+/// writing them -- including the `MATCH_NOT_FOUND` path, which *reads back* the
+/// byte it just committed to decide whether it needs escaping.
+fn encode_unrolled(input: &[u8], output: &mut [u8], hash_size: u32, min_len: u32, v: Unrolled) -> i32 {
     let min_len_u = min_len as usize;
-    let mask = ((1u64 << hash_size) - 1) as u64;
+    let mask = (1u64 << hash_size) - 1;
 
     let n = input.len();
-    if (n as i64) - (min_len_u as i64) < 32 {
+    // The C's own guard is on minLen; the loop bound additionally needs
+    // end_slack bytes, so both are required for the arithmetic below to stay
+    // inside the buffer.
+    if (n as i64) - (min_len_u as i64) < 32 || (n as i64) - (v.end_slack as i64) < 32 {
         return LIBBSC_NOT_COMPRESSIBLE;
     }
     if output.len() < 9 {
@@ -305,14 +352,25 @@ pub fn encode_large(input: &[u8], output: &mut [u8], hash_size: u32, min_len: u3
 
     let mut lookup = vec![0i32; 1usize << hash_size];
     let output_eob = output.len() - 8;
-    let input_min_len_end = n - min_len_u - 32;
+    let input_min_len_end = n - v.end_slack - 32;
+
+    // `*(T *)a == *(T *)b` at the body's width.
+    let probe_eq = |a: usize, b: usize| -> bool {
+        if v.t_size == 8 {
+            u64_at(input, a) == u64_at(input, b)
+        } else {
+            u32_at(input, a) == u32_at(input, b)
+        }
+    };
 
     let mut ip = 0usize;
     let mut op = 0usize;
     let mut heuristic = 0usize;
-    // The C guards this load with `input < inputMinLenEnd`; the length check
-    // above already guarantees it, but the shape is kept so the two read alike.
-    let mut heuristic_v: u64 = if ip < input_min_len_end { u64_at(input, ip) } else { 0 };
+    let mut heuristic_v: u64 = if v.heuristic && ip < input_min_len_end {
+        u64_at(input, ip)
+    } else {
+        0
+    };
 
     for _ in 0..4 {
         output[op] = input[ip];
@@ -329,16 +387,12 @@ pub fn encode_large(input: &[u8], output: &mut [u8], hash_size: u32, min_len: u3
         // from the low byte up, which is what the shifts below index.
         let next8 = next8_le.swap_bytes();
 
-        // ((a >> 12) ^ a) >> 3 ^ a, i.e. a ^ (a >> 3) ^ (a >> 15) evaluated at
-        // 64 bits. The generic body computes the same expression over a 32-bit
-        // context; at 64 bits the shifts pull in neighbouring bytes, which is
-        // one of the reasons the two bodies choose different matches.
+        // a ^ (a >> 3) ^ (a >> 15), evaluated at 64 bits. The generic body
+        // computes the same expression over a 32-bit context; at 64 bits the
+        // shifts pull in neighbouring bytes, which is one of the reasons the
+        // bodies choose different matches.
         let mix = ((next8 >> 12) ^ next8) >> 3 ^ next8;
 
-        // Each of the four positions: claim the hash slot, then test either for
-        // a match worth taking or for a literal flag byte needing an escape.
-        // `k` is the offset within the four, and the flag byte for offset k is
-        // `next8 >> (3 - k) * 8`.
         let mut good: Option<(usize, usize)> = None; // (offset, reference)
         let mut bad: Option<usize> = None; // offset
         for k in 0..4usize {
@@ -347,9 +401,11 @@ pub fn encode_large(input: &[u8], output: &mut [u8], hash_size: u32, min_len: u3
             lookup[index] = (ip + k) as i32;
             if value > 0 {
                 let reference = value as usize;
-                if u64_at(input, ip + min_len_u - 8 + k) == u64_at(input, reference + min_len_u - 8)
-                    && u64_at(input, ip + k) == u64_at(input, reference)
-                {
+                let probe_ok = match v.probe {
+                    Some(off) => probe_eq(ip + off + k, reference + off),
+                    None => true,
+                };
+                if probe_ok && probe_eq(ip + k, reference) {
                     good = Some((k, reference));
                     break;
                 }
@@ -381,30 +437,31 @@ pub fn encode_large(input: &[u8], output: &mut [u8], hash_size: u32, min_len: u3
         ip += k;
         op += k;
 
-        // GOOD_MATCH_FOUND: verify against the heuristic, then measure.
-        let mut not_found = heuristic > ip && heuristic_v != u64_at(input, reference + (heuristic - ip));
+        let mut not_found = v.heuristic
+            && heuristic > ip
+            && heuristic_v != u64_at(input, reference + (heuristic - ip));
 
         if !not_found {
-            let mut len = 8usize;
+            let mut len = v.len_start;
+            // Eight bytes at a time whatever `T` is, then the exact mismatching
+            // byte. The generic body has no equivalent -- it steps in fours and
+            // compares a 2-byte and a 1-byte tail, which is where they part.
             while ip + len < input_min_len_end {
                 let m = u64_at(input, ip + len) ^ u64_at(input, reference + len);
                 if m != 0 {
-                    // The exact mismatching byte. The generic body has no
-                    // equivalent -- it steps in fours and then compares a
-                    // 2-byte and a 1-byte tail, which is where the two part.
                     len += (m.trailing_zeros() / 8) as usize;
                     break;
                 }
                 len += 8;
             }
 
-            if len < min_len_u {
+            if v.heuristic && len < min_len_u {
                 heuristic = ip + len;
                 heuristic_v = u64_at(input, heuristic);
                 not_found = true;
             } else {
                 ip += len;
-                let mut rem = len - min_len_u;
+                let mut rem = len - v.len_sub;
                 output[op] = MATCH_FLAG;
                 op += 1;
                 while rem >= 254 {
@@ -421,8 +478,8 @@ pub fn encode_large(input: &[u8], output: &mut [u8], hash_size: u32, min_len: u3
             }
         }
 
-        // MATCH_NOT_FOUND: the literal is already in the output; read it back
-        // to see whether it is a flag byte needing an escape.
+        // MATCH_NOT_FOUND, reachable only in the `large` body: the literal is
+        // already in the output; read it back to see whether it needs escaping.
         ip += 1;
         let written = output[op];
         op += 1;
@@ -432,9 +489,9 @@ pub fn encode_large(input: &[u8], output: &mut [u8], hash_size: u32, min_len: u3
         }
     }
 
-    // The tail is identical to the generic body's: no room left to match, but
-    // the hash table still has to be walked so that a literal flag byte is
-    // escaped exactly when the decoder will expect it.
+    // The tail is the generic body's: no room left to match, but the hash table
+    // still has to be walked so a literal flag byte is escaped exactly when the
+    // decoder expects it.
     {
         let mut context = input[ip - 1] as u32
             | ((input[ip - 2] as u32) << 8)
@@ -465,6 +522,57 @@ pub fn encode_large(input: &[u8], output: &mut [u8], hash_size: u32, min_len: u3
     }
 }
 
+/// `bsc_lzp_encode_large<unsigned long long>` (:362), which is also
+/// `bsc_lzp_encode_large_fast_path` (:469) with the defaults folded in.
+pub fn encode_large(input: &[u8], output: &mut [u8], hash_size: u32, min_len: u32) -> i32 {
+    let m = min_len as usize;
+    encode_unrolled(input, output, hash_size, min_len, Unrolled {
+        t_size: 8,
+        end_slack: m,
+        probe: Some(m.saturating_sub(8)),
+        len_start: 8,
+        len_sub: m,
+        heuristic: true,
+    })
+}
+
+/// `bsc_lzp_encode_small<T>` (:74), for `minLen == sizeof(T)`.
+pub fn encode_small(input: &[u8], output: &mut [u8], hash_size: u32, min_len: u32, t_size: usize) -> i32 {
+    encode_unrolled(input, output, hash_size, min_len, Unrolled {
+        t_size,
+        end_slack: t_size,
+        probe: None,
+        len_start: t_size,
+        len_sub: t_size,
+        heuristic: false,
+    })
+}
+
+/// `bsc_lzp_encode_small2x<T>` (:170), for `minLen == 2 * sizeof(T)`.
+pub fn encode_small2x(input: &[u8], output: &mut [u8], hash_size: u32, min_len: u32, t_size: usize) -> i32 {
+    encode_unrolled(input, output, hash_size, min_len, Unrolled {
+        t_size,
+        end_slack: 2 * t_size,
+        probe: Some(t_size),
+        len_start: 2 * t_size,
+        len_sub: 2 * t_size,
+        heuristic: false,
+    })
+}
+
+/// `bsc_lzp_encode_medium<T>` (:266), for `minLen <= 2 * sizeof(T)`.
+pub fn encode_medium(input: &[u8], output: &mut [u8], hash_size: u32, min_len: u32, t_size: usize) -> i32 {
+    let m = min_len as usize;
+    encode_unrolled(input, output, hash_size, min_len, Unrolled {
+        t_size,
+        end_slack: 2 * t_size,
+        probe: Some(m.saturating_sub(t_size)),
+        len_start: m,
+        len_sub: m,
+        heuristic: false,
+    })
+}
+
 /// `bsc_lzp_encode_block` (:679): pick the body the C would pick.
 ///
 /// This reproduces the **x86-64 / AArch64** dispatch, because those are the
@@ -480,14 +588,15 @@ pub fn encode_block(input: &[u8], output: &mut [u8], hash_size: u32, min_len: u3
     if hash_size <= 17 {
         // The C's chain, in order. Each arm is `result = (cond && result ==
         // NOT_ENOUGH_MEMORY) ? f(...) : result`, and none of these ever returns
-        // NOT_ENOUGH_MEMORY, so the first matching condition wins.
+        // NOT_ENOUGH_MEMORY, so the FIRST matching condition wins -- which is
+        // why 4 and 8 reach `small` rather than the `minLen <= 8` `medium` arm
+        // below them, and 16 reaches `small2x` rather than `medium`.
         match min_len {
-            //  4 => encode_small<unsigned int>          not ported yet
-            //  8 => encode_small<unsigned long long>    not ported yet
-            // 16 => encode_small2x<unsigned long long>  not ported yet
-            //  5..=7  => encode_medium<unsigned int>          not ported yet
-            //  9..=15 => encode_medium<unsigned long long>    not ported yet
-            4..=16 => encode_generic(input, output, hash_size, min_len),
+            4 => encode_small(input, output, hash_size, min_len, 4),
+            8 => encode_small(input, output, hash_size, min_len, 8),
+            16 => encode_small2x(input, output, hash_size, min_len, 8),
+            m if m <= 8 => encode_medium(input, output, hash_size, min_len, 4),
+            m if m <= 16 => encode_medium(input, output, hash_size, min_len, 8),
             _ => encode_large(input, output, hash_size, min_len),
         }
     } else {

--- a/rust/darc-codecs/src/bsc/lzp_enc.rs
+++ b/rust/darc-codecs/src/bsc/lzp_enc.rs
@@ -1,0 +1,622 @@
+//! BSC's forward LZP, ported from `Compression/BSC/libbsc/lzp/lzp.cpp`
+//! (`bsc_lzp_encode_generic` :583, `bsc_lzp_compress_serial` :829,
+//! `bsc_lzp_num_blocks` :44).
+//!
+//! The inverse lives in [`super::lzp`]; read its header first for the framing
+//! and the escape rule, which this module produces rather than consumes.
+//!
+//! ## Why only the generic encoder
+//!
+//! `bsc_lzp_encode_block` (:679) dispatches through a stack of width-specialised
+//! bodies -- `encode_small`, `encode_small2x`, `encode_medium`, `encode_large`
+//! and a `_fast_path` for the default parameters -- all of them behind
+//!
+//! ```text
+//! #if !defined(LIBBSC_NO_UNALIGNED_ACCESS) && (defined(LIBBSC_x86_64) || defined(LIBBSC_AArch64))
+//!     if (hashSize <= 17) { ... }
+//! ```
+//!
+//! and falls back to `bsc_lzp_encode_generic` otherwise. The generic body is
+//! what runs on i386, on 32-bit ARM, under `LIBBSC_NO_UNALIGNED_ACCESS`, and on
+//! any target at all once `hashSize >= 18` -- a size DArc exposes directly, via
+//! `-mbsc:h18` and up.
+//!
+//! So the two must agree byte for byte, or libbsc on i386 and libbsc on x86-64
+//! would write different archives from the same input. This port implements the
+//! generic body alone and `bsc-lzp-encode-check.sh` compares it against whatever
+//! path the C takes on the host, which is how that agreement gets tested rather
+//! than assumed.
+//!
+//! ## No parallel variant
+//!
+//! `bsc_lzp_compress_parallel` is inside `#ifdef LIBBSC_OPENMP`, and DArc never
+//! defines `LIBBSC_OPENMP_SUPPORT` (see `Compression/BSC/makefile`), so
+//! `bsc_lzp_compress` always reaches the serial function. The two split the
+//! input identically anyway -- both use `bsc_lzp_num_blocks` -- so this is a
+//! scheduling difference, not a format one.
+
+use super::LIBBSC_NOT_COMPRESSIBLE;
+
+/// `LIBBSC_LZP_MATCH_FLAG` (:42).
+const MATCH_FLAG: u8 = 0xF2;
+
+/// `bsc_lzp_num_blocks` (:44). The thresholds are `k*k*65536` for each `k`, in
+/// descending order, so the block count grows with the square root of the
+/// input; below `2*2*65536` it is a single block.
+fn num_blocks(n: usize) -> usize {
+    const BREAK_POINTS: [(usize, usize); 12] = [
+        (128, 128 * 128 * 65536),
+        (96, 96 * 96 * 65536),
+        (64, 64 * 64 * 65536),
+        (48, 48 * 48 * 65536),
+        (32, 32 * 32 * 65536),
+        (24, 24 * 24 * 65536),
+        (16, 16 * 16 * 65536),
+        (12, 12 * 12 * 65536),
+        (8, 8 * 8 * 65536),
+        (6, 6 * 6 * 65536),
+        (4, 4 * 4 * 65536),
+        (2, 2 * 2 * 65536),
+    ];
+    for (blocks, threshold) in BREAK_POINTS {
+        if n >= threshold {
+            return blocks;
+        }
+    }
+    1
+}
+
+/// Read four bytes little-endian, the portable spelling of the C's
+/// `*(unsigned int *)p`.
+///
+/// Every call site below is inside the slack the C relies on: `inputMinLenEnd`
+/// stops `minLen + 32` bytes short of the end, so a 4-byte read at or before it
+/// cannot pass the buffer. The bound is asserted here rather than trusted --
+/// the C reads past its own loop condition by design, and a port that copied
+/// that shape without the slack would read out of bounds on short inputs.
+#[inline]
+fn u32_at(buf: &[u8], at: usize) -> u32 {
+    u32::from_le_bytes([buf[at], buf[at + 1], buf[at + 2], buf[at + 3]])
+}
+
+/// `bsc_lzp_encode_generic` (:583). Encodes `input` into `output`, returning the
+/// number of bytes written, or `LIBBSC_NOT_COMPRESSIBLE` when the result would
+/// not fit in the space allowed.
+///
+/// `output` is the C's `[output, outputEnd)` window; the C stops at
+/// `outputEnd - 8`, so the caller must supply at least 9 bytes.
+pub fn encode_generic(input: &[u8], output: &mut [u8], hash_size: u32, min_len: u32) -> i32 {
+    let n = input.len();
+    let min_len = min_len as usize;
+
+    // `if (inputEnd - input - minLen < 32) return LIBBSC_NOT_COMPRESSIBLE;`
+    // Signed in the C, so an input shorter than minLen also lands here.
+    if (n as i64) - (min_len as i64) < 32 {
+        return LIBBSC_NOT_COMPRESSIBLE;
+    }
+    if output.len() < 9 {
+        return LIBBSC_NOT_COMPRESSIBLE;
+    }
+
+    let mask = ((1u64 << hash_size) - 1) as u32;
+    let mut lookup = vec![0i32; 1usize << hash_size];
+
+    // outputEOB = outputEnd - 8. Both loops below stop at it, and the final
+    // return treats having reached it as "did not fit".
+    let output_eob = output.len() - 8;
+    // inputMinLenEnd = inputEnd - minLen - 32, which the guard above makes >= 0.
+    let input_min_len_end = n - min_len - 32;
+
+    let mut ip = 0usize; // `input`  as an offset from inputStart
+    let mut op = 0usize; // `output` as an offset from outputStart
+    let mut heuristic = 0usize; // `heuristic`, likewise an offset
+
+    // The first four bytes are copied verbatim: they are what seeds the context.
+    for _ in 0..4 {
+        output[op] = input[ip];
+        op += 1;
+        ip += 1;
+    }
+
+    let context_at = |ip: usize| -> u32 {
+        input[ip - 1] as u32
+            | ((input[ip - 2] as u32) << 8)
+            | ((input[ip - 3] as u32) << 16)
+            | ((input[ip - 4] as u32) << 24)
+    };
+
+    // ── Main loop: match search ─────────────────────────────────────────────
+    {
+        let mut context = context_at(ip);
+
+        while ip < input_min_len_end && op < output_eob {
+            let index = (((context >> 15) ^ context ^ (context >> 3)) & mask) as usize;
+            let value = lookup[index];
+            lookup[index] = ip as i32;
+
+            // `value > 0`, not `>= 0`: position 0 is indistinguishable from
+            // "never seen" in the C's zero-initialised table, so a match at the
+            // very start is never taken. Reproduced deliberately.
+            if value > 0 {
+                let reference = value as usize;
+
+                // The C tests the LAST four bytes of the minimum length first,
+                // then the first four -- cheapest rejection first, and the
+                // order is immaterial to the outcome.
+                let matches = u32_at(input, ip + min_len - 4)
+                    == u32_at(input, reference + min_len - 4)
+                    && u32_at(input, ip) == u32_at(input, reference);
+
+                let mut found = false;
+                if matches {
+                    // The heuristic: a previous failed match already proved
+                    // these four bytes differ, so do not walk them again.
+                    if heuristic > ip
+                        && u32_at(input, heuristic) != u32_at(input, reference + (heuristic - ip))
+                    {
+                        // falls through to the literal path
+                    } else {
+                        let mut len = 4usize;
+                        while ip + len < input_min_len_end {
+                            if u32_at(input, ip + len) != u32_at(input, reference + len) {
+                                break;
+                            }
+                            len += 4;
+                        }
+
+                        if len < min_len {
+                            heuristic = ip + len;
+                        } else {
+                            // Two tail comparisons, 2 bytes then 1, each adding
+                            // its width only on equality. Written as the C does
+                            // rather than as a byte loop: the widths are what
+                            // decide the final length.
+                            len += 2 * usize::from(
+                                u16::from_le_bytes([input[ip + len], input[ip + len + 1]])
+                                    == u16::from_le_bytes([
+                                        input[reference + len],
+                                        input[reference + len + 1],
+                                    ]),
+                            );
+                            len += usize::from(input[ip + len] == input[reference + len]);
+
+                            ip += len;
+                            context = context_at(ip);
+
+                            output[op] = MATCH_FLAG;
+                            op += 1;
+
+                            let mut rem = len - min_len;
+                            while rem >= 254 {
+                                rem -= 254;
+                                output[op] = 254;
+                                op += 1;
+                                if op >= output_eob {
+                                    break;
+                                }
+                            }
+                            output[op] = rem as u8;
+                            op += 1;
+                            found = true;
+                        }
+                    }
+                }
+
+                if !found {
+                    // LIBBSC_LZP_MATCH_NOT_FOUND
+                    let next = input[ip];
+                    output[op] = next;
+                    op += 1;
+                    ip += 1;
+                    context = (context << 8) | next as u32;
+                    if next == MATCH_FLAG {
+                        output[op] = 255;
+                        op += 1;
+                    }
+                }
+            } else {
+                let next = input[ip];
+                output[op] = next;
+                op += 1;
+                ip += 1;
+                context = (context << 8) | next as u32;
+            }
+        }
+    }
+
+    // ── Tail: no more room to match, but the table still has to be walked and
+    // literal flag bytes still have to be escaped. ──────────────────────────
+    {
+        let mut context = context_at(ip);
+
+        while ip < n && op < output_eob {
+            let index = (((context >> 15) ^ context ^ (context >> 3)) & mask) as usize;
+            let value = lookup[index];
+            lookup[index] = ip as i32;
+
+            let next = input[ip];
+            output[op] = next;
+            op += 1;
+            ip += 1;
+            context = (context << 8) | next as u32;
+            if next == MATCH_FLAG && value > 0 {
+                output[op] = 255;
+                op += 1;
+            }
+        }
+    }
+
+    if op >= output_eob {
+        LIBBSC_NOT_COMPRESSIBLE
+    } else {
+        op as i32
+    }
+}
+
+/// Read eight bytes little-endian, the portable spelling of `*(unsigned long long *)p`.
+#[inline]
+fn u64_at(buf: &[u8], at: usize) -> u64 {
+    u64::from_le_bytes([
+        buf[at],
+        buf[at + 1],
+        buf[at + 2],
+        buf[at + 3],
+        buf[at + 4],
+        buf[at + 5],
+        buf[at + 6],
+        buf[at + 7],
+    ])
+}
+
+/// `LIBBSC_DEFAULT_LZPHASHSIZE` (`libbsc.h:78`).
+pub const DEFAULT_LZP_HASH_SIZE: u32 = 15;
+/// `LIBBSC_DEFAULT_LZPMINLEN` (`libbsc.h:79`).
+pub const DEFAULT_LZP_MIN_LEN: u32 = 72;
+
+/// `bsc_lzp_encode_large_fast_path` (:469): the body reached for exactly the
+/// default parameters, and therefore the one every ordinary `-mbsc` archive
+/// goes through. **Not** an optimisation of [`encode_block`] -- it finds
+/// different match lengths and so emits different bytes; see the module header.
+///
+/// Four positions are examined per iteration. The four literal bytes are
+/// written up-front by the C's `*(unsigned int *)output = ...` store, so the
+/// per-position paths advance over bytes that are already in the output rather
+/// than writing them -- including the `MATCH_NOT_FOUND` path, which *reads back*
+/// the byte it just committed to decide whether it needs escaping.
+pub fn encode_large_fast_path(input: &[u8], output: &mut [u8]) -> i32 {
+    const MIN_LEN: usize = DEFAULT_LZP_MIN_LEN as usize;
+    let mask = ((1u32 << DEFAULT_LZP_HASH_SIZE) - 1) as u64;
+
+    let n = input.len();
+    if (n as i64) - (MIN_LEN as i64) < 32 {
+        return LIBBSC_NOT_COMPRESSIBLE;
+    }
+    if output.len() < 9 {
+        return LIBBSC_NOT_COMPRESSIBLE;
+    }
+
+    let mut lookup = vec![0i32; 1usize << DEFAULT_LZP_HASH_SIZE];
+    let output_eob = output.len() - 8;
+    let input_min_len_end = n - MIN_LEN - 32;
+
+    let mut ip = 0usize;
+    let mut op = 0usize;
+    let mut heuristic = 0usize;
+    // The C guards this load with `input < inputMinLenEnd`; the length check
+    // above already guarantees it, but the shape is kept so the two read alike.
+    let mut heuristic_v: u64 = if ip < input_min_len_end { u64_at(input, ip) } else { 0 };
+
+    for _ in 0..4 {
+        output[op] = input[ip];
+        op += 1;
+        ip += 1;
+    }
+
+    while ip < input_min_len_end && op < output_eob {
+        // `*(unsigned long long *)(input - 4)`, then the four literals are
+        // stored to the output before anything decides what to do with them.
+        let next8_le = u64_at(input, ip - 4);
+        output[op..op + 4].copy_from_slice(&((next8_le >> 32) as u32).to_le_bytes());
+        // Byte-swapped, the value reads as input[3], input[2], ... input[-4]
+        // from the low byte up, which is what the shifts below index.
+        let next8 = next8_le.swap_bytes();
+
+        // ((a >> 12) ^ a) >> 3 ^ a, i.e. a ^ (a >> 3) ^ (a >> 15) evaluated at
+        // 64 bits. The generic body computes the same expression over a 32-bit
+        // context; at 64 bits the shifts pull in neighbouring bytes, which is
+        // one of the reasons the two bodies choose different matches.
+        let mix = ((next8 >> 12) ^ next8) >> 3 ^ next8;
+
+        // Each of the four positions: claim the hash slot, then test either for
+        // a match worth taking or for a literal flag byte needing an escape.
+        // `k` is the offset within the four, and the flag byte for offset k is
+        // `next8 >> (3 - k) * 8`.
+        let mut good: Option<(usize, usize)> = None; // (offset, reference)
+        let mut bad: Option<usize> = None; // offset
+        for k in 0..4usize {
+            let index = ((mix >> (32 - 8 * k)) & mask) as usize;
+            let value = lookup[index];
+            lookup[index] = (ip + k) as i32;
+            if value > 0 {
+                let reference = value as usize;
+                if u64_at(input, ip + MIN_LEN - 8 + k) == u64_at(input, reference + MIN_LEN - 8)
+                    && u64_at(input, ip + k) == u64_at(input, reference)
+                {
+                    good = Some((k, reference));
+                    break;
+                }
+                if ((next8 >> ((3 - k) * 8)) as u8) == MATCH_FLAG {
+                    bad = Some(k);
+                    break;
+                }
+            }
+        }
+
+        if let Some(k) = bad {
+            // BAD_MATCH_FOUND: step past the literal, which is already in the
+            // output, and append the escape byte.
+            ip += k + 1;
+            op += k + 1;
+            output[op] = 255;
+            op += 1;
+            continue;
+        }
+
+        let (k, reference) = match good {
+            Some(g) => g,
+            None => {
+                ip += 4;
+                op += 4;
+                continue;
+            }
+        };
+        ip += k;
+        op += k;
+
+        // GOOD_MATCH_FOUND: verify against the heuristic, then measure.
+        let mut not_found = heuristic > ip && heuristic_v != u64_at(input, reference + (heuristic - ip));
+
+        if !not_found {
+            let mut len = 8usize;
+            while ip + len < input_min_len_end {
+                let m = u64_at(input, ip + len) ^ u64_at(input, reference + len);
+                if m != 0 {
+                    // The exact mismatching byte. The generic body has no
+                    // equivalent -- it steps in fours and then compares a
+                    // 2-byte and a 1-byte tail, which is where the two part.
+                    len += (m.trailing_zeros() / 8) as usize;
+                    break;
+                }
+                len += 8;
+            }
+
+            if len < MIN_LEN {
+                heuristic = ip + len;
+                heuristic_v = u64_at(input, heuristic);
+                not_found = true;
+            } else {
+                ip += len;
+                let mut rem = len - MIN_LEN;
+                output[op] = MATCH_FLAG;
+                op += 1;
+                while rem >= 254 {
+                    rem -= 254;
+                    output[op] = 254;
+                    op += 1;
+                    if op >= output_eob {
+                        break;
+                    }
+                }
+                output[op] = rem as u8;
+                op += 1;
+                continue;
+            }
+        }
+
+        // MATCH_NOT_FOUND: the literal is already in the output; read it back
+        // to see whether it is a flag byte needing an escape.
+        ip += 1;
+        let written = output[op];
+        op += 1;
+        if written == MATCH_FLAG {
+            output[op] = 255;
+            op += 1;
+        }
+    }
+
+    // The tail is identical to the generic body's: no room left to match, but
+    // the hash table still has to be walked so that a literal flag byte is
+    // escaped exactly when the decoder will expect it.
+    {
+        let mut context = input[ip - 1] as u32
+            | ((input[ip - 2] as u32) << 8)
+            | ((input[ip - 3] as u32) << 16)
+            | ((input[ip - 4] as u32) << 24);
+
+        while ip < n && op < output_eob {
+            let index = (((context >> 15) ^ context ^ (context >> 3)) as u64 & mask) as usize;
+            let value = lookup[index];
+            lookup[index] = ip as i32;
+
+            let next = input[ip];
+            output[op] = next;
+            op += 1;
+            ip += 1;
+            context = (context << 8) | next as u32;
+            if next == MATCH_FLAG && value > 0 {
+                output[op] = 255;
+                op += 1;
+            }
+        }
+    }
+
+    if op >= output_eob {
+        LIBBSC_NOT_COMPRESSIBLE
+    } else {
+        op as i32
+    }
+}
+
+/// `bsc_lzp_encode_block` (:679): pick the body the C would pick.
+///
+/// This reproduces the **x86-64 / AArch64** dispatch, because those are the
+/// targets DArc ships and their archives are what the fingerprints in
+/// `Tests/run-tests.sh` record. On i386 or under `LIBBSC_NO_UNALIGNED_ACCESS`
+/// the C would take [`encode_generic`] for every parameter and emit different
+/// bytes -- a divergence that predates this port and is the C's, not ours.
+///
+/// Only the default-parameter body is ported so far; the four remaining
+/// specialisations fall through to the generic one, where
+/// `bsc-lzp-encode-check.sh` reports them as mismatches until they land.
+pub fn encode_block(input: &[u8], output: &mut [u8], hash_size: u32, min_len: u32) -> i32 {
+    if hash_size <= 17 && hash_size == DEFAULT_LZP_HASH_SIZE && min_len == DEFAULT_LZP_MIN_LEN {
+        return encode_large_fast_path(input, output);
+    }
+    encode_generic(input, output, hash_size, min_len)
+}
+
+/// `bsc_lzp_compress_serial` (:829) -- and therefore `bsc_lzp_compress`, since
+/// the parallel variant is compiled out. Writes the block index and the coded
+/// blocks into `output`, returning the total byte count.
+///
+/// `output` must be at least `input.len()` bytes: the C hands each block an
+/// output window bounded by the remaining space in a buffer of exactly `n`, and
+/// declares the whole thing incompressible when a block cannot fit.
+pub fn compress(input: &[u8], output: &mut [u8], hash_size: u32, min_len: u32) -> i32 {
+    let n = input.len();
+    if output.len() < n || n == 0 {
+        return LIBBSC_NOT_COMPRESSIBLE;
+    }
+
+    let n_blocks = num_blocks(n);
+
+    if n_blocks == 1 {
+        // The C passes `output + 1 .. output + n - 1`, i.e. one byte reserved
+        // for the count and one byte short at the end. For n < 2 that window is
+        // inverted; the C never notices because bsc_lzp_encode_block's own
+        // length check returns first, but slicing it in Rust panics, so the
+        // same answer is given here instead.
+        if n < 2 {
+            return LIBBSC_NOT_COMPRESSIBLE;
+        }
+        let result = encode_block(input, &mut output[1..n - 1], hash_size, min_len);
+        if result < 0 {
+            return result;
+        }
+        output[0] = 1;
+        return result + 1;
+    }
+
+    let chunk_size = n / n_blocks;
+    let mut output_ptr = 1 + 8 * n_blocks;
+
+    output[0] = n_blocks as u8;
+    for block_id in 0..n_blocks {
+        let input_start = block_id * chunk_size;
+        let input_size = if block_id != n_blocks - 1 {
+            chunk_size
+        } else {
+            n - input_start
+        };
+        // The window given to the block is the smaller of its input size and
+        // whatever is left of the n-byte buffer.
+        let mut output_size = input_size;
+        if output_size > n - output_ptr {
+            output_size = n - output_ptr;
+        }
+
+        let result = encode_block(
+            &input[input_start..input_start + input_size],
+            &mut output[output_ptr..output_ptr + output_size],
+            hash_size,
+            min_len,
+        );
+
+        let result = if result < 0 {
+            // Store the block instead -- unless storing it would overrun, in
+            // which case the whole input is declared incompressible.
+            if output_ptr + input_size >= n {
+                return LIBBSC_NOT_COMPRESSIBLE;
+            }
+            output[output_ptr..output_ptr + input_size]
+                .copy_from_slice(&input[input_start..input_start + input_size]);
+            input_size
+        } else {
+            result as usize
+        };
+
+        // Two little-endian 32-bit words per block: the input size, then the
+        // coded size. Equal sizes are how the decoder recognises a stored block.
+        output[1 + 8 * block_id..1 + 8 * block_id + 4]
+            .copy_from_slice(&(input_size as i32).to_le_bytes());
+        output[1 + 8 * block_id + 4..1 + 8 * block_id + 8]
+            .copy_from_slice(&(result as i32).to_le_bytes());
+
+        output_ptr += result;
+    }
+
+    output_ptr as i32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bsc::lzp;
+
+    /// The property the format rests on: whatever the encoder emits, the
+    /// already-verified decoder must return the original bytes.
+    fn round_trip(data: &[u8], hash_size: u32, min_len: u32) {
+        let mut coded = vec![0u8; data.len().max(64)];
+        let n = compress(data, &mut coded, hash_size, min_len);
+        if n < 0 {
+            return; // incompressible is a legitimate answer, not a failure
+        }
+        let mut back = vec![0u8; data.len() + 64];
+        let got = lzp::decompress(&coded[..n as usize], &mut back, hash_size, min_len)
+            .expect("the decoder must read what the encoder wrote");
+        assert_eq!(&back[..got], data);
+    }
+
+    #[test]
+    fn round_trips_repetitive_data() {
+        let data: Vec<u8> = b"the quick brown fox jumps over the lazy dog. "
+            .iter()
+            .cycle()
+            .take(100_000)
+            .copied()
+            .collect();
+        round_trip(&data, 16, 32);
+    }
+
+    #[test]
+    fn round_trips_data_containing_the_flag_byte() {
+        // 0xF2 in the input has to be escaped; a corpus without it never
+        // exercises the escape on either side.
+        let mut data = vec![0u8; 60_000];
+        let mut s: u32 = 7;
+        for (i, b) in data.iter_mut().enumerate() {
+            s = s.wrapping_mul(1103515245).wrapping_add(12345);
+            *b = if i % 17 == 0 { 0xF2 } else { (s >> 16) as u8 };
+        }
+        round_trip(&data, 16, 32);
+    }
+
+    #[test]
+    fn short_input_is_not_compressible() {
+        let data = [1u8; 16];
+        let mut out = [0u8; 64];
+        assert_eq!(
+            encode_block(&data, &mut out, 16, 32),
+            LIBBSC_NOT_COMPRESSIBLE
+        );
+    }
+
+    #[test]
+    fn block_count_matches_the_c_table() {
+        assert_eq!(num_blocks(0), 1);
+        assert_eq!(num_blocks(2 * 2 * 65536 - 1), 1);
+        assert_eq!(num_blocks(2 * 2 * 65536), 2);
+        assert_eq!(num_blocks(4 * 4 * 65536), 4);
+        assert_eq!(num_blocks(128 * 128 * 65536), 128);
+    }
+}

--- a/rust/darc-codecs/src/bsc/mod.rs
+++ b/rust/darc-codecs/src/bsc/mod.rs
@@ -48,6 +48,7 @@ pub mod bwt;
 pub mod dispatch;
 pub mod header;
 pub mod lzp;
+pub mod lzp_enc;
 pub mod model;
 pub mod model_consts;
 pub mod predictor;
@@ -60,6 +61,9 @@ pub mod tables;
 pub const LIBBSC_NO_ERROR: i32 = 0;
 pub const LIBBSC_BAD_PARAMETER: i32 = -1;
 pub const LIBBSC_NOT_ENOUGH_MEMORY: i32 = -2;
+/// Not an error the caller must propagate: the encoder returns it to mean
+/// "this block did not shrink", and `bsc_compress` answers by storing it.
+pub const LIBBSC_NOT_COMPRESSIBLE: i32 = -3;
 pub const LIBBSC_UNEXPECTED_EOB: i32 = -5;
 pub const LIBBSC_DATA_CORRUPT: i32 = -6;
 

--- a/rust/darc-codecs/src/exports.rs
+++ b/rust/darc-codecs/src/exports.rs
@@ -699,6 +699,35 @@ pub unsafe extern "C" fn darc_rs_bsc_decompress_block(
     bsc::dispatch::decompress(inp, out)
 }
 
+/// `bsc_lzp_compress`: LZP-encode `input` into `output`. Returns the number of
+/// bytes written, or a negative libbsc code -- `LIBBSC_NOT_COMPRESSIBLE` (-3)
+/// when the input does not shrink, which the caller answers by skipping LZP.
+///
+/// Exported for the differential harness ahead of the rest of the BSC encoder;
+/// nothing in the archiver calls it yet.
+///
+/// # Safety
+/// `input` must be valid for `in_size` bytes, `output` for `out_cap` bytes.
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_bsc_lzp_compress(
+    input: *const u8,
+    in_size: c_int,
+    output: *mut u8,
+    out_cap: c_int,
+    hash_size: c_int,
+    min_len: c_int,
+) -> c_int {
+    if input.is_null() || output.is_null() || in_size < 0 || out_cap < 0 {
+        return FREEARC_ERRCODE_GENERAL;
+    }
+    if !(10..=28).contains(&hash_size) || !(4..=255).contains(&min_len) {
+        return bsc::LIBBSC_BAD_PARAMETER;
+    }
+    let inp = core::slice::from_raw_parts(input, in_size as usize);
+    let out = core::slice::from_raw_parts_mut(output, out_cap as usize);
+    bsc::lzp_enc::compress(inp, out, hash_size as u32, min_len as u32)
+}
+
 /// LZ4 raw-block decode, mirroring `LZ4_decompress_safe`: returns the number of
 /// bytes written, or a negative code. This is the *safe* variant -- it must not
 /// read past `src` nor write past `dst` however malformed the block is, since

--- a/rust/difftest/bsc-lzp-encode-check.sh
+++ b/rust/difftest/bsc-lzp-encode-check.sh
@@ -87,13 +87,13 @@ fail=0; tested=0; ncmp=0; outstanding=0; outstanding_names=""
 #   15:72  encode_large_fast_path  <- DArc's DEFAULT, every ordinary -mbsc block
 #   18:*   encode_generic          <- hashSize >= 18 leaves the specialised chain
 #   23:*   encode_generic
-# encode_large covers every minLen >= 17 at hashSize <= 17, and the
-# "fast path" is that same function with the defaults folded in -- the two
-# C bodies are textually identical once the constants are substituted.
-PORTED="12:32 12:64 12:72 15:32 15:64 15:72 16:32 16:64 16:72 17:32 17:64 17:72 \
-18:4 18:8 18:16 18:32 18:64 18:72 23:4 23:8 23:16 23:32 23:64 23:72"
+# ALL six bodies are ported, so every cell must match. The literal is kept
+# rather than dropping the mechanism: it is what makes a body regressing out of
+# the ported set a hard failure rather than a quiet line of prose.
+PORTED="ALL"
 
 is_ported() {
+  case "$PORTED" in ALL) return 0;; esac
   case " $PORTED " in *" $1:$2 "*) return 0;; esac
   return 1
 }

--- a/rust/difftest/bsc-lzp-encode-check.sh
+++ b/rust/difftest/bsc-lzp-encode-check.sh
@@ -87,7 +87,11 @@ fail=0; tested=0; ncmp=0; outstanding=0; outstanding_names=""
 #   15:72  encode_large_fast_path  <- DArc's DEFAULT, every ordinary -mbsc block
 #   18:*   encode_generic          <- hashSize >= 18 leaves the specialised chain
 #   23:*   encode_generic
-PORTED="15:72 18:4 18:8 18:16 18:32 18:64 18:72 23:4 23:8 23:16 23:32 23:64 23:72"
+# encode_large covers every minLen >= 17 at hashSize <= 17, and the
+# "fast path" is that same function with the defaults folded in -- the two
+# C bodies are textually identical once the constants are substituted.
+PORTED="12:32 12:64 12:72 15:32 15:64 15:72 16:32 16:64 16:72 17:32 17:64 17:72 \
+18:4 18:8 18:16 18:32 18:64 18:72 23:4 23:8 23:16 23:32 23:64 23:72"
 
 is_ported() {
   case " $PORTED " in *" $1:$2 "*) return 0;; esac
@@ -146,5 +150,5 @@ is_ported 15 72 || { echo "the DEFAULT parameters (15,72) are no longer in PORTE
 echo "bsc-lzp-encode: $ncmp/$tested byte-identical to the C"
 if [ "$outstanding" -gt 0 ]; then
   echo "bsc-lzp-encode: $outstanding comparisons differ in bodies not ported yet:$outstanding_names"
-  echo "                (encode_small / small2x / medium / large -- see bsc/lzp_enc.rs)"
+  echo "                (encode_small / small2x / medium -- see bsc/lzp_enc.rs)"
 fi

--- a/rust/difftest/bsc-lzp-encode-check.sh
+++ b/rust/difftest/bsc-lzp-encode-check.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Differential-test the BSC LZP ENCODER against the C original.
+#
+# The first encoder-side cut into BSC. LZP is the compressor's first stage and
+# depends on neither the block sorter nor the entropy coder, so a mismatch here
+# points squarely at the match finder -- the context hash, the heuristic, the
+# match-length tail, the escape of a literal flag byte -- and not at four
+# interacting stages. Same ordering the decode side was built in.
+#
+# BYTE-IDENTITY is the bar, not round-tripping. LZP output is what the block
+# sorter and the entropy coder then consume, so an encoding that is merely legal
+# would change every -mbsc archive while decoding perfectly.
+#
+# bsc_lzp_encode_block (:679) picks one of SIX bodies from (hashSize, minLen),
+# and they do not emit the same bytes -- see rust/darc-codecs/src/bsc/lzp_enc.rs
+# for the measurement. So the grid below is not redundant coverage of one
+# algorithm; each cell selects a different encoder, and PORTED below records
+# which of them the Rust implements today. A cell outside PORTED that differs is
+# outstanding work, reported and counted; a cell inside PORTED that differs is a
+# bug and fails the run.
+#
+# The C reference comes from a pinned revision, not the working tree -- see
+# c-reference.sh for why.
+set -uo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$ROOT/rust/difftest/c-reference.sh"
+CREF="$(darc_c_reference "$ROOT")" || exit 1
+W="${TMPDIR:-/tmp}/bsc-lzp-enc.$$"; mkdir -p "$W"
+trap 'rm -rf "$W"' EXIT
+
+( cd "$ROOT/rust" && cargo build --release -p darc-codecs ) >/dev/null 2>&1 \
+  || { echo "cargo build failed" >&2; exit 1; }
+LIB="$ROOT/rust/target/release/libdarc_codecs.a"
+
+# libsais.c is its own translation unit (see bsc_ccodec.cpp). The Rust staticlib
+# trails the sources so it links on GNU ld.
+cc() { local out="$1"; shift
+  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+    -I"$CREF" -I"$CREF/Compression" \
+    "$CREF/rust/difftest/bsc_lzp_enc_ref.cpp" "$CREF/rust/difftest/bsc_ccodec.cpp" \
+    "$CREF/Compression/BSC/libbsc/bwt/libsais/libsais.c" "$@" -o "$out"; }
+cc "$W/c"                    || exit 1
+cc "$W/rs" -DUSE_RUST "$LIB" || exit 1
+
+# LZP finds repeats an order-4 context predicts, so the corpus is built around
+# what makes and breaks that prediction: long exact repeats, near-repeats that
+# match then diverge (the heuristic's reason to exist), matches longer than 254
+# (the length continuation), literal 0xF2 bytes (the escape), and data with no
+# repeats at all (every position a literal, and the whole block incompressible).
+python3 - "$W/in" <<'PY'
+import os,sys
+d=sys.argv[1]; os.makedirs(d,exist_ok=True)
+def prng(seed,n):
+    s=seed; o=bytearray()
+    for _ in range(n): s=(s*1103515245+12345)&0xffffffff; o.append((s>>16)&0xff)
+    return bytes(o)
+w=lambda n,b: open(f"{d}/{n}","wb").write(b)
+
+w("text",     b"the quick brown fox jumps over the lazy dog. "*4000)
+w("runs",     b"".join(bytes([i%251])*300 for i in range(600)))
+w("noise",    prng(7, 300000))
+w("zeros",    b"\x00"*200000)
+# Near-repeats: a long block repeated with one byte changed each time, so a
+# match starts, runs, and dies. This is what the `heuristic` short-circuit is
+# for, and a corpus of exact repeats never reaches it.
+base = prng(11, 4096)
+w("near",     b"".join(base[:i%4000] + bytes([(i*7)&0xff]) + base[i%4000:] for i in range(80)))
+# Matches far longer than 254, so the length continuation bytes are emitted.
+w("longmatch", (b"A"*100000 + prng(3, 64)) * 3)
+# Literal flag bytes (0xF2) in otherwise compressible data: each must be escaped.
+w("flagbyte", bytes(0xF2 if i % 13 == 0 else (i*5) & 0xff for i in range(150000)))
+# Text with the flag byte sprinkled in, so escapes land INSIDE matches too.
+w("flagtext", (b"lorem ipsum dolor \xf2 sit amet "*6000))
+for n in (0,1,32,33,64,4096,65536,65537):
+    w(f"n_{n}", (b"abcdefgh"*20000)[:n])
+PY
+
+fail=0; tested=0; ncmp=0; outstanding=0; outstanding_names=""
+
+# The C picks a different encoder body per (hashSize, minLen) -- six of them,
+# and they emit different bytes (see bsc/lzp_enc.rs). PORTED lists the pairs
+# whose body the Rust implements; those must be byte-identical or this fails.
+# Everything else is reported and counted, because a mismatch there is expected
+# work rather than a regression -- but it is never silent, and the assertion at
+# the bottom refuses to let the ported set quietly shrink.
+#
+#   15:72  encode_large_fast_path  <- DArc's DEFAULT, every ordinary -mbsc block
+#   18:*   encode_generic          <- hashSize >= 18 leaves the specialised chain
+#   23:*   encode_generic
+PORTED="15:72 18:4 18:8 18:16 18:32 18:64 18:72 23:4 23:8 23:16 23:32 23:64 23:72"
+
+is_ported() {
+  case " $PORTED " in *" $1:$2 "*) return 0;; esac
+  return 1
+}
+
+for hash in 12 15 16 17 18 23; do
+  for minlen in 4 8 16 32 64 72; do
+    for f in "$W"/in/*; do
+      bn=$(basename "$f"); tag="[h$hash:l$minlen] $bn"
+      "$W/c"  "$hash" "$minlen" < "$f" >| "$W/oc" 2>/dev/null \
+        || { echo "  $tag: C driver failed"; fail=$((fail+1)); continue; }
+      "$W/rs" "$hash" "$minlen" < "$f" >| "$W/or" 2>/dev/null \
+        || { echo "  $tag: Rust driver failed"; fail=$((fail+1)); continue; }
+      tested=$((tested+1))
+      # The 4-byte prefix is the result code, so this compares outcome and bytes
+      # in one go.
+      if cmp -s "$W/oc" "$W/or"; then
+        ncmp=$((ncmp+1))
+      elif is_ported "$hash" "$minlen"; then
+        echo "  $tag: differs from the C -- this body IS ported, so it is a bug"
+        fail=$((fail+1))
+      else
+        outstanding=$((outstanding+1))
+        case " $outstanding_names " in
+          *" h$hash:l$minlen "*) ;;
+          *) outstanding_names="$outstanding_names h$hash:l$minlen" ;;
+        esac
+      fi
+    done
+  done
+done
+
+# Coverage, asserted rather than assumed. A run where every input came back
+# "not compressible" would compare nothing but error codes and still be green.
+coded=0
+for hash in 15 23; do
+  for f in "$W"/in/text "$W"/in/runs "$W"/in/longmatch; do
+    "$W/c" "$hash" 72 < "$f" >| "$W/oc" 2>/dev/null || continue
+    rc=$(python3 -c "import sys;d=open(sys.argv[1],'rb').read()[:4];print(int.from_bytes(d,'little',signed=True))" "$W/oc")
+    [ "$rc" -gt 0 ] && coded=$((coded+1))
+  done
+done
+
+# The defaults must be in the ported set and must pass. If that ever stops being
+# true, every -mbsc archive changes, so it is checked by name rather than left
+# to the loop above.
+is_ported 15 72 || { echo "the DEFAULT parameters (15,72) are no longer in PORTED"; fail=$((fail+1)); }
+
+[ "$tested" -gt 0 ] || { echo "no inputs were encoded -- the harness reached nothing"; exit 1; }
+[ "$coded" -ge 4 ] || {
+  echo "only $coded of 6 compressible cases actually produced LZP output;"
+  echo "the corpus is not exercising the match finder"; fail=$((fail+1)); }
+[ "$fail" -eq 0 ] || { echo "bsc-lzp-encode: $fail failures"; exit 1; }
+
+echo "bsc-lzp-encode: $ncmp/$tested byte-identical to the C"
+if [ "$outstanding" -gt 0 ]; then
+  echo "bsc-lzp-encode: $outstanding comparisons differ in bodies not ported yet:$outstanding_names"
+  echo "                (encode_small / small2x / medium / large -- see bsc/lzp_enc.rs)"
+fi

--- a/rust/difftest/bsc_ccodec.cpp
+++ b/rust/difftest/bsc_ccodec.cpp
@@ -53,6 +53,13 @@ int darc_bsc_st_encode (unsigned char *T, int n, int k, int features)
 int darc_bsc_st_decode (unsigned char *T, int n, int k, int index, int features)
 { return bsc_st_decode(T, n, k, index, features); }
 
+/* Forward LZP, for the LZP-ENCODER differential harness. This is the first
+ * encoder-side cut into BSC: LZP is the compressor's first stage and depends on
+ * neither the block sorter nor the entropy coder, so a mismatch here points at
+ * the match finder alone. */
+int darc_bsc_lzp_compress (const unsigned char *in, unsigned char *out, int n, int hashSize, int minLen, int features)
+{ return bsc_lzp_compress(in, out, n, hashSize, minLen, features); }
+
 /* The whole codec, for the end-to-end differential harness: bsc_compress builds
  * a real framed block (header + entropy + block-sort + optional LZP), and the C
  * and Rust dispatchers both invert it. */

--- a/rust/difftest/bsc_lzp_enc_ref.cpp
+++ b/rust/difftest/bsc_lzp_enc_ref.cpp
@@ -1,0 +1,79 @@
+/* Reference driver for differential-testing the BSC LZP ENCODER.
+ *
+ *     bsc_lzp_enc_ref HASH MINLEN  <in >out
+ *
+ * Built twice from the same source: plain it drives the C `bsc_lzp_compress`,
+ * and under -DUSE_RUST the Rust `darc_rs_bsc_lzp_compress`. Byte-for-byte
+ * equality of the two outputs is the bar -- LZP produces the bytes the block
+ * sorter and the entropy coder then consume, so a "valid but different"
+ * encoding would silently change every -mbsc archive.
+ *
+ * stdout is the result code as a 4-byte little-endian int followed by the
+ * payload, and the process exits 0 either way. A single `cmp` of the two
+ * stdouts therefore covers the outcome as well as the bytes: one side
+ * declaring an input incompressible while the other encodes it differs here
+ * just as loudly as a wrong byte, which a driver that wrote nothing on failure
+ * would have hidden behind two empty files.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern "C" {
+int darc_bsc_init (int features);
+int darc_bsc_lzp_compress (const unsigned char *in, unsigned char *out, int n, int hashSize, int minLen, int features);
+#ifdef USE_RUST
+int darc_rs_bsc_lzp_compress (const unsigned char *in, int inSize, unsigned char *out, int outCap, int hashSize, int minLen);
+#endif
+}
+
+static unsigned char *slurp (size_t *outLen) {
+  size_t cap = 1 << 20, len = 0;
+  unsigned char *b = (unsigned char *)malloc(cap);
+  if (!b) exit(3);
+  for (;;) {
+    if (len == cap) { cap *= 2; b = (unsigned char *)realloc(b, cap); if (!b) exit(3); }
+    size_t n = fread(b + len, 1, cap - len, stdin);
+    if (n == 0) break;
+    len += n;
+  }
+  *outLen = len;
+  return b;
+}
+
+static void emit (int rc, const unsigned char *payload, size_t len) {
+  unsigned char hdr[4] = { (unsigned char)( (unsigned)rc        & 0xff),
+                           (unsigned char)(((unsigned)rc >>  8) & 0xff),
+                           (unsigned char)(((unsigned)rc >> 16) & 0xff),
+                           (unsigned char)(((unsigned)rc >> 24) & 0xff) };
+  fwrite (hdr, 1, 4, stdout);
+  if (len) fwrite (payload, 1, len, stdout);
+}
+
+int main (int argc, char **argv) {
+  if (argc < 3) { fprintf(stderr, "usage: %s HASH MINLEN\n", argv[0]); return 2; }
+  int hashSize = atoi(argv[1]);
+  int minLen   = atoi(argv[2]);
+
+  darc_bsc_init(0);
+
+  size_t len = 0;
+  unsigned char *in = slurp(&len);
+  int n = (int)len;
+
+  /* bsc_lzp_compress_serial writes into a buffer of exactly n bytes and treats
+   * running out as "not compressible", so the sizes must match on both sides or
+   * the comparison is between two different problems. */
+  unsigned char *out = (unsigned char *)malloc(n > 0 ? n : 1);
+  if (!out) { free(in); return 3; }
+
+#ifdef USE_RUST
+  int rc = darc_rs_bsc_lzp_compress (in, n, out, n, hashSize, minLen);
+#else
+  int rc = darc_bsc_lzp_compress (in, out, n, hashSize, minLen, 0);
+#endif
+
+  emit (rc, out, rc > 0 ? (size_t)rc : 0);
+  free(in); free(out);
+  return 0;
+}


### PR DESCRIPTION
First encoder-side cut into BSC. The decoder has been merged for a while; the encoder is what still blocks deleting `Compression/BSC` (~17k lines of C). This lands LZP, the compressor's first stage, **complete and byte-identical at every parameter DArc can select**.

## libbsc's LZP encoder is six algorithms, not one

`bsc_lzp_encode_block` (`lzp.cpp:679`) picks a body from `(hashSize, minLen)` — five width-specialised ones behind `x86_64 || AArch64 && !NO_UNALIGNED_ACCESS && hashSize <= 17`, and `bsc_lzp_encode_generic` otherwise. It reads like one algorithm with fast paths. **It isn't.** The generic body walks a match four bytes at a time then adds a two-byte and a one-byte tail comparison; the unrolled ones walk it eight at a time and use `bit_scan_forward64(m) / 8` to land on the exact mismatching byte. Different lengths, different output.

Measured, not reasoned about: a generic-only port is byte-identical at `hashSize >= 18` and three bytes shorter below. Building the C reference a second time with `-DLIBBSC_NO_UNALIGNED_ACCESS` — which compiles the specialisations out — makes it match at **every** parameter. One run establishes both that the generic port is right and that the specialisations diverge; comparing against only the default C build would have shown a mismatch with no way to tell which side was wrong.

**Consequence that outlives this port: a `-mbsc` archive's bytes depend on the build target.** x86-64 and AArch64 take the specialised paths, i386 and 32-bit ARM the generic one. Both decode, which is why it has never surfaced.

## The four unrolled bodies are one function

They share a skeleton and differ in exactly four places:

| body | end slack | second probe | `len` from | `len -=` | heuristic |
|---|---|---|---|---|---|
| `small<T>` | `T` | none | `T` | `T` | no |
| `small2x<T>` | `2T` | `T` | `2T` | `2T` | no |
| `medium<T>` | `2T` | `minLen - T` | `minLen` | `minLen` | no |
| `large<u64>` | `minLen` | `minLen - 8` | `8` | `minLen` | **yes** |

Found by diffing them against each other, not by reading: each is ~100 lines of goto-threaded code with four unrolled positions and eight labels, and three of the four differences are a single token. `encode_large_fast_path` turned out to be `encode_large<u64>` with the default constants folded in — textually identical once substituted. They are one parameterised function here, because four transcriptions of the same hundred lines is four chances to mistype a shift.

The C's dispatch order is preserved: its chain is `result = (cond && result == NOT_ENOUGH_MEMORY) ? f(...) : result`, so the **first** matching condition wins — which is why `minLen` 4 and 8 reach `small` rather than the `minLen <= 8` `medium` arm below them.

Also ported: `bsc_lzp_compress_serial` and `bsc_lzp_num_blocks`. The parallel variant is inside `#ifdef LIBBSC_OPENMP` and DArc never defines `LIBBSC_OPENMP_SUPPORT`, so it is unreachable; both split the input identically regardless.

## The harness

`bsc-lzp-encode-check.sh` compares **576 (parameter, input) pairs** byte for byte, with the result code carried in the output so one side refusing an input differs as loudly as a wrong byte. **576/576 match.** The corpus targets what makes and breaks an order-4 prediction: exact repeats, near-repeats that match then diverge (the `heuristic` short-circuit), matches past 254 (the length continuation), literal `0xF2` bytes (the escape), and noise that compresses to nothing. Now wired into CI.

One bug it found immediately: a 1-byte input panicked, because the C's `output + 1 .. output + n - 1` window is inverted for `n < 2` and it never notices — `bsc_lzp_encode_block`'s own length check returns first. Slicing that in Rust aborts, so the same answer is given earlier instead.

## Verified

30 BSC unit tests pass, and `bsc-check`, `bsc-bwt-check`, `bsc-st-check` and `bsc-full-check` all still pass — nothing on the decode side moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)