### PR TITLE
BSC: port the coder layer — block splitting and framing

### DIFF
--- a/rust/darc-codecs/src/bsc/qlfc_enc.rs
+++ b/rust/darc-codecs/src/bsc/qlfc_enc.rs
@@ -974,3 +974,136 @@ pub fn fast_encode(input: &[u8], output: &mut [u8]) -> i32 {
 
     coder.finish() as i32
 }
+
+/// `bsc_coder_split_blocks` (`coder.cpp:88`): choose where to cut a large input
+/// into `n_blocks` independently-coded pieces.
+///
+/// Not an even split. It samples every 32nd byte, counts how often the sample
+/// differs from its predecessor -- a cheap proxy for how much the local
+/// statistics move -- and cuts at every `rankSize / nBlocks`-th change, so
+/// blocks carry roughly equal amounts of *variation* rather than equal length.
+/// Only when there are fewer changes than blocks does it fall back to even
+/// division.
+///
+/// The C leaves `blockStart`/`blockSize` entries untouched if the scan ends
+/// before it has made `nBlocks - 1` cuts, and they are uninitialised stack
+/// arrays. That is unreachable -- the branch is guarded by
+/// `rankSize > nBlocks`, so at least `nBlocks` changes exist and
+/// `blockRankSize >= 1` -- but the port does not depend on it: everything is
+/// initialised, and a short scan simply leaves a zero-length block.
+pub fn split_blocks(input: &[u8], n_blocks: usize) -> Vec<(usize, usize)> {
+    let n = input.len();
+    let mut out = vec![(0usize, 0usize); n_blocks];
+    if n_blocks == 0 {
+        return out;
+    }
+
+    let mut rank_size = 0usize;
+    let mut i = 1usize;
+    while i < n {
+        if input[i] != input[i - 1] {
+            rank_size += 1;
+        }
+        i += 32;
+    }
+
+    if rank_size > n_blocks {
+        let block_rank_size = rank_size / n_blocks;
+        out[0].0 = 0;
+        rank_size = 0;
+        let mut id = 0usize;
+        let mut i = 1usize;
+        while i < n {
+            if input[i] != input[i - 1] {
+                rank_size += 1;
+                if rank_size == block_rank_size {
+                    rank_size = 0;
+                    out[id].1 = i - out[id].0;
+                    id += 1;
+                    out[id].0 = i;
+                    if id == n_blocks - 1 {
+                        break;
+                    }
+                }
+            }
+            i += 32;
+        }
+        out[n_blocks - 1].1 = n - out[n_blocks - 1].0;
+    } else {
+        for p in 0..n_blocks {
+            out[p].0 = (n / n_blocks) * p;
+            out[p].1 = if p != n_blocks - 1 {
+                n / n_blocks
+            } else {
+                n - (n / n_blocks) * (n_blocks - 1)
+            };
+        }
+    }
+    out
+}
+
+/// `bsc_coder_compress_serial` (`coder.cpp:130`) -- and therefore
+/// `bsc_coder_compress`, since the parallel variant is inside
+/// `#ifdef LIBBSC_OPENMP` and DArc never defines `LIBBSC_OPENMP_SUPPORT`.
+///
+/// The framing is LZP's, one layer up: a block count, then two little-endian
+/// 32-bit words per block (input size, coded size), then the coded blocks. A
+/// block whose two sizes are equal was stored rather than coded, which is how
+/// the decoder recognises one the encoder gave up on.
+pub fn coder_compress(input: &[u8], output: &mut [u8], coder: u32) -> i32 {
+    let n = input.len();
+    if n == 0 || output.len() < n {
+        return LIBBSC_NOT_COMPRESSIBLE;
+    }
+
+    let encode = |inp: &[u8], out: &mut [u8]| -> i32 {
+        match coder {
+            1 => static_encode(inp, out),
+            2 => adaptive_encode(inp, out),
+            3 => fast_encode(inp, out),
+            _ => super::LIBBSC_BAD_PARAMETER,
+        }
+    };
+
+    let n_blocks = num_blocks(n);
+    if n_blocks == 1 {
+        if n < 2 {
+            return LIBBSC_NOT_COMPRESSIBLE;
+        }
+        let result = encode(input, &mut output[1..n]);
+        if result < 0 {
+            return result;
+        }
+        output[0] = 1;
+        return result + 1;
+    }
+
+    let blocks = split_blocks(input, n_blocks);
+    let mut output_ptr = 1 + 8 * n_blocks;
+    output[0] = n_blocks as u8;
+
+    for (id, &(start, size)) in blocks.iter().enumerate() {
+        let mut out_size = size;
+        if out_size > n - output_ptr {
+            out_size = n - output_ptr;
+        }
+        let result = encode(
+            &input[start..start + size],
+            &mut output[output_ptr..output_ptr + out_size],
+        );
+        let result = if result < 0 {
+            if output_ptr + size >= n {
+                return LIBBSC_NOT_COMPRESSIBLE;
+            }
+            output[output_ptr..output_ptr + size].copy_from_slice(&input[start..start + size]);
+            size
+        } else {
+            result as usize
+        };
+        output[1 + 8 * id..1 + 8 * id + 4].copy_from_slice(&(size as i32).to_le_bytes());
+        output[1 + 8 * id + 4..1 + 8 * id + 8].copy_from_slice(&(result as i32).to_le_bytes());
+        output_ptr += result;
+    }
+
+    output_ptr as i32
+}

