### PR TITLE
BSC: port the QLFC forward transform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -853,6 +853,10 @@ jobs:
         # pairs, covering all six of the C's encoder bodies -- they emit
         # DIFFERENT bytes from each other, so the grid is not redundant.
         rust/difftest/bsc-lzp-encode-check.sh
+        # The QLFC forward transform: the stage all three encode bodies share.
+        # Compares the rank array AND the MTF table, since the table is an
+        # output that becomes the block's preamble.
+        rust/difftest/bsc-qlfc-transform-check.sh
         # LZ4-HC is the one ENCODER-side harness: it requires the Rust encoder
         # to be byte-identical to the C for every level DArc can select (1-9),
         # and decodes each block with the C decoder rather than lz4_flex.

--- a/rust/darc-codecs/src/bsc/mod.rs
+++ b/rust/darc-codecs/src/bsc/mod.rs
@@ -53,6 +53,7 @@ pub mod model;
 pub mod model_consts;
 pub mod predictor;
 pub mod qlfc;
+pub mod qlfc_enc;
 pub mod rangecoder;
 pub mod st;
 pub mod tables;

--- a/rust/darc-codecs/src/bsc/qlfc_enc.rs
+++ b/rust/darc-codecs/src/bsc/qlfc_enc.rs
@@ -1,0 +1,208 @@
+//! The QLFC forward transform and the coder's block segmentation, ported from
+//! `Compression/BSC/libbsc/coder/qlfc/qlfc.cpp` and `coder/coder.cpp`.
+//!
+//! The three encode bodies that consume this -- static, adaptive and fast --
+//! are still C; this is the stage beneath them, and the one they all share.
+//!
+//! ## Only one transform needs porting, and it is the scalar one
+//!
+//! `qlfc.cpp` carries two `QLFC_TRANSFORM_FUNCTION_NAME` bodies: a SIMD one
+//! (:205, for SSE2/AVX/AVX512/A64) and a scalar `#else` fallback (:469). After
+//! LZP -- where six encoder bodies turned out to emit *different* bytes -- the
+//! obvious question was whether these diverge too.
+//!
+//! They do not. Building the pinned C twice, once as-is and once with
+//! `-DLIBBSC_CPU_FEATURE=0` to force the scalar path, and encoding the same
+//! corpus gives byte-identical output: 15/15 across all three coders and five
+//! input shapes. So this ports the scalar body, which is the same function
+//! written legibly.
+//!
+//! The reason the two cases differ is worth keeping in mind rather than
+//! generalising from: this transform computes a **rank**, which the input
+//! determines, while LZP's encoder makes a **choice**, which it does not.
+//!
+//! ## What the transform produces
+//!
+//! Walking the input backwards, each *run* of equal bytes contributes one
+//! entry: the byte's rank in a move-to-front table, except the first time a
+//! byte is ever seen, where the rank is replaced by a running count of distinct
+//! symbols. Entries are filled from the end of `buffer` downwards, so the
+//! return value is where they start. `MTFTable` is left holding the alphabet in
+//! last-seen order, which the encoder then codes as the block's preamble.
+
+use super::model::ALPHABET_SIZE;
+
+/// `bsc_qlfc_transform` (:469). Returns the offset into `buffer` at which the
+/// rank array begins; entries run from there to `buffer[n]`.
+///
+/// `mtf_table` is written, not read -- it is an output as much as `buffer` is.
+pub fn transform(input: &[u8], buffer: &mut [u8], mtf_table: &mut [u8; ALPHABET_SIZE]) -> usize {
+    let n = input.len();
+    let mut flag = [0u8; ALPHABET_SIZE];
+
+    for (i, e) in mtf_table.iter_mut().enumerate() {
+        *e = i as u8;
+    }
+
+    // The one special case: a block ending in 0 starts the table with 1 ahead
+    // of 0, so the final run does not code as rank 0.
+    if input[n - 1] == 0 {
+        mtf_table[0] = 1;
+        mtf_table[1] = 0;
+    }
+
+    let mut index = n;
+    // `int nSymbols` in the C, not a byte. It reaches 256 on a block using the
+    // whole alphabet, and only the ASSIGNMENT to `rank` truncates. Typed as u8
+    // here it overflowed -- caught by the differential harness on the
+    // full-alphabet input, and by this crate building with overflow-checks on.
+    let mut n_symbols: i32 = 0;
+    let mut i = n as isize - 1;
+
+    while i >= 0 {
+        let current_char = input[i as usize];
+        i -= 1;
+        // Skip the rest of this run: one entry is emitted per run, not per byte.
+        while i >= 0 && input[i as usize] == current_char {
+            i -= 1;
+        }
+
+        // Move-to-front, unrolled four at a time in the C. The unrolling is not
+        // cosmetic to reproduce -- it is just a shift of the same chain -- but
+        // the *shape* is kept so the rank arithmetic lines up with the source.
+        let mut previous_char = mtf_table[0];
+        let mut rank: usize = 1;
+        mtf_table[0] = current_char;
+        loop {
+            let t0 = mtf_table[rank];
+            mtf_table[rank] = previous_char;
+            if t0 == current_char {
+                break;
+            }
+            let t1 = mtf_table[rank + 1];
+            mtf_table[rank + 1] = t0;
+            if t1 == current_char {
+                rank += 1;
+                break;
+            }
+            let t2 = mtf_table[rank + 2];
+            mtf_table[rank + 2] = t1;
+            if t2 == current_char {
+                rank += 2;
+                break;
+            }
+            let t3 = mtf_table[rank + 3];
+            mtf_table[rank + 3] = t2;
+            if t3 == current_char {
+                rank += 3;
+                break;
+            }
+            rank += 4;
+            previous_char = t3;
+        }
+
+        // First sighting of this byte: its "rank" is instead the number of
+        // distinct symbols seen so far, which is what lets the decoder rebuild
+        // the alphabet from the preamble.
+        let mut rank = rank as u8;
+        if flag[current_char as usize] == 0 {
+            flag[current_char as usize] = 1;
+            rank = n_symbols as u8;
+            n_symbols += 1;
+        }
+
+        index -= 1;
+        buffer[index] = rank;
+    }
+
+    buffer[n - 1] = 1;
+
+    // Collapse the first still-unused entry onto its predecessor. That repeat
+    // is what terminates the decoder's preamble loop and sets its maxRank.
+    for rank in 1..ALPHABET_SIZE {
+        if flag[mtf_table[rank] as usize] == 0 {
+            mtf_table[rank] = mtf_table[rank - 1];
+            break;
+        }
+    }
+
+    index
+}
+
+/// `bsc_coder_num_blocks` (`coder.cpp:52`). The same table as LZP's
+/// `bsc_lzp_num_blocks`, spelled separately in the C.
+pub fn num_blocks(n: usize) -> usize {
+    const BREAK_POINTS: [(usize, usize); 12] = [
+        (128, 128 * 128 * 65536),
+        (96, 96 * 96 * 65536),
+        (64, 64 * 64 * 65536),
+        (48, 48 * 48 * 65536),
+        (32, 32 * 32 * 65536),
+        (24, 24 * 24 * 65536),
+        (16, 16 * 16 * 65536),
+        (12, 12 * 12 * 65536),
+        (8, 8 * 8 * 65536),
+        (6, 6 * 6 * 65536),
+        (4, 4 * 4 * 65536),
+        (2, 2 * 2 * 65536),
+    ];
+    for (blocks, threshold) in BREAK_POINTS {
+        if n >= threshold {
+            return blocks;
+        }
+    }
+    1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run(input: &[u8]) -> (usize, Vec<u8>, [u8; ALPHABET_SIZE]) {
+        let mut buffer = vec![0u8; input.len()];
+        let mut mtf = [0u8; ALPHABET_SIZE];
+        let idx = transform(input, &mut buffer, &mut mtf);
+        (idx, buffer, mtf)
+    }
+
+    #[test]
+    fn one_entry_per_run_not_per_byte() {
+        // Three runs -> three entries, however long the runs are.
+        let input = b"aaaaabbbbbccccc";
+        let (idx, _, _) = run(input);
+        assert_eq!(input.len() - idx, 3);
+    }
+
+    #[test]
+    fn first_sighting_uses_the_symbol_count() {
+        // Walking backwards, 'c' is seen first and gets 0, then 'b' gets 1,
+        // then 'a' gets 2 -- the running count, not an MTF rank.
+        //
+        // The last entry then reads 1, not 0: `buffer[n - 1] = 1` runs after
+        // the walk and overwrites it unconditionally. That slot belongs to the
+        // run the decoder starts from, whose rank it already knows, so the C
+        // spends it on a constant. Worth a test of its own, because a port that
+        // dropped that line would still round-trip everything else.
+        let input = b"abc";
+        let (idx, buffer, _) = run(input);
+        assert_eq!(&buffer[idx..], &[2, 1, 1]);
+    }
+
+    #[test]
+    fn a_block_ending_in_zero_reorders_the_table() {
+        // input[n-1] == 0 swaps the first two table entries before the walk.
+        let with_zero = [1u8, 2, 0];
+        let (_, _, mtf) = run(&with_zero);
+        // 0 was seen last going backwards, so it leads the table either way;
+        // the point is that the special case does not corrupt the alphabet.
+        assert_eq!(mtf[0], 1);
+    }
+
+    #[test]
+    fn block_count_matches_the_c_table() {
+        assert_eq!(num_blocks(0), 1);
+        assert_eq!(num_blocks(2 * 2 * 65536 - 1), 1);
+        assert_eq!(num_blocks(2 * 2 * 65536), 2);
+        assert_eq!(num_blocks(128 * 128 * 65536), 128);
+    }
+}

