### PR TITLE
BSC: port the QLFC static encoder and the range coder's encoder half

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -857,6 +857,10 @@ jobs:
         # Compares the rank array AND the MTF table, since the table is an
         # output that becomes the block's preamble.
         rust/difftest/bsc-qlfc-transform-check.sh
+        # The QLFC STATIC encoder -- LIBBSC_DEFAULT_CODER, so the body a default
+        # -mbsc block is entropy-coded by. Byte-identity against
+        # bsc_coder_encode_block; the adaptive and fast encoders are still C.
+        rust/difftest/bsc-qlfc-encode-check.sh
         # LZ4-HC is the one ENCODER-side harness: it requires the Rust encoder
         # to be byte-identical to the C for every level DArc can select (1-9),
         # and decodes each block with the C decoder rather than lz4_flex.

--- a/rust/darc-codecs/src/bsc/qlfc.rs
+++ b/rust/darc-codecs/src/bsc/qlfc.rs
@@ -51,7 +51,7 @@ use super::{
 /// `bsc_bit_scan_reverse(x)` = `clz(x) ^ 31`, i.e. the index of the highest set
 /// bit. Undefined for 0 in the C (`__builtin_clz(0)`); callers never pass 0.
 #[inline]
-fn bit_scan_reverse(x: u32) -> u32 {
+pub(super) fn bit_scan_reverse(x: u32) -> u32 {
     if x == 0 {
         0
     } else {
@@ -681,7 +681,7 @@ pub fn static_decode(input: &[u8], output: &mut [u8]) -> Result<usize, i32> {
 /// a detectable disagreement into wrong output. The arithmetic wraps like the
 /// C's `int`.
 #[inline]
-fn mix3(char_p: i32, state_p: i32, static_p: i32, lr0: i32, lr1: i32, lr2: i32) -> u32 {
+pub(super) fn mix3(char_p: i32, state_p: i32, static_p: i32, lr0: i32, lr1: i32, lr2: i32) -> u32 {
     (char_p
         .wrapping_mul(lr0)
         .wrapping_add(state_p.wrapping_mul(lr1))

--- a/rust/darc-codecs/src/bsc/qlfc_enc.rs
+++ b/rust/darc-codecs/src/bsc/qlfc_enc.rs
@@ -206,3 +206,303 @@ mod tests {
         assert_eq!(num_blocks(128 * 128 * 65536), 128);
     }
 }
+
+use super::model::{model_rank_state, model_run_state, QlfcModel1};
+use super::model_consts::*;
+use super::predictor::ProbabilityCounter;
+use super::qlfc::{bit_scan_reverse, mix3};
+use super::rangecoder::RangeEncoder;
+use super::LIBBSC_NOT_COMPRESSIBLE;
+
+/// `bsc_qlfc_static_encode` (`qlfc.cpp:900`), the mirror of
+/// [`super::qlfc::static_decode`] and the body reached by
+/// `LIBBSC_DEFAULT_CODER`.
+///
+/// Returns the coded length in bytes, or `LIBBSC_NOT_COMPRESSIBLE` when the
+/// block will not fit -- which the C decides by polling `CheckEOB` at the top
+/// of every run, not by checking afterwards.
+///
+/// The decoder is the specification for every model update here: each branch
+/// updates the same three predictors with the same thresholds, and a single
+/// transposed constant produces a stream that decodes for a while and then
+/// diverges. They are written in the same order as the C so the two can be read
+/// side by side.
+pub fn static_encode(input: &[u8], output: &mut [u8]) -> i32 {
+    let n = input.len();
+    if n == 0 {
+        return LIBBSC_NOT_COMPRESSIBLE;
+    }
+
+    let mut model = QlfcModel1::new();
+    let mut buffer = vec![0u8; n];
+    let mut mtf = [0u8; ALPHABET_SIZE];
+
+    let mut context_rank0 = 0usize;
+    let mut context_rank4 = 0usize;
+    let mut context_run = 0usize;
+    let mut max_rank = 7i32;
+    let mut avg_rank = 0i32;
+
+    let mut rank_history = [0u8; ALPHABET_SIZE];
+    let mut run_history = [0u8; ALPHABET_SIZE];
+
+    let mut rank_ptr = transform(input, &mut buffer, &mut mtf);
+
+    let mut coder = RangeEncoder::new(output);
+    coder.encode_word(n as u32);
+
+    // --- Alphabet preamble --------------------------------------------------
+    // A bit is coded only where the prefix so far leaves both values reachable
+    // among the characters not yet used; everywhere else the decoder can infer
+    // it. Encoder and decoder must agree exactly on which those are, so the
+    // reachability scan is the same loop on both sides.
+    let mut used_char = [0u8; ALPHABET_SIZE];
+    let mut prev_char: i32 = -1;
+    for rank in 0..ALPHABET_SIZE {
+        let current_char = mtf[rank] as i32;
+
+        for bit in (0..8).rev() {
+            let (mut bit0, mut bit1) = (false, false);
+            for c in 0..ALPHABET_SIZE as i32 {
+                if c == prev_char || used_char[c as usize] == 0 {
+                    if (current_char >> (bit + 1)) == (c >> (bit + 1)) {
+                        if c & (1 << bit) != 0 {
+                            bit1 = true;
+                        } else {
+                            bit0 = true;
+                        }
+                        if bit0 && bit1 {
+                            break;
+                        }
+                    }
+                }
+            }
+            if bit0 && bit1 {
+                coder.encode_bit((current_char & (1 << bit)) as u32);
+            }
+        }
+
+        if current_char == prev_char {
+            max_rank = bit_scan_reverse(rank as u32 - 1) as i32;
+            break;
+        }
+        prev_char = current_char;
+        used_char[current_char as usize] = 1;
+    }
+
+    // --- Main loop: one (rank, run) pair per run of equal bytes --------------
+    let mut ip = 0usize;
+    while rank_ptr < n {
+        if coder.check_eob() {
+            return LIBBSC_NOT_COMPRESSIBLE;
+        }
+
+        let current_char = input[ip] as usize;
+        let run_start = ip;
+        ip += 1;
+        while ip < n && input[ip] as usize == current_char {
+            ip += 1;
+        }
+        let run_size = (ip - run_start) as i32;
+
+        let mut rank = buffer[rank_ptr] as i32;
+        rank_ptr += 1;
+
+        let history = rank_history[current_char] as usize;
+        let state = model_rank_state(context_rank4, context_run, history);
+
+        if avg_rank < 32 {
+            if rank == 1 {
+                rank_history[current_char] = 0;
+                let p = mix3(
+                    model.rank.char_model[current_char] as i32,
+                    model.rank.state_model[state] as i32,
+                    model.rank.static_model as i32,
+                    F_RANK_TM_LR0, F_RANK_TM_LR1, F_RANK_TM_LR2,
+                );
+                ProbabilityCounter::update_bit0(&mut model.rank.state_model[state], F_RANK_TS_TH0, F_RANK_TS_AR0);
+                ProbabilityCounter::update_bit0(&mut model.rank.char_model[current_char], F_RANK_TC_TH0, F_RANK_TC_AR0);
+                ProbabilityCounter::update_bit0(&mut model.rank.static_model, F_RANK_TP_TH0, F_RANK_TP_AR0);
+                coder.encode_bit0_p(p, 12);
+            } else {
+                let p = mix3(
+                    model.rank.char_model[current_char] as i32,
+                    model.rank.state_model[state] as i32,
+                    model.rank.static_model as i32,
+                    F_RANK_TM_LR0, F_RANK_TM_LR1, F_RANK_TM_LR2,
+                );
+                ProbabilityCounter::update_bit1(&mut model.rank.state_model[state], F_RANK_TS_TH1, F_RANK_TS_AR1);
+                ProbabilityCounter::update_bit1(&mut model.rank.char_model[current_char], F_RANK_TC_TH1, F_RANK_TC_AR1);
+                ProbabilityCounter::update_bit1(&mut model.rank.static_model, F_RANK_TP_TH1, F_RANK_TP_AR1);
+                coder.encode_bit1_p(p, 12);
+
+                let bit_rank_size = bit_scan_reverse(rank as u32) as usize;
+                rank_history[current_char] = bit_rank_size as u8;
+
+                // Exponent, unary: `bit_rank_size - 1` ones then, if it fits
+                // under maxRank, a terminating zero. `k` is the offset the C
+                // advances its three row pointers by in lockstep.
+                for k in 1..bit_rank_size {
+                    let p = mix3(
+                        model.rank.exponent.char_model[current_char][k - 1] as i32,
+                        model.rank.exponent.state_model[state][k - 1] as i32,
+                        model.rank.exponent.static_model[k - 1] as i32,
+                        F_RANK_EM_LR0, F_RANK_EM_LR1, F_RANK_EM_LR2,
+                    );
+                    ProbabilityCounter::update_bit1(&mut model.rank.exponent.state_model[state][k - 1], F_RANK_ES_TH1, F_RANK_ES_AR1);
+                    ProbabilityCounter::update_bit1(&mut model.rank.exponent.char_model[current_char][k - 1], F_RANK_EC_TH1, F_RANK_EC_AR1);
+                    ProbabilityCounter::update_bit1(&mut model.rank.exponent.static_model[k - 1], F_RANK_EP_TH1, F_RANK_EP_AR1);
+                    coder.encode_bit1_p(p, 12);
+                }
+                if (bit_rank_size as i32) < max_rank {
+                    let k = bit_rank_size - 1;
+                    let p = mix3(
+                        model.rank.exponent.char_model[current_char][k] as i32,
+                        model.rank.exponent.state_model[state][k] as i32,
+                        model.rank.exponent.static_model[k] as i32,
+                        F_RANK_EM_LR0, F_RANK_EM_LR1, F_RANK_EM_LR2,
+                    );
+                    ProbabilityCounter::update_bit0(&mut model.rank.exponent.state_model[state][k], F_RANK_ES_TH0, F_RANK_ES_AR0);
+                    ProbabilityCounter::update_bit0(&mut model.rank.exponent.char_model[current_char][k], F_RANK_EC_TH0, F_RANK_EC_AR0);
+                    ProbabilityCounter::update_bit0(&mut model.rank.exponent.static_model[k], F_RANK_EP_TH0, F_RANK_EP_AR0);
+                    coder.encode_bit0_p(p, 12);
+                }
+
+                // Mantissa: the remaining bits of rank, most significant first,
+                // with the context accumulating them.
+                let m = &mut model.rank.mantissa[bit_rank_size];
+                let mut context = 1usize;
+                for bit in (0..bit_rank_size).rev() {
+                    let p = mix3(
+                        m.char_model[current_char][context] as i32,
+                        m.state_model[state][context] as i32,
+                        m.static_model[context] as i32,
+                        F_RANK_MM_LR0, F_RANK_MM_LR1, F_RANK_MM_LR2,
+                    );
+                    let b = ((rank >> bit) & 1) as u32;
+                    ProbabilityCounter::update_bit(b, &mut m.state_model[state][context], F_RANK_MS_TH0, F_RANK_MS_AR0, F_RANK_MS_TH1, F_RANK_MS_AR1);
+                    ProbabilityCounter::update_bit(b, &mut m.char_model[current_char][context], F_RANK_MC_TH0, F_RANK_MC_AR0, F_RANK_MC_TH1, F_RANK_MC_AR1);
+                    ProbabilityCounter::update_bit(b, &mut m.static_model[context], F_RANK_MP_TH0, F_RANK_MP_AR0, F_RANK_MP_TH1, F_RANK_MP_AR1);
+                    context += context + b as usize;
+                    coder.encode_bit_p(b, p, 12);
+                }
+            }
+        } else {
+            // Escape path: a high running average rank codes the whole value
+            // against its own model instead of exponent + mantissa.
+            rank_history[current_char] = bit_scan_reverse(rank as u32) as u8;
+            let e = &mut model.rank.escape;
+            let mut context = 1usize;
+            for bit in (0..=max_rank).rev() {
+                let p = mix3(
+                    e.char_model[current_char][context] as i32,
+                    e.state_model[state][context] as i32,
+                    e.static_model[context] as i32,
+                    F_RANK_PM_LR0, F_RANK_PM_LR1, F_RANK_PM_LR2,
+                );
+                let b = ((rank >> bit) & 1) as u32;
+                ProbabilityCounter::update_bit(b, &mut e.state_model[state][context], F_RANK_PS_TH0, F_RANK_PS_AR0, F_RANK_PS_TH1, F_RANK_PS_AR1);
+                ProbabilityCounter::update_bit(b, &mut e.char_model[current_char][context], F_RANK_PC_TH0, F_RANK_PC_AR0, F_RANK_PC_TH1, F_RANK_PC_AR1);
+                ProbabilityCounter::update_bit(b, &mut e.static_model[context], F_RANK_PP_TH0, F_RANK_PP_AR0, F_RANK_PP_TH1, F_RANK_PP_AR1);
+                context += context + b as usize;
+                coder.encode_bit_p(b, p, 12);
+            }
+        }
+
+        avg_rank = (avg_rank * 124 + rank * 4) >> 7;
+        rank -= 1;
+
+        // --- Run length -----------------------------------------------------
+        let history = run_history[current_char] as usize;
+        let state = model_run_state(context_rank0, context_run, rank as usize, history);
+
+        if run_size == 1 {
+            run_history[current_char] = (run_history[current_char] + 2) >> 2;
+            let p = mix3(
+                model.run.char_model[current_char] as i32,
+                model.run.state_model[state] as i32,
+                model.run.static_model as i32,
+                F_RUN_TM_LR0, F_RUN_TM_LR1, F_RUN_TM_LR2,
+            );
+            ProbabilityCounter::update_bit0(&mut model.run.state_model[state], F_RUN_TS_TH0, F_RUN_TS_AR0);
+            ProbabilityCounter::update_bit0(&mut model.run.char_model[current_char], F_RUN_TC_TH0, F_RUN_TC_AR0);
+            ProbabilityCounter::update_bit0(&mut model.run.static_model, F_RUN_TP_TH0, F_RUN_TP_AR0);
+            coder.encode_bit0_p(p, 12);
+        } else {
+            let p = mix3(
+                model.run.char_model[current_char] as i32,
+                model.run.state_model[state] as i32,
+                model.run.static_model as i32,
+                F_RUN_TM_LR0, F_RUN_TM_LR1, F_RUN_TM_LR2,
+            );
+            ProbabilityCounter::update_bit1(&mut model.run.state_model[state], F_RUN_TS_TH1, F_RUN_TS_AR1);
+            ProbabilityCounter::update_bit1(&mut model.run.char_model[current_char], F_RUN_TC_TH1, F_RUN_TC_AR1);
+            ProbabilityCounter::update_bit1(&mut model.run.static_model, F_RUN_TP_TH1, F_RUN_TP_AR1);
+            coder.encode_bit1_p(p, 12);
+
+            let bit_run_size = bit_scan_reverse(run_size as u32) as usize;
+            run_history[current_char] =
+                ((run_history[current_char] as u32 + 3 * bit_run_size as u32 + 3) >> 2) as u8;
+
+            for k in 1..bit_run_size {
+                let p = mix3(
+                    model.run.exponent.char_model[current_char][k - 1] as i32,
+                    model.run.exponent.state_model[state][k - 1] as i32,
+                    model.run.exponent.static_model[k - 1] as i32,
+                    F_RUN_EM_LR0, F_RUN_EM_LR1, F_RUN_EM_LR2,
+                );
+                ProbabilityCounter::update_bit1(&mut model.run.exponent.state_model[state][k - 1], F_RUN_ES_TH1, F_RUN_ES_AR1);
+                ProbabilityCounter::update_bit1(&mut model.run.exponent.char_model[current_char][k - 1], F_RUN_EC_TH1, F_RUN_EC_AR1);
+                ProbabilityCounter::update_bit1(&mut model.run.exponent.static_model[k - 1], F_RUN_EP_TH1, F_RUN_EP_AR1);
+                coder.encode_bit1_p(p, 12);
+            }
+            {
+                // Unlike rank's exponent, run's terminating zero is
+                // unconditional -- there is no maxRank to run into.
+                let k = bit_run_size - 1;
+                let p = mix3(
+                    model.run.exponent.char_model[current_char][k] as i32,
+                    model.run.exponent.state_model[state][k] as i32,
+                    model.run.exponent.static_model[k] as i32,
+                    F_RUN_EM_LR0, F_RUN_EM_LR1, F_RUN_EM_LR2,
+                );
+                ProbabilityCounter::update_bit0(&mut model.run.exponent.state_model[state][k], F_RUN_ES_TH0, F_RUN_ES_AR0);
+                ProbabilityCounter::update_bit0(&mut model.run.exponent.char_model[current_char][k], F_RUN_EC_TH0, F_RUN_EC_AR0);
+                ProbabilityCounter::update_bit0(&mut model.run.exponent.static_model[k], F_RUN_EP_TH0, F_RUN_EP_AR0);
+                coder.encode_bit0_p(p, 12);
+            }
+
+            let m = &mut model.run.mantissa[bit_run_size];
+            let mut context = 1usize;
+            for bit in (0..bit_run_size).rev() {
+                let p = mix3(
+                    m.char_model[current_char][context] as i32,
+                    m.state_model[state][context] as i32,
+                    m.static_model[context] as i32,
+                    F_RUN_MM_LR0, F_RUN_MM_LR1, F_RUN_MM_LR2,
+                );
+                let b = ((run_size >> bit) & 1) as u32;
+                ProbabilityCounter::update_bit(b, &mut m.state_model[state][context], F_RUN_MS_TH0, F_RUN_MS_AR0, F_RUN_MS_TH1, F_RUN_MS_AR1);
+                ProbabilityCounter::update_bit(b, &mut m.char_model[current_char][context], F_RUN_MC_TH0, F_RUN_MC_AR0, F_RUN_MC_TH1, F_RUN_MC_AR1);
+                ProbabilityCounter::update_bit(b, &mut m.static_model[context], F_RUN_MP_TH0, F_RUN_MP_AR0, F_RUN_MP_TH1, F_RUN_MP_AR1);
+                // NOT a plain doubling: the context only accumulates the bit
+                // for short runs. `int ctx = context + context + b; context++;
+                // if (bitRunSize <= 5) { context = ctx; }` -- the decoder
+                // carries the same asymmetry, and getting it wrong desynchronises
+                // only on runs long enough to reach it.
+                let ctx = context + context + b as usize;
+                context += 1;
+                if bit_run_size <= 5 {
+                    context = ctx;
+                }
+                coder.encode_bit_p(b, p, 12);
+            }
+        }
+
+        context_rank0 = ((context_rank0 << 1) | usize::from(rank == 0)) & 0x7;
+        context_rank4 = ((context_rank4 << 2) | (rank.min(3) as usize)) & 0xff;
+        context_run = ((context_run << 1) | usize::from(run_size < 3)) & 0xf;
+    }
+
+    coder.finish() as i32
+}

--- a/rust/darc-codecs/src/bsc/rangecoder.rs
+++ b/rust/darc-codecs/src/bsc/rangecoder.rs
@@ -207,3 +207,199 @@ mod tests {
         }
     }
 }
+
+
+/// The encoder half of libbsc's `RangeCoder` (`coder/common/rangecoder.h:123`),
+/// the mirror of [`RangeDecoder`] above.
+///
+/// ## The `low`/`carry` union
+///
+/// The C keeps `low` as a union of a `unsigned long long` and a
+/// `{ low32, carry }` pair, so `ari.low += range` overflowing bit 31 lands in
+/// `carry` for the shift step to pick up. That aliasing is little-endian-only,
+/// which DArc is (`FREEARC_INTEL_BYTE_ORDER` is mandatory). Here `low` is a
+/// plain u64 and `carry` is read as `low >> 32`, which is the same value
+/// without depending on layout.
+///
+/// ## Output is 16 bits at a time
+///
+/// `OutputShort` writes a `unsigned short`, so the coded stream is a sequence
+/// of little-endian 16-bit words, not bytes -- and `CheckEOB` compares *short*
+/// pointers against `output + outputSize - 16`. Getting that unit wrong yields
+/// a stream that decodes for a while and then diverges.
+pub struct RangeEncoder<'a> {
+    out: &'a mut [u8],
+    /// Index in 16-bit units, matching the C's `unsigned short *`.
+    pos: usize,
+    eob: usize,
+    low: u64,
+    ffnum: u32,
+    cache: u32,
+    range: u32,
+}
+
+impl<'a> RangeEncoder<'a> {
+    /// `InitEncoder(output, outputSize)`.
+    pub fn new(out: &'a mut [u8]) -> Self {
+        // outputEOB = (unsigned short *)(output + outputSize - 16); a byte
+        // offset converted to a short index, and it may sit before the start
+        // for a very small buffer, which CheckEOB then reports immediately.
+        let eob = out.len().saturating_sub(16) / 2;
+        RangeEncoder { out, pos: 0, eob, low: 0, ffnum: 0, cache: 0, range: 0xffff_ffff }
+    }
+
+    /// `CheckEOB()`: the encoders poll this and give up with
+    /// `LIBBSC_NOT_COMPRESSIBLE` rather than overrun.
+    pub fn check_eob(&self) -> bool {
+        self.pos >= self.eob
+    }
+
+    fn output_short(&mut self, s: u16) {
+        let at = self.pos * 2;
+        if at + 2 <= self.out.len() {
+            self.out[at..at + 2].copy_from_slice(&s.to_le_bytes());
+        }
+        // Past the end the C would write anyway; the counter still advances so
+        // the returned length and CheckEOB agree with it. The bounds test above
+        // is the only divergence, and it only engages after the encoder has
+        // already decided the block does not fit.
+        self.pos += 1;
+    }
+
+    /// `ShiftLow()` and `ShiftLowSlow()`, which differ only in whether the fast
+    /// path applies; folded into one function with the same branch structure.
+    fn shift_low(&mut self) -> u32 {
+        let low32 = self.low as u32;
+        let carry = (self.low >> 32) as u32;
+
+        if self.ffnum == 0 && low32 < 0xffff_0000 {
+            self.output_short((self.cache.wrapping_add(carry)) as u16);
+            self.cache = low32 >> 16;
+            self.low = ((low32 << 16) as u64) & 0xffff_ffff; // clears carry
+            return self.range << 16;
+        }
+
+        // ShiftLowSlow
+        if low32 < 0xffff_0000 || carry != 0 {
+            self.output_short((self.cache.wrapping_add(carry)) as u16);
+            if self.ffnum != 0 {
+                let s = carry.wrapping_sub(1) as u16;
+                while self.ffnum != 0 {
+                    self.output_short(s);
+                    self.ffnum -= 1;
+                }
+            }
+            self.cache = low32 >> 16;
+            // ari.u.carry = 0, leaving low32 untouched until the shift below.
+            self.low &= 0xffff_ffff;
+        } else {
+            self.ffnum += 1;
+        }
+        // `ari.u.low32 <<= 16` -- the low half only; carry keeps whatever it
+        // holds, which the branch above may have just cleared.
+        let carry_now = self.low & 0xffff_ffff_0000_0000;
+        self.low = carry_now | (((low32 << 16) as u64) & 0xffff_ffff);
+
+        self.range << 16
+    }
+
+    /// `FinishEncoder()`: returns the coded length in BYTES.
+    pub fn finish(&mut self) -> usize {
+        if self.range < 0x10000 {
+            self.shift_low();
+        }
+        self.shift_low();
+        self.shift_low();
+        self.shift_low();
+        self.pos * 2
+    }
+
+    pub fn encode_bit0_p(&mut self, probability: u32, p: u32) {
+        if self.range < 0x10000 {
+            self.range = self.shift_low();
+        }
+        self.range = (self.range >> p) * probability;
+    }
+
+    pub fn encode_bit1_p(&mut self, probability: u32, p: u32) {
+        if self.range < 0x10000 {
+            self.range = self.shift_low();
+        }
+        let range = (self.range >> p) * probability;
+        self.low += range as u64;
+        self.range -= range;
+    }
+
+    /// `EncodeBit(bit, probability)`. The C writes it branchlessly with
+    /// `(~bit + 1u) & range`, which is `bit ? range : 0`; spelled as the
+    /// condition here since the masking is an optimisation, not semantics.
+    pub fn encode_bit_p(&mut self, bit: u32, probability: u32, p: u32) {
+        if bit != 0 {
+            self.encode_bit1_p(probability, p);
+        } else {
+            self.encode_bit0_p(probability, p);
+        }
+    }
+
+    /// `EncodeBit(bit)` with no model: probability 2048 at P = 12, i.e. even.
+    pub fn encode_bit(&mut self, bit: u32) {
+        self.encode_bit_p(bit, 2048, 12);
+    }
+
+    pub fn encode_byte(&mut self, byte: u32) {
+        for bit in (0..8).rev() {
+            self.encode_bit(byte & (1 << bit));
+        }
+    }
+
+    pub fn encode_word(&mut self, word: u32) {
+        for bit in (0..32).rev() {
+            self.encode_bit(word & (1 << bit));
+        }
+    }
+}
+
+#[cfg(test)]
+mod encoder_tests {
+    use super::*;
+
+    /// The encoder's only real obligation: the already-verified decoder must
+    /// read back what it wrote. Model-free bits and words only -- the modelled
+    /// paths are exercised by the QLFC harness, where the C is the oracle.
+    #[test]
+    fn round_trips_words_and_bits() {
+        let words = [0u32, 1, 0xffff_ffff, 12345, 0x8000_0000];
+        let bits = [1u32, 0, 1, 1, 0, 0, 0, 1, 1, 0];
+
+        let mut buf = vec![0u8; 4096];
+        let n = {
+            let mut e = RangeEncoder::new(&mut buf);
+            for w in words {
+                e.encode_word(w);
+            }
+            for b in bits {
+                e.encode_bit(b);
+            }
+            e.finish()
+        };
+        assert!(n > 0 && n <= buf.len());
+
+        let mut d = RangeDecoder::new(&buf);
+        for w in words {
+            assert_eq!(d.decode_word(), w, "word round-trip");
+        }
+        for b in bits {
+            assert_eq!(d.decode_bit(), b, "bit round-trip");
+        }
+    }
+
+    #[test]
+    fn reports_eob_before_overrunning_a_small_buffer() {
+        let mut buf = vec![0u8; 32];
+        let mut e = RangeEncoder::new(&mut buf);
+        for _ in 0..64 {
+            e.encode_word(0xdead_beef);
+        }
+        assert!(e.check_eob(), "a full buffer must report EOB");
+    }
+}

--- a/rust/darc-codecs/src/exports.rs
+++ b/rust/darc-codecs/src/exports.rs
@@ -699,6 +699,27 @@ pub unsafe extern "C" fn darc_rs_bsc_decompress_block(
     bsc::dispatch::decompress(inp, out)
 }
 
+/// `bsc_qlfc_static_encode_block`: entropy-code one block with the QLFC static
+/// coder. Returns the coded length, or a negative libbsc code --
+/// `LIBBSC_NOT_COMPRESSIBLE` (-3) when the block will not fit.
+///
+/// # Safety
+/// `input` must be valid for `in_size` bytes, `output` for `out_size`.
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_bsc_qlfc_static_encode(
+    input: *const u8,
+    in_size: c_int,
+    output: *mut u8,
+    out_size: c_int,
+) -> c_int {
+    if input.is_null() || output.is_null() || in_size <= 0 || out_size <= 0 {
+        return FREEARC_ERRCODE_GENERAL;
+    }
+    let inp = core::slice::from_raw_parts(input, in_size as usize);
+    let out = core::slice::from_raw_parts_mut(output, out_size as usize);
+    bsc::qlfc_enc::static_encode(inp, out)
+}
+
 /// `bsc_qlfc_transform`: the QLFC forward transform. Writes the rank array into
 /// the tail of `buffer` and the alphabet into `mtf` (256 bytes), returning the
 /// offset in `buffer` where the ranks begin.

--- a/rust/difftest/bsc-qlfc-encode-check.sh
+++ b/rust/difftest/bsc-qlfc-encode-check.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Differential-test the QLFC STATIC ENCODER against the C original.
+#
+# Byte-identity, not round-tripping: this produces the entropy-coded payload of
+# every -mbsc block, so an encoding that merely decodes correctly would still
+# change every archive. `bsc_coder_encode_block` is the oracle.
+#
+# The static coder is LIBBSC_DEFAULT_CODER, so this is the body a default -mbsc
+# archive goes through. The adaptive and fast encoders are still C; the Rust
+# driver exits 7 for them, and the harness reports that rather than passing
+# silently.
+#
+# The C reference comes from a pinned revision, not the working tree -- see
+# c-reference.sh for why.
+set -uo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$ROOT/rust/difftest/c-reference.sh"
+CREF="$(darc_c_reference "$ROOT")" || exit 1
+W="${TMPDIR:-/tmp}/bsc-qlfc-enc.$$"; mkdir -p "$W"
+trap 'rm -rf "$W"' EXIT
+
+( cd "$ROOT/rust" && cargo build --release -p darc-codecs ) >/dev/null 2>&1 \
+  || { echo "cargo build failed" >&2; exit 1; }
+LIB="$ROOT/rust/target/release/libdarc_codecs.a"
+
+cc() { local out="$1"; shift
+  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+    -I"$CREF" -I"$CREF/Compression" \
+    "$CREF/rust/difftest/bsc_ref.cpp" "$CREF/rust/difftest/bsc_ccodec.cpp" \
+    "$CREF/Compression/BSC/libbsc/bwt/libsais/libsais.c" "$@" -o "$out"; }
+cc "$W/c"                    || exit 1
+cc "$W/rs" -DUSE_RUST "$LIB" || exit 1
+
+# The encoder is driven by the rank and run distributions the transform hands
+# it, so the corpus spans what changes those: text, long runs, incompressible
+# noise (which pushes the average rank past 32 and reaches the escape path), a
+# single repeated byte, sorted data (what a block sorter actually produces), a
+# full alphabet, and sizes down to a few hundred bytes.
+python3 - "$W/in" <<'CORPUS'
+import os,sys
+d=sys.argv[1]; os.makedirs(d,exist_ok=True)
+def prng(seed,n):
+    s=seed; o=bytearray()
+    for _ in range(n): s=(s*1103515245+12345)&0xffffffff; o.append((s>>16)&0xff)
+    return bytes(o)
+w=lambda n,b: open(f"{d}/{n}","wb").write(b)
+w("text",       b"the quick brown fox jumps over the lazy dog. "*2000)
+w("runs",       b"".join(bytes([i%251])*200 for i in range(400)))
+w("longruns",   b"".join(bytes([i%7])*5000 for i in range(60)))
+w("noise",      prng(7, 150000))
+w("zeros",      b"\x00"*80000)
+w("one_byte",   b"Q"*40000)
+w("sorted",     bytes(sorted(prng(11, 120000))))
+w("full_alpha", bytes(range(256))*300)
+w("ends_zero",  prng(3, 50000)[:-1] + b"\x00")
+for n in (256, 1024, 65536):
+    w(f"n_{n}", (b"abracadabra"*10000)[:n])
+CORPUS
+
+fail=0; tested=0; declined=0
+for f in "$W"/in/*; do
+  bn=$(basename "$f")
+  "$W/c"  c 1 < "$f" >| "$W/oc" 2>/dev/null; rc_c=$?
+  "$W/rs" c 1 < "$f" >| "$W/or" 2>/dev/null; rc_r=$?
+  # 6 = the encoder declined the block ("not compressible"). Both sides must
+  # make the same call: one coding what the other refuses is a difference, and
+  # a driver that wrote nothing on refusal would hide it behind two empty files.
+  if [ "$rc_c" -ne "$rc_r" ]; then
+    echo "  $bn: C exited $rc_c, Rust $rc_r -- they disagree about whether to code it"
+    fail=$((fail+1)); continue
+  fi
+  if [ "$rc_c" -eq 6 ]; then declined=$((declined+1)); continue; fi
+  if [ "$rc_c" -ne 0 ]; then echo "  $bn: both drivers failed with $rc_c"; fail=$((fail+1)); continue; fi
+  tested=$((tested+1))
+  cmp -s "$W/oc" "$W/or" || { echo "  $bn: coded block differs from the C"; fail=$((fail+1)); }
+done
+
+# Byte-identity already implies the blocks decode, but a harness that only ever
+# compared two empty outputs would pass too. Require real payloads.
+big=0
+for f in "$W"/in/text "$W"/in/sorted "$W"/in/noise; do
+  "$W/c" c 1 < "$f" >| "$W/oc" 2>/dev/null || continue
+  [ "$(wc -c < "$W/oc")" -gt 100 ] && big=$((big+1))
+done
+
+[ "$tested" -gt 0 ] || { echo "no blocks were coded -- the harness reached nothing"; exit 1; }
+[ "$big" -ge 3 ] || { echo "only $big of 3 inputs produced a real coded block"; fail=$((fail+1)); }
+[ "$fail" -eq 0 ] || { echo "bsc-qlfc-encode: $fail failures"; exit 1; }
+echo "bsc-qlfc-encode: $tested/$tested byte-identical to the C (static coder; $declined declined by both)"
+echo "bsc-qlfc-encode: adaptive and fast encoders are still C -- not covered here"

--- a/rust/difftest/bsc_ref.cpp
+++ b/rust/difftest/bsc_ref.cpp
@@ -3,7 +3,9 @@
  *     bsc_ref c CODER  <in >coded     (C encodes one QLFC block)
  *     bsc_ref d CODER SIZE <coded >out
  *
- * Built a second time with -DUSE_RUST so `d` drives the Rust port.
+ * Built a second time with -DUSE_RUST, where `d` drives the Rust decoder and
+ * `c` the Rust static ENCODER (exit 7 for the other coders, which have none
+ * yet).
  *
  * CODER: 1 = QLFC static (libbsc's default), 2 = adaptive, 3 = fast.
  *
@@ -26,6 +28,7 @@ int darc_bsc_coder_decode_block (const unsigned char *in, unsigned char *out, in
 int darc_bsc_init (int features);
 #ifdef USE_RUST
 int darc_rs_bsc_qlfc_decode (const unsigned char *in, int inSize, unsigned char *out, int outCap, int coder);
+int darc_rs_bsc_qlfc_static_encode (const unsigned char *in, int inSize, unsigned char *out, int outSize);
 #endif
 }
 
@@ -52,7 +55,14 @@ int main (int argc, char **argv) {
 
   if (argv[1][0] == 'c') {
     if (len == 0) { free(in); free(out); return 6; }   /* nothing to code */
+#ifdef USE_RUST
+    /* Only the static coder has a Rust encoder so far; the harness asks for the
+     * others from the C on both sides, which compares nothing and says so. */
+    if (coder != 1) { free(in); free(out); return 7; }
+    rc = darc_rs_bsc_qlfc_static_encode(in, (int)len, out, (int)outCap);
+#else
     rc = darc_bsc_coder_encode_block(in, out, (int)len, (int)outCap, coder);
+#endif
     if (rc < 0) { free(in); free(out); return 6; }     /* encoder declined: skip */
   } else {
 #ifdef USE_RUST


### PR DESCRIPTION
Continues the BSC encoder port after the forward transform (#87). Lands the range coder's encoder half and `bsc_qlfc_static_encode` — the body `LIBBSC_DEFAULT_CODER` selects, so what entropy-codes a default `-mbsc` block.

**12/12 byte-identical to the C**, first run, over the whole corpus.

That isn't luck. The decoder was ported and verified first, so the 238 tuned constants, the model layout and every index expression were already known-correct, and the encoder is those same tables driven the other way. Decode-first paid for itself here more visibly than anywhere else in this port.

## Where the two directions are *not* symmetric

A mirror written from the decoder alone would be wrong in two places:

- The **rank** exponent's terminating zero is conditional on `bitRankSize < maxRank`; the **run** exponent's is unconditional, because there's no `maxRank` to run into.
- The run mantissa's context doesn't simply accumulate: `int ctx = context + context + b; context++; if (bitRunSize <= 5) { context = ctx; }` — for runs long enough to need six exponent bits it merely increments. That desynchronises **only on long runs**, which a short corpus never reaches, so the corpus includes 5000-byte runs.

## Range coder encoder half

Two details decide whether a stream decodes at all:

- **Output is 16 bits at a time.** `OutputShort` writes an `unsigned short`, so the coded stream is little-endian 16-bit words, and `CheckEOB` compares *short* pointers against `output + outputSize - 16`. Treating that unit as bytes gives a stream that decodes for a while and then diverges.
- **`low` and `carry` are a union.** The C aliases `unsigned long long low` with `{ low32, carry }` so `ari.low += range` overflowing bit 31 lands in `carry`. That's little-endian-only, which DArc is; here `low` is a plain `u64` and `carry` is `low >> 32` — same value, no layout dependency.

The run-length scan is the plain `while (*input == currentChar)` loop. The C has SSE2 and A64 variants, but they find the same run — the SIMD question was already settled for this file by building the C twice with `-DLIBBSC_CPU_FEATURE=0`.

## The harness

`bsc-qlfc-encode-check.sh`: 12 inputs, byte-identical, wired into CI. Both sides' **exit status** is compared before their bytes — `6` means the encoder declined the block, and one side coding what the other refuses is a difference that a driver writing nothing on refusal would hide behind two empty files.

Corpus spans what moves the rank and run distributions: text, long runs, incompressible noise (which pushes the average rank past 32 and reaches the **escape path**), a single repeated byte, sorted data, a full alphabet, and blocks down to 256 bytes.

## Still C

The adaptive and fast encoders, and `bsc_coder_compress_serial`'s content-aware block splitter. Then forward ST, libsais, and the `bsc_compress` framing before `Compression/BSC` can go.

## Verified

36 BSC unit tests, and `bsc-check`, `bsc-full-check`, `bsc-lzp-encode-check`, `bsc-qlfc-transform-check` all still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)