--- a/rust/darc-codecs/src/exports.rs
+++ b/rust/darc-codecs/src/exports.rs
@@ -760,6 +760,27 @@ pub unsafe extern "C" fn darc_rs_bsc_qlfc_fast_encode(
     bsc::qlfc_enc::fast_encode(inp, out)
 }
 
+/// `bsc_coder_compress`: split a block and entropy-code each piece, producing
+/// the framed payload `bsc_compress` embeds.
+///
+/// # Safety
+/// `input` must be valid for `in_size` bytes, `output` for `out_size`.
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_bsc_coder_compress(
+    input: *const u8,
+    in_size: c_int,
+    output: *mut u8,
+    out_size: c_int,
+    coder: c_int,
+) -> c_int {
+    if input.is_null() || output.is_null() || in_size <= 0 || out_size <= 0 {
+        return FREEARC_ERRCODE_GENERAL;
+    }
+    let inp = core::slice::from_raw_parts(input, in_size as usize);
+    let out = core::slice::from_raw_parts_mut(output, out_size as usize);
+    bsc::qlfc_enc::coder_compress(inp, out, coder as u32)
+}
+
 /// `bsc_qlfc_transform`: the QLFC forward transform. Writes the rank array into
 /// the tail of `buffer` and the alphabet into `mtf` (256 bytes), returning the
 /// offset in `buffer` where the ranks begin.