--- a/rust/darc-codecs/src/exports.rs
+++ b/rust/darc-codecs/src/exports.rs
@@ -699,6 +699,31 @@ pub unsafe extern "C" fn darc_rs_bsc_decompress_block(
     bsc::dispatch::decompress(inp, out)
 }
 
+/// `bsc_qlfc_transform`: the QLFC forward transform. Writes the rank array into
+/// the tail of `buffer` and the alphabet into `mtf` (256 bytes), returning the
+/// offset in `buffer` where the ranks begin.
+///
+/// Exported for the differential harness ahead of the QLFC encode bodies;
+/// nothing in the archiver calls it yet.
+///
+/// # Safety
+/// `input` and `buffer` must be valid for `n` bytes, `mtf` for 256.
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_bsc_qlfc_transform(
+    input: *const u8,
+    n: c_int,
+    buffer: *mut u8,
+    mtf: *mut u8,
+) -> c_int {
+    if input.is_null() || buffer.is_null() || mtf.is_null() || n <= 0 {
+        return FREEARC_ERRCODE_GENERAL;
+    }
+    let inp = core::slice::from_raw_parts(input, n as usize);
+    let buf = core::slice::from_raw_parts_mut(buffer, n as usize);
+    let mtf = &mut *(mtf as *mut [u8; 256]);
+    bsc::qlfc_enc::transform(inp, buf, mtf) as c_int
+}
+
 /// `bsc_lzp_compress`: LZP-encode `input` into `output`. Returns the number of
 /// bytes written, or a negative libbsc code -- `LIBBSC_NOT_COMPRESSIBLE` (-3)
 /// when the input does not shrink, which the caller answers by skipping LZP.

--- a/rust/difftest/bsc-qlfc-transform-check.sh
+++ b/rust/difftest/bsc-qlfc-transform-check.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Differential-test the QLFC forward transform against the C original.
+#
+# The transform is the stage all three QLFC encode bodies (static, adaptive,
+# fast) share: it turns a block into a rank array plus the alphabet the encoder
+# codes as its preamble. Cutting here means a mismatch points at the
+# move-to-front walk rather than at the range coder wrapped around it -- the
+# same ordering the QLFC *decoders* were built in.
+#
+# BOTH outputs are compared. `MTFTable` is an output of this function, not a
+# scratch buffer, and a port producing the right ranks from a wrong table would
+# go on to write a preamble no decoder could follow.
+#
+# On the SIMD question: qlfc.cpp has two transform bodies, a vectorised one and
+# a scalar `#else`. Unlike LZP's six encoder bodies -- which emit different
+# bytes -- these agree: building the C twice, once with -DLIBBSC_CPU_FEATURE=0,
+# gives byte-identical encoder output over the corpus. So the port implements
+# the scalar body and this harness compares it against whichever the host picks.
+#
+# The C reference comes from a pinned revision, not the working tree -- see
+# c-reference.sh for why.
+set -uo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$ROOT/rust/difftest/c-reference.sh"
+CREF="$(darc_c_reference "$ROOT")" || exit 1
+W="${TMPDIR:-/tmp}/bsc-qlfc-tr.$$"; mkdir -p "$W"
+trap 'rm -rf "$W"' EXIT
+
+( cd "$ROOT/rust" && cargo build --release -p darc-codecs ) >/dev/null 2>&1 \
+  || { echo "cargo build failed" >&2; exit 1; }
+LIB="$ROOT/rust/target/release/libdarc_codecs.a"
+
+cc() { local out="$1"; shift
+  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+    -I"$CREF" -I"$CREF/Compression" \
+    "$CREF/rust/difftest/bsc_qlfc_transform_ref.cpp" "$CREF/rust/difftest/bsc_ccodec.cpp" \
+    "$CREF/Compression/BSC/libbsc/bwt/libsais/libsais.c" "$@" -o "$out"; }
+cc "$W/c"                    || exit 1
+cc "$W/rs" -DUSE_RUST "$LIB" || exit 1
+
+# The transform is driven by the RUN structure and the order in which symbols
+# are first seen, walking backwards. So: long runs, single-symbol blocks, a full
+# alphabet, blocks ending in 0 (the one special case in the table setup), a
+# ranks-only-just-fit alphabet of 255 symbols, and BWT-like output, which is
+# what it actually sees in a real archive.
+python3 - "$W/in" <<'PY'
+import os,sys
+d=sys.argv[1]; os.makedirs(d,exist_ok=True)
+def prng(seed,n):
+    s=seed; o=bytearray()
+    for _ in range(n): s=(s*1103515245+12345)&0xffffffff; o.append((s>>16)&0xff)
+    return bytes(o)
+w=lambda n,b: open(f"{d}/{n}","wb").write(b)
+
+w("text",     b"the quick brown fox jumps over the lazy dog. "*3000)
+w("runs",     b"".join(bytes([i%251])*200 for i in range(500)))
+w("noise",    prng(7, 200000))
+w("zeros",    b"\x00"*100000)
+w("one_byte", b"Q"*50000)
+# The `input[n-1] == 0` special case, which reorders the table before the walk.
+w("ends_zero", prng(3, 60000)[:-1] + b"\x00")
+w("all_zero_runs", b"".join(b"\x00"*50 + bytes([i%255+1])*7 for i in range(2000)))
+# Every byte value present, and 255 of them (one short of the alphabet), since
+# the preamble's terminating repeat depends on an unused entry existing.
+w("full_alphabet", bytes(range(256))*400)
+w("alphabet_255",  bytes((i%255)+1 for i in range(120000)))
+# Sorted-ish data, which is the shape a block sorter actually hands over.
+w("bwt_like", bytes(sorted(prng(11, 150000))))
+for n in (1,2,3,4,17,255,256,257,65536):
+    w(f"n_{n}", (b"abracadabra"*10000)[:n])
+PY
+
+fail=0; tested=0
+for f in "$W"/in/*; do
+  bn=$(basename "$f")
+  "$W/c"  < "$f" >| "$W/oc" 2>/dev/null || { echo "  $bn: C driver failed";    fail=$((fail+1)); continue; }
+  "$W/rs" < "$f" >| "$W/or" 2>/dev/null || { echo "  $bn: Rust driver failed"; fail=$((fail+1)); continue; }
+  tested=$((tested+1))
+  cmp -s "$W/oc" "$W/or" || { echo "  $bn: transform output differs from the C"; fail=$((fail+1)); }
+done
+
+# Coverage: a transform that returned `index == n` for everything would emit no
+# ranks at all and still compare equal on both sides. Require the corpus to
+# actually produce rank arrays.
+nonempty=0
+for f in "$W"/in/text "$W"/in/runs "$W"/in/bwt_like; do
+  "$W/c" < "$f" >| "$W/oc" 2>/dev/null || continue
+  sz=$(wc -c < "$W/oc")
+  [ "$sz" -gt 260 ] && nonempty=$((nonempty+1))
+done
+
+[ "$tested" -gt 0 ] || { echo "no inputs were transformed -- the harness reached nothing"; exit 1; }
+[ "$nonempty" -ge 3 ] || {
+  echo "only $nonempty of 3 inputs produced a rank array; the corpus is not exercising the walk"
+  fail=$((fail+1)); }
+[ "$fail" -eq 0 ] || { echo "bsc-qlfc-transform: $fail failures"; exit 1; }
+echo "bsc-qlfc-transform: $tested/$tested byte-identical to the C (ranks and MTF table)"

--- a/rust/difftest/bsc_ccodec.cpp
+++ b/rust/difftest/bsc_ccodec.cpp
@@ -53,6 +53,17 @@ int darc_bsc_st_encode (unsigned char *T, int n, int k, int features)
 int darc_bsc_st_decode (unsigned char *T, int n, int k, int index, int features)
 { return bsc_st_decode(T, n, k, index, features); }
 
+/* The QLFC forward transform, for the transform differential harness. This is
+ * the stage all three encode bodies share, and it is cut out on its own for the
+ * same reason the QLFC decoders were: a mismatch here points at the MTF walk
+ * rather than at the range coder wrapped around it.
+ *
+ * qlfc.cpp is included above, so bsc_qlfc_transform is already declared -- and
+ * with C++ linkage, so re-declaring it inside this extern "C" block is an
+ * error rather than a redundancy. */
+int darc_bsc_qlfc_transform (const unsigned char *in, int n, unsigned char *buffer, unsigned char *mtf)
+{ return (int)(bsc_qlfc_transform(in, buffer, n, mtf) - buffer); }
+
 /* Forward LZP, for the LZP-ENCODER differential harness. This is the first
  * encoder-side cut into BSC: LZP is the compressor's first stage and depends on
  * neither the block sorter nor the entropy coder, so a mismatch here points at

--- a/rust/difftest/bsc_qlfc_transform_ref.cpp
+++ b/rust/difftest/bsc_qlfc_transform_ref.cpp
@@ -1,0 +1,70 @@
+/* Reference driver for differential-testing the QLFC forward transform.
+ *
+ *     bsc_qlfc_transform_ref  <in >out
+ *
+ * Built twice: plain drives the C `bsc_qlfc_transform`, `-DUSE_RUST` the Rust
+ * port. The transform is the stage all three QLFC encode bodies share, so
+ * cutting here means a mismatch points at the move-to-front walk rather than at
+ * the range coder wrapped around it -- the same reason the QLFC *decoders* were
+ * tested at the coder level rather than through a whole block.
+ *
+ * stdout is:
+ *
+ *     int32  index          where the rank array starts within the buffer
+ *     uint8  mtf[256]       the alphabet the encoder codes as its preamble
+ *     uint8  ranks[n-index] the rank array itself
+ *
+ * Both outputs are compared, not just the ranks: `MTFTable` is an output of
+ * this function, and a port that produced the right ranks from a wrong table
+ * would go on to write a preamble no decoder could follow.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern "C" {
+int darc_bsc_init (int features);
+int darc_bsc_qlfc_transform (const unsigned char *in, int n, unsigned char *buffer, unsigned char *mtf);
+#ifdef USE_RUST
+int darc_rs_bsc_qlfc_transform (const unsigned char *in, int n, unsigned char *buffer, unsigned char *mtf);
+#endif
+}
+
+int main (void) {
+  darc_bsc_init(0);
+
+  size_t cap = 1 << 20, len = 0;
+  unsigned char *in = (unsigned char *)malloc(cap);
+  if (!in) return 3;
+  for (;;) {
+    if (len == cap) { cap *= 2; in = (unsigned char *)realloc(in, cap); if (!in) return 3; }
+    size_t n = fread(in + len, 1, cap - len, stdin);
+    if (n == 0) break;
+    len += n;
+  }
+  int n = (int)len;
+  if (n <= 0) { free(in); return 0; }
+
+  unsigned char *buffer = (unsigned char *)malloc(n);
+  unsigned char mtf[256];
+  if (!buffer) { free(in); return 3; }
+  memset(buffer, 0, n);
+  memset(mtf, 0, sizeof mtf);
+
+#ifdef USE_RUST
+  int index = darc_rs_bsc_qlfc_transform (in, n, buffer, mtf);
+#else
+  int index = darc_bsc_qlfc_transform (in, n, buffer, mtf);
+#endif
+
+  unsigned char hdr[4] = { (unsigned char)( (unsigned)index        & 0xff),
+                           (unsigned char)(((unsigned)index >>  8) & 0xff),
+                           (unsigned char)(((unsigned)index >> 16) & 0xff),
+                           (unsigned char)(((unsigned)index >> 24) & 0xff) };
+  fwrite (hdr, 1, 4, stdout);
+  fwrite (mtf, 1, sizeof mtf, stdout);
+  if (index >= 0 && index < n) fwrite (buffer + index, 1, (size_t)(n - index), stdout);
+
+  free(in); free(buffer);
+  return 0;
+}


### PR DESCRIPTION
Next step in the BSC encoder port, after LZP (#86). This is the stage all three QLFC encode bodies share: it walks a block backwards emitting one move-to-front rank per **run** of equal bytes, and leaves behind the alphabet the encoder codes as the block's preamble.

## One transform to port, not two

`qlfc.cpp` carries a vectorised transform (`:205`) and a scalar `#else` (`:469`). After the LZP encoder — where six bodies emitted **different** bytes — the obvious worry was that these diverge too.

**They don't.** Building the pinned C twice, once with `-DLIBBSC_CPU_FEATURE=0` to force the scalar path, gives byte-identical encoder output over the corpus: 15/15 across all three coders and five input shapes. So this ports the scalar body, which is the same function written legibly.

The distinction worth carrying forward, rather than the precedent: this transform computes a **rank**, which the input determines; LZP's encoder makes a **choice**, which it doesn't. Cheap to check either way.

## What the harness found

`nSymbols` is `int` in the C, and only the *assignment* to `rank` truncates it to a byte. Typed as `u8` here it overflowed on a block using the whole alphabet — 256 distinct symbols, one past what a byte holds.

The unit tests did not catch it: a hand-written corpus reaches for `"abc"` and `"aaabbb"`, not all 256 values. The differential harness caught it on its first run. Second time in this port a **width** has been the bug — see also the directory reader's 4-vs-8-byte time field in #85.

## The harness

`bsc-qlfc-transform-check.sh`: **19 inputs, byte-identical on both outputs.** Comparing the MTF table matters — it's an output of this function, not a scratch buffer, and a port producing the right ranks from a wrong table would go on to write a preamble no decoder could follow.

Corpus built for what drives the walk: long runs, single-symbol blocks, a full 256-value alphabet, 255 values (one short, so an unused entry still exists for the preamble's terminating repeat), blocks ending in `0` (the one special case in the table setup), and sorted data — the shape a block sorter actually hands over.

Also ports `bsc_coder_num_blocks`, the same table as LZP's spelled separately in the C.

Still C: the three encode bodies themselves, and `bsc_coder_compress_serial`'s content-aware block splitter.

## Verified

34 BSC unit tests, and `bsc-check`, `bsc-full-check` and `bsc-lzp-encode-check` all still pass. Harness wired into CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)