--- a/rust/difftest/bsc-qlfc-encode-check.sh
+++ b/rust/difftest/bsc-qlfc-encode-check.sh
@@ -77,6 +77,47 @@ for f in "$W"/in/*; do
 done
 done
 
+# --- The coder LAYER: block splitting plus framing -------------------------
+# bsc_coder_compress is what bsc_compress actually calls. Its splitter is NOT an
+# even division -- it samples every 32nd byte, counts how often the sample
+# changes, and cuts so that blocks carry equal amounts of variation.
+#
+# That path only runs above 2*2*65536 bytes, so the two inputs below are sized
+# to force 2 and 4 blocks. Without them every case takes the single-block
+# shortcut and the splitter is never executed at all -- which is exactly what
+# the first run of this harness did.
+python3 - "$W/big" <<'BIG'
+import os,sys
+d=sys.argv[1]; os.makedirs(d,exist_ok=True)
+def prng(seed,n):
+    s=seed; o=bytearray()
+    for _ in range(n): s=(s*1103515245+12345)&0xffffffff; o.append((s>>16)&0xff)
+    return bytes(o)
+open(f"{d}/two",  "wb").write((b"the quick brown fox "*20000 + prng(5,60000))*2)
+open(f"{d}/four", "wb").write(bytes(sorted(prng(3,1200000))))
+BIG
+
+layer=0; multi=0
+for coder in 1 2 3; do
+  for f in "$W"/big/*; do
+    bn="$(basename "$f") coder$coder"
+    "$W/c"  C "$coder" < "$f" >| "$W/oc" 2>/dev/null; rc_c=$?
+    "$W/rs" C "$coder" < "$f" >| "$W/or" 2>/dev/null; rc_r=$?
+    if [ "$rc_c" -ne "$rc_r" ]; then
+      echo "  $bn: C exited $rc_c, Rust $rc_r"; fail=$((fail+1)); continue
+    fi
+    [ "$rc_c" -eq 0 ] || continue
+    layer=$((layer+1))
+    cmp -s "$W/oc" "$W/or" || { echo "  $bn: coder layer differs from the C"; fail=$((fail+1)); }
+    # output[0] is the block count; anything above 1 means the splitter ran.
+    nb=$(od -An -N1 -tu1 < "$W/oc" | tr -d ' ')
+    [ "${nb:-1}" -gt 1 ] && multi=$((multi+1))
+  done
+done
+[ "$multi" -ge 3 ] || {
+  echo "the multi-block splitter was reached $multi times; the large inputs are not"
+  echo "large enough, and split_blocks is going untested"; fail=$((fail+1)); }
+
 # Byte-identity already implies the blocks decode, but a harness that only ever
 # compared two empty outputs would pass too. Require real payloads.
 big=0
@@ -88,4 +129,5 @@ done
 [ "$tested" -gt 0 ] || { echo "no blocks were coded -- the harness reached nothing"; exit 1; }
 [ "$big" -ge 3 ] || { echo "only $big of 3 inputs produced a real coded block"; fail=$((fail+1)); }
 [ "$fail" -eq 0 ] || { echo "bsc-qlfc-encode: $fail failures"; exit 1; }
-echo "bsc-qlfc-encode: $tested/$tested byte-identical to the C (all three coders; $declined declined by both)"
+echo "bsc-qlfc-encode: $tested/$tested blocks + $layer coder-layer cases byte-identical to the C"
+echo "bsc-qlfc-encode: (all three coders; $declined declined by both; $multi multi-block)"

--- a/rust/difftest/bsc_ccodec.cpp
+++ b/rust/difftest/bsc_ccodec.cpp
@@ -35,6 +35,11 @@ int darc_bsc_coder_decode_block (const unsigned char *in, unsigned char *out, in
 
 int darc_bsc_init (int features) { return bsc_init(features); }
 
+/* The coder layer above the three encode bodies: block splitting plus framing.
+ * bsc_coder_compress is what bsc_compress actually calls. */
+int darc_bsc_coder_compress (const unsigned char *in, unsigned char *out, int n, int coder, int features)
+{ return bsc_coder_compress(in, out, n, coder, features); }
+
 /* Forward BWT (with auxiliary indexes) and its inverse, for the inverse-BWT
  * differential harness. The encoder is the same libsais forward transform a
  * real archive was built with, so the index / num_indexes / transformed bytes

--- a/rust/difftest/bsc_ref.cpp
+++ b/rust/difftest/bsc_ref.cpp
@@ -23,6 +23,7 @@
 
 extern "C" {
 int darc_bsc_coder_encode_block (const unsigned char *in, unsigned char *out, int inSize, int outSize, int coder);
+int darc_bsc_coder_compress (const unsigned char *in, unsigned char *out, int n, int coder, int features);
 int darc_bsc_coder_decode_block (const unsigned char *in, unsigned char *out, int coder);
 int darc_bsc_init (int features);
 #ifdef USE_RUST
@@ -30,12 +31,13 @@ int darc_rs_bsc_qlfc_decode (const unsigned char *in, int inSize, unsigned char 
 int darc_rs_bsc_qlfc_static_encode (const unsigned char *in, int inSize, unsigned char *out, int outSize);
 int darc_rs_bsc_qlfc_adaptive_encode (const unsigned char *in, int inSize, unsigned char *out, int outSize);
 int darc_rs_bsc_qlfc_fast_encode (const unsigned char *in, int inSize, unsigned char *out, int outSize);
+int darc_rs_bsc_coder_compress (const unsigned char *in, int inSize, unsigned char *out, int outSize, int coder);
 #endif
 }
 
 int main (int argc, char **argv) {
-  if (argc < 2 || (argv[1][0] != 'c' && argv[1][0] != 'd')) {
-    fprintf(stderr, "usage: %s c CODER | d CODER SIZE\n", argv[0]); return 2; }
+  if (argc < 2 || (argv[1][0] != 'c' && argv[1][0] != 'd' && argv[1][0] != 'C')) {
+    fprintf(stderr, "usage: %s c CODER | C CODER | d CODER SIZE\n", argv[0]); return 2; }
   darc_bsc_init(0);
   int coder = argc > 2 ? atoi(argv[2]) : 1;
 
@@ -53,6 +55,23 @@ int main (int argc, char **argv) {
   size_t outCap = argv[1][0] == 'c' ? len * 2 + (1<<16) : (size_t)size + 4096;
   unsigned char *out = (unsigned char*)malloc(outCap); if (!out) { free(in); return 3; }
   int rc;
+
+  if (argv[1][0] == 'C') {
+    /* The whole coder layer: split + frame + code, which is what bsc_compress
+     * calls. The buffer is exactly len bytes on both sides, since the C treats
+     * running out of it as "not compressible". */
+    if (len == 0) { free(in); free(out); return 6; }
+    unsigned char *cbuf = (unsigned char*)malloc(len);
+    if (!cbuf) { free(in); free(out); return 3; }
+#ifdef USE_RUST
+    rc = darc_rs_bsc_coder_compress(in, (int)len, cbuf, (int)len, coder);
+#else
+    rc = darc_bsc_coder_compress(in, cbuf, (int)len, coder, 0);
+#endif
+    if (rc < 0) { free(cbuf); free(in); free(out); return 6; }
+    if (fwrite(cbuf, 1, (size_t)rc, stdout) != (size_t)rc) { free(cbuf); free(in); free(out); return 5; }
+    free(cbuf); free(in); free(out); return 0;
+  }
 
   if (argv[1][0] == 'c') {
     if (len == 0) { free(in); free(out); return 6; }   /* nothing to code */


### PR DESCRIPTION
Completes `bsc_coder_compress` — what `bsc_compress` actually calls. With the three encode bodies (#88, #89), the whole coder layer is now Rust.

## The splitter is not an even division

`bsc_coder_split_blocks` samples every 32nd byte, counts how often the sample differs from its predecessor — a cheap proxy for how much the local statistics move — and cuts at every `rankSize / nBlocks`-th change, so blocks carry roughly equal amounts of **variation** rather than equal length. Even division is only the fallback, taken when there are fewer changes than blocks.

The C leaves `blockStart`/`blockSize` entries untouched if the scan ends before making `nBlocks - 1` cuts, and they're uninitialised stack arrays. That's unreachable — the branch is guarded by `rankSize > nBlocks` — but the port doesn't lean on it.

## The harness was green before it ran the code

My first coder-layer comparison passed 12/12. Every input was under `2*2*65536` bytes, so `bsc_coder_num_blocks` returned 1 every time and **the splitter never executed** — the single-block shortcut was doing all the work.

Fixed by sizing two inputs to force 2 and 4 blocks, and then by making the corpus's adequacy an **assertion** rather than an assumption: the first output byte *is* the block count, so the run now requires at least three cases where it exceeds 1. Without that, trimming the corpus later would silently return the harness to proving nothing.

**6/6 coder-layer cases byte-identical** across all three coders, on top of 36/36 individual blocks.

## Remaining in BSC

Forward ST3–ST6, libsais, and the `bsc_compress` framing that ties the stages together.

## Verified

`bsc-check`, `bsc-full-check`, `bsc-lzp-encode-check`, `bsc-qlfc-transform-check` all still pass. Rebased onto the CI split (`6a28a2a`), so this runs against the four-way-concurrent harness jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)