### PR TITLE
BSC: port the forward BWT, replacing libsais with SA-IS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1014,6 +1014,13 @@ jobs:
         # Compares the primary index as well as the bytes: the index alone
         # decides where the decoder starts unwinding.
         rust/difftest/bsc-st-encode-check.sh
+        # The forward BWT. Not a translation of libsais: a string's suffixes all
+        # have distinct lengths, so the suffix array has no ties to break and the
+        # BWT is a function of it, which makes any correct construction produce
+        # libsais's bytes. Verified before the port was written -- a qsort/memcmp
+        # suffix array matched libsais over 21 inputs -- and held here against
+        # SA-IS, for libsais_bwt, libsais_bwt_aux and the libbsc wrapper.
+        rust/difftest/bsc-bwt-encode-check.sh
 
   # SREP is not an in-process codec: the archiver spawns a `srep` binary
   # (arc.ini's [External compressor:srep]), so this compares files rather than

--- a/rust/darc-codecs/src/bsc/bwt_enc.rs
+++ b/rust/darc-codecs/src/bsc/bwt_enc.rs
@@ -1,0 +1,468 @@
+//! Forward Burrows-Wheeler transform -- the last block sorter BSC needs.
+//!
+//! # Why this is not a port of libsais
+//!
+//! The C reaches this through `libsais_bwt_aux`, and libsais is 8,532 lines:
+//! SIMD induction, OpenMP partitioning, context pooling, 16-bit and 64-bit
+//! variants. Almost none of that is *semantics*; it is engineering to make one
+//! particular answer arrive quickly.
+//!
+//! The answer is unique. Every suffix of a string has a distinct length, so no
+//! two suffixes are equal, so the suffix array is totally ordered with no ties
+//! to break -- and the BWT and its primary index are functions of that array.
+//! Any correct construction therefore produces the same bytes as libsais.
+//!
+//! That is a claim worth testing rather than believing, so it was tested before
+//! any of this was written: a `qsort`-with-`memcmp` suffix array -- the
+//! slowest correct construction there is -- reproduces `libsais_bwt`'s output
+//! and index exactly across 21 inputs, including the shapes where a tie-break
+//! would show up (`banana`, `mississippi`, `abcabcabc`*1000, `ab`*4000,
+//! all-zeros, single-byte, full alphabet, already-sorted). A second experiment
+//! confirmed the sampled-index convention the same way. Had either come back
+//! false, this module would have had to mirror libsais's structure instead.
+//!
+//! So what is implemented here is SA-IS: linear time, ~250 lines, and the
+//! algorithm libsais is itself an optimised implementation of.
+//!
+//! # The two output conventions, both verified against the C
+//!
+//! `libsais_bwt` does not write the BWT array as-is. With `p` the position
+//! where `SA[p] == 0`, it writes `T[n-1]` first, then the BWT with the entry at
+//! `p` omitted, and returns `p + 1`.
+//!
+//! `libsais_bwt_aux` additionally fills `I[j] = (position i with SA[i] == j*r)
+//! + 1` for `j` in `0 ..= (n-1)/r`, where `I[0]` is the primary index. DArc
+//! always takes this path: libbsc.cpp's `indexes[256]` is a stack array, so the
+//! pointer is never null.
+
+/// Marker for an unfilled suffix-array slot. `n` never reaches `u32::MAX`
+/// because a BSC block is bounded well below 4 GB.
+const EMPTY: u32 = u32::MAX;
+
+/// True where the suffix at `i` is S-type (smaller than the suffix at `i+1`).
+fn build_types(t: &[u32]) -> Vec<bool> {
+    let n = t.len();
+    let mut ty = vec![false; n];
+    // The sentinel is the smallest suffix, hence S-type.
+    ty[n - 1] = true;
+    for i in (0..n - 1).rev() {
+        ty[i] = match t[i].cmp(&t[i + 1]) {
+            std::cmp::Ordering::Less => true,
+            std::cmp::Ordering::Greater => false,
+            // Equal: the type propagates from the right.
+            std::cmp::Ordering::Equal => ty[i + 1],
+        };
+    }
+    ty
+}
+
+/// An LMS ("leftmost S") position: S-type with an L-type immediately before it.
+#[inline]
+fn is_lms(ty: &[bool], i: usize) -> bool {
+    i > 0 && ty[i] && !ty[i - 1]
+}
+
+fn bucket_sizes(t: &[u32], k: usize) -> Vec<u32> {
+    let mut b = vec![0u32; k];
+    for &c in t {
+        b[c as usize] += 1;
+    }
+    b
+}
+
+/// Exclusive prefix sums: the first slot of each bucket.
+fn bucket_heads(bkt: &[u32]) -> Vec<i64> {
+    let mut h = Vec::with_capacity(bkt.len());
+    let mut sum = 0i64;
+    for &c in bkt {
+        h.push(sum);
+        sum += c as i64;
+    }
+    h
+}
+
+/// Inclusive prefix sums minus one: the last slot of each bucket.
+fn bucket_tails(bkt: &[u32]) -> Vec<i64> {
+    let mut tl = Vec::with_capacity(bkt.len());
+    let mut sum = 0i64;
+    for &c in bkt {
+        sum += c as i64;
+        tl.push(sum - 1);
+    }
+    tl
+}
+
+/// The induced-sort core: given the LMS suffixes already in place, fill in
+/// every L-type left to right, then every S-type right to left.
+fn induce(t: &[u32], sa: &mut [u32], ty: &[bool], bkt: &[u32]) {
+    let n = t.len();
+
+    let mut heads = bucket_heads(bkt);
+    for i in 0..n {
+        let v = sa[i];
+        // `v > 0` skips both EMPTY and position 0, which has no predecessor.
+        if v != EMPTY && v > 0 {
+            let j = (v - 1) as usize;
+            if !ty[j] {
+                let c = t[j] as usize;
+                sa[heads[c] as usize] = j as u32;
+                heads[c] += 1;
+            }
+        }
+    }
+
+    let mut tails = bucket_tails(bkt);
+    for i in (0..n).rev() {
+        let v = sa[i];
+        if v != EMPTY && v > 0 {
+            let j = (v - 1) as usize;
+            if ty[j] {
+                let c = t[j] as usize;
+                sa[tails[c] as usize] = j as u32;
+                tails[c] -= 1;
+            }
+        }
+    }
+}
+
+/// Are the LMS substrings starting at `a` and `b` equal, symbol and type alike?
+fn lms_substr_eq(t: &[u32], ty: &[bool], a: usize, b: usize) -> bool {
+    let n = t.len();
+    // The sentinel's LMS substring is the sentinel alone, equal only to itself.
+    if a == n - 1 || b == n - 1 {
+        return a == b;
+    }
+    let mut d = 0usize;
+    loop {
+        let a_end = d > 0 && is_lms(ty, a + d);
+        let b_end = d > 0 && is_lms(ty, b + d);
+        if a_end && b_end {
+            return true;
+        }
+        if a_end != b_end {
+            return false;
+        }
+        if t[a + d] != t[b + d] || ty[a + d] != ty[b + d] {
+            return false;
+        }
+        d += 1;
+        // Safe: the sentinel at n-1 is LMS, so one side always terminates.
+    }
+}
+
+/// Suffix array of `t` by SA-IS. `t` must end with a unique `0` sentinel that
+/// occurs nowhere else, and every symbol must be below `k`.
+fn sais(t: &[u32], k: usize) -> Vec<u32> {
+    let n = t.len();
+    if n == 0 {
+        return Vec::new();
+    }
+    if n == 1 {
+        return vec![0];
+    }
+
+    let ty = build_types(t);
+    let bkt = bucket_sizes(t, k);
+    let lms: Vec<u32> = (1..n).filter(|&i| is_lms(&ty, i)).map(|i| i as u32).collect();
+    let n1 = lms.len();
+
+    // Round one: LMS suffixes dropped into their buckets in arbitrary order.
+    // Inducing from them sorts the LMS *substrings*, which is enough to name.
+    let mut sa = vec![EMPTY; n];
+    {
+        let mut tails = bucket_tails(&bkt);
+        for &p in lms.iter().rev() {
+            let c = t[p as usize] as usize;
+            sa[tails[c] as usize] = p;
+            tails[c] -= 1;
+        }
+    }
+    induce(t, &mut sa, &ty, &bkt);
+
+    // Name the LMS substrings in the order that sort put them.
+    let mut sorted_lms = Vec::with_capacity(n1);
+    for i in 0..n {
+        let v = sa[i];
+        if v != EMPTY && v > 0 && is_lms(&ty, v as usize) {
+            sorted_lms.push(v);
+        }
+    }
+
+    let mut names = vec![0u32; n];
+    let mut cur = 0u32;
+    if !sorted_lms.is_empty() {
+        names[sorted_lms[0] as usize] = 0;
+        let mut prev = sorted_lms[0] as usize;
+        for &pos in &sorted_lms[1..] {
+            let pos = pos as usize;
+            if !lms_substr_eq(t, &ty, prev, pos) {
+                cur += 1;
+            }
+            names[pos] = cur;
+            prev = pos;
+        }
+    }
+    let name_count = cur as usize + 1;
+
+    // The reduced string: one name per LMS position, in TEXT order.
+    let s1: Vec<u32> = lms.iter().map(|&p| names[p as usize]).collect();
+
+    // If names are not yet unique the substring order is not the suffix order,
+    // so recurse. The reduced string ends with the sentinel's name, which is 0
+    // and unique, so it satisfies this function's own precondition.
+    let sa1 = if name_count < n1 {
+        sais(&s1, name_count)
+    } else {
+        let mut r = vec![0u32; n1];
+        for (i, &name) in s1.iter().enumerate() {
+            r[name as usize] = i as u32;
+        }
+        r
+    };
+
+    // Round two: place the LMS suffixes in their true order, then induce again.
+    let mut sa = vec![EMPTY; n];
+    {
+        let mut tails = bucket_tails(&bkt);
+        for i in (0..n1).rev() {
+            let p = lms[sa1[i] as usize];
+            let c = t[p as usize] as usize;
+            sa[tails[c] as usize] = p;
+            tails[c] -= 1;
+        }
+    }
+    induce(t, &mut sa, &ty, &bkt);
+    sa
+}
+
+/// Suffix array of a byte string, without sentinel, as `u32` positions.
+fn suffix_array(input: &[u8]) -> Vec<u32> {
+    let n = input.len();
+    // Shift by one so 0 can serve as a sentinel no real byte can collide with.
+    let mut t: Vec<u32> = Vec::with_capacity(n + 1);
+    t.extend(input.iter().map(|&b| b as u32 + 1));
+    t.push(0);
+    let mut sa = sais(&t, 257);
+    // sa[0] is the sentinel suffix; drop it.
+    sa.remove(0);
+    sa
+}
+
+/// `libsais_bwt` (`libsais.c:7110`): the BWT of `input` into `output`, with the
+/// entry for the position-0 suffix omitted and `input[n-1]` written first.
+///
+/// Returns `p + 1` where `SA[p] == 0`, matching the C, or `n` for `n <= 1`.
+pub fn bwt_encode(input: &[u8], output: &mut [u8]) -> i32 {
+    let n = input.len();
+    if n <= 1 {
+        if n == 1 {
+            output[0] = input[0];
+        }
+        return n as i32;
+    }
+
+    let sa = suffix_array(input);
+    let mut p = 0usize;
+    let mut l = vec![0u8; n];
+    for i in 0..n {
+        let s = sa[i] as usize;
+        if s == 0 {
+            p = i;
+        }
+        l[i] = input[(s + n - 1) % n];
+    }
+
+    output[0] = input[n - 1];
+    let mut k = 1usize;
+    for i in 0..n {
+        if i == p {
+            continue;
+        }
+        output[k] = l[i];
+        k += 1;
+    }
+    (p + 1) as i32
+}
+
+/// `libsais_bwt_aux` (`libsais.c:7136`): as [`bwt_encode`], and additionally
+/// `i[j] = (position with SA == j*r) + 1`. Returns 0 on success, matching the C
+/// -- the primary index comes back in `i[0]`, not in the return value.
+///
+/// `r` must be a power of two of at least 2, and `i` must hold at least
+/// `(n-1)/r + 1` entries.
+pub fn bwt_aux_encode(input: &[u8], output: &mut [u8], r: usize, i_out: &mut [i32]) -> i32 {
+    let n = input.len();
+    if r < 2 || (r & (r - 1)) != 0 {
+        return -1; // LIBBSC_BAD_PARAMETER
+    }
+    if n <= 1 {
+        if n == 1 {
+            output[0] = input[0];
+        }
+        i_out[0] = n as i32;
+        return 0;
+    }
+
+    let sa = suffix_array(input);
+    let mut p = 0usize;
+    let mut l = vec![0u8; n];
+    // pos_of[s] is where suffix s landed; the sampled indexes read it directly.
+    let mut pos_of = vec![0u32; n];
+    for idx in 0..n {
+        let s = sa[idx] as usize;
+        pos_of[s] = idx as u32;
+        if s == 0 {
+            p = idx;
+        }
+        l[idx] = input[(s + n - 1) % n];
+    }
+
+    let count = (n - 1) / r;
+    for j in 0..=count {
+        i_out[j] = pos_of[j * r] as i32 + 1;
+    }
+
+    output[0] = input[n - 1];
+    let mut k = 1usize;
+    for idx in 0..n {
+        if idx == p {
+            continue;
+        }
+        output[k] = l[idx];
+        k += 1;
+    }
+    0
+}
+
+/// `bsc_bwt_encode` (`bwt.cpp:178`): the aux transform plus the `mod` the C
+/// derives from `n`, writing the sampled indexes the caller stores in the
+/// block. Returns the primary index, or a negative libbsc error.
+pub fn bsc_bwt_encode(
+    input: &mut [u8],
+    n: usize,
+    num_indexes: &mut u8,
+    indexes: &mut [i32],
+) -> i32 {
+    if n <= 1 {
+        *num_indexes = 0;
+        return n as i32;
+    }
+
+    // bwt.cpp:193 -- the largest power of two at or below n/8, halved.
+    let mut m = n / 8;
+    m |= m >> 1;
+    m |= m >> 2;
+    m |= m >> 4;
+    m |= m >> 8;
+    m |= m >> 16;
+    m >>= 1;
+
+    let src = input[..n].to_vec();
+    let mut i_arr = vec![0i32; 256];
+    let rc = bwt_aux_encode(&src, &mut input[..n], m + 1, &mut i_arr);
+    if rc != 0 {
+        return rc;
+    }
+
+    // The C only publishes the sampled indexes when the aux call succeeded.
+    *num_indexes = ((n - 1) / (m + 1)) as u8;
+    let index = i_arr[0];
+    for t in 0..*num_indexes as usize {
+        indexes[t] = i_arr[t + 1] - 1;
+    }
+    index
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The suffix array by brute force, for cross-checking SA-IS on small
+    /// inputs. Deliberately the dumbest correct construction.
+    fn naive_sa(input: &[u8]) -> Vec<u32> {
+        let n = input.len();
+        let mut sa: Vec<u32> = (0..n as u32).collect();
+        sa.sort_by(|&a, &b| input[a as usize..].cmp(&input[b as usize..]));
+        sa
+    }
+
+    #[test]
+    fn sais_matches_brute_force() {
+        let cases: Vec<Vec<u8>> = vec![
+            b"banana".to_vec(),
+            b"mississippi".to_vec(),
+            b"abracadabra".to_vec(),
+            b"aaaaaaaa".to_vec(),
+            b"ab".repeat(50),
+            b"abc".repeat(37),
+            (0u8..=255).collect(),
+            vec![0u8; 100],
+            b"the quick brown fox".to_vec(),
+        ];
+        for c in cases {
+            assert_eq!(suffix_array(&c), naive_sa(&c), "SA differs for {:?}", &c[..c.len().min(16)]);
+        }
+    }
+
+    #[test]
+    fn sais_matches_brute_force_on_random() {
+        let mut s: u32 = 12345;
+        for trial in 0..200 {
+            let n = 1 + (trial * 7) % 300;
+            // A small alphabet makes repeats -- and thus recursion -- likely.
+            let alpha = 1 + (trial % 4) as u8;
+            let data: Vec<u8> = (0..n)
+                .map(|_| {
+                    s = s.wrapping_mul(1103515245).wrapping_add(12345);
+                    ((s >> 16) as u8) % alpha
+                })
+                .collect();
+            assert_eq!(suffix_array(&data), naive_sa(&data), "SA differs, trial {trial}");
+        }
+    }
+
+    #[test]
+    fn bwt_round_trips_through_a_naive_inverse() {
+        for case in [b"banana".to_vec(), b"mississippi".to_vec(), b"abracadabra".to_vec()] {
+            let n = case.len();
+            let mut out = vec![0u8; n];
+            let index = bwt_encode(&case, &mut out) as usize;
+
+            // Undo the C's packing: reinsert the omitted entry to get the BWT.
+            let mut l = Vec::with_capacity(n);
+            l.extend_from_slice(&out[1..index]);
+            l.push(out[0]);
+            l.extend_from_slice(&out[index..]);
+
+            // Textbook inverse BWT from the full L column and primary index.
+            let mut counts = [0usize; 256];
+            for &b in &l {
+                counts[b as usize] += 1;
+            }
+            let mut starts = [0usize; 256];
+            let mut sum = 0;
+            for c in 0..256 {
+                starts[c] = sum;
+                sum += counts[c];
+            }
+            // LF(i): the row of the suffix one character to the left. Note this
+            // is the mapping itself, not its inverse -- walking the inverse
+            // rebuilds the string rotated by one.
+            let mut lf = vec![0usize; n];
+            let mut seen = [0usize; 256];
+            for i in 0..n {
+                let c = l[i] as usize;
+                lf[i] = starts[c] + seen[c];
+                seen[c] += 1;
+            }
+            // Row `index - 1` is the suffix starting at 0: the original string.
+            let mut p = index - 1;
+            let mut rebuilt = vec![0u8; n];
+            for i in (0..n).rev() {
+                rebuilt[i] = l[p];
+                p = lf[p];
+            }
+            assert_eq!(rebuilt, case, "round trip failed");
+        }
+    }
+}

--- a/rust/darc-codecs/src/bsc/mod.rs
+++ b/rust/darc-codecs/src/bsc/mod.rs
@@ -45,6 +45,7 @@
 
 pub mod adler32;
 pub mod bwt;
+pub mod bwt_enc;
 pub mod dispatch;
 pub mod header;
 pub mod lzp;

--- a/rust/darc-codecs/src/bsc/qlfc_enc.rs
+++ b/rust/darc-codecs/src/bsc/qlfc_enc.rs
@@ -1389,10 +1389,9 @@ pub fn store(input: &[u8], output: &mut [u8]) -> i32 {
 /// `bsc_compress` (`libbsc.cpp:213`), the out-of-place form: LZP, block sort,
 /// entropy code, frame.
 ///
-/// **Block sorter 1 (BWT) is not supported yet** -- `bsc_bwt_encode` needs
-/// libsais, which is unported -- so this handles ST3..ST6 and returns
-/// NOT_SUPPORTED for BWT. That is also why the `lzSize <= HEADER_SIZE` fallback
-/// below, which forces BWT, is reported rather than silently mis-sorted.
+/// Handles every block sorter the C has a CPU encoder for: BWT (via
+/// [`super::bwt_enc`]) and ST3..ST6. ST7/ST8 return NOT_SUPPORTED, as they do
+/// in the C without CUDA.
 ///
 /// `output` must have at least `n + 28` bytes: the block sorters wrap the first
 /// 28 bytes past the end of their working area.
@@ -1450,17 +1449,27 @@ pub fn compress(
         output[..n].copy_from_slice(input);
     }
 
+    let mut block_sorter = block_sorter;
     if lz_size <= super::HEADER_SIZE {
-        // The C forces BWT here. Without libsais there is nothing to force it
-        // to, so this is refused rather than answered with a different sorter.
-        return -4; // LIBBSC_NOT_SUPPORTED
+        // libbsc.cpp:279 -- too little data to sort; fall back to BWT and record
+        // that in the mode, so the decoder reads it back as BWT.
+        block_sorter = 1; // LIBBSC_BLOCKSORTER_BWT
+        mode = (mode & 0xffff_ffe0) | 1;
     }
 
-    let sorter_k = match block_sorter {
-        3..=6 => block_sorter,
-        _ => return -4, // BWT and ST7/ST8: no encoder here
+    let mut num_indexes: u8 = 0;
+    let mut indexes = [0i32; 256];
+    let index = match block_sorter {
+        1 => super::bwt_enc::bsc_bwt_encode(output, lz_size, &mut num_indexes, &mut indexes),
+        3..=6 => st_encode(output, lz_size, block_sorter),
+        _ => return -4, // ST7/ST8 have no CPU encoder in the C either
     };
-    let index = st_encode(output, lz_size, sorter_k);
+
+    // libbsc.cpp:303 -- small blocks carry no sampled indexes even though the
+    // sorter computed them. This is on `n`, the ORIGINAL size, not `lz_size`.
+    if n < 64 * 1024 {
+        num_indexes = 0;
+    }
     if index < 0 {
         return index;
     }
@@ -1470,18 +1479,21 @@ pub fn compress(
     // The out-of-place bsc_compress STORES the block here; only the in-place
     // variant returns NOT_COMPRESSIBLE. Carrying the in-place behaviour over is
     // the bug the differential harness caught -- the C succeeded on
-    // incompressible noise while this refused it. `num_indexes` is 0 for every
-    // ST sorter, so the C's `result + 1 + 4 * num_indexes` reduces to
-    // `result + 1`.
-    if result < 0 || (result as usize) + 1 >= n {
+    // incompressible noise while this refused it.
+    let ni = num_indexes as usize;
+    if result < 0 || (result as usize) + 1 + 4 * ni >= n {
         return store(input, output);
     }
     let result = result as usize;
     output[super::HEADER_SIZE..super::HEADER_SIZE + result].copy_from_slice(&coded[..result]);
-    // num_indexes is 0 for every ST sorter; the trailing count byte is still
-    // written, which is what the decoder reads.
-    output[super::HEADER_SIZE + result] = 0;
-    let result = result + 1;
+    // The sampled indexes, then the count byte the decoder reads first. For the
+    // ST sorters `ni` is 0 and this reduces to a single zero byte.
+    for (t, &v) in indexes[..ni].iter().enumerate() {
+        let at = super::HEADER_SIZE + result + 4 * t;
+        output[at..at + 4].copy_from_slice(&v.to_le_bytes());
+    }
+    output[super::HEADER_SIZE + result + 4 * ni] = num_indexes;
+    let result = result + 1 + 4 * ni;
 
     let w = |o: &mut [u8], at: usize, v: u32| o[at..at + 4].copy_from_slice(&v.to_le_bytes());
     w(output, 0, (result + super::HEADER_SIZE) as u32);

--- a/rust/darc-codecs/src/exports.rs
+++ b/rust/darc-codecs/src/exports.rs
@@ -810,6 +810,66 @@ pub unsafe extern "C" fn darc_rs_bsc_st_encode(data: *mut u8, n: c_int, k: c_int
     bsc::qlfc_enc::st_encode(t, n as usize, k as u32)
 }
 
+/// `libsais_bwt`: the forward BWT, in libsais's packed output convention --
+/// `input[n-1]` first, then the transform with the position-0 entry omitted.
+/// Returns `p + 1` where `SA[p] == 0`.
+///
+/// # Safety
+/// `input` and `output` must both be valid for `n` bytes.
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_bsc_bwt_encode(
+    input: *const u8, output: *mut u8, n: c_int,
+) -> c_int {
+    if input.is_null() || output.is_null() || n < 0 {
+        return FREEARC_ERRCODE_GENERAL;
+    }
+    let inp = core::slice::from_raw_parts(input, n as usize);
+    let out = core::slice::from_raw_parts_mut(output, n as usize);
+    bsc::bwt_enc::bwt_encode(inp, out)
+}
+
+/// `libsais_bwt_aux`: as [`darc_rs_bsc_bwt_encode`], plus the sampled indexes
+/// `i_out[j] = (position with SA == j*r) + 1`. Returns 0 on success; the
+/// primary index comes back in `i_out[0]`, matching the C.
+///
+/// # Safety
+/// `input`/`output` must be valid for `n` bytes and `i_out` for at least
+/// `(n-1)/r + 1` `int32`s.
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_bsc_bwt_aux_encode(
+    input: *const u8, output: *mut u8, n: c_int, r: c_int, i_out: *mut c_int,
+) -> c_int {
+    if input.is_null() || output.is_null() || i_out.is_null() || n < 0 || r < 2 {
+        return FREEARC_ERRCODE_GENERAL;
+    }
+    let inp = core::slice::from_raw_parts(input, n as usize);
+    let out = core::slice::from_raw_parts_mut(output, n as usize);
+    let cnt = if n <= 1 { 1 } else { (n as usize - 1) / (r as usize) + 1 };
+    let ia = core::slice::from_raw_parts_mut(i_out, cnt);
+    bsc::bwt_enc::bwt_aux_encode(inp, out, r as usize, ia)
+}
+
+/// `bsc_bwt_encode` (`bwt.cpp:178`): the in-place forward BWT plus the sampled
+/// indexes the caller stores in the block. Returns the primary index.
+///
+/// # Safety
+/// `data` must be valid for `n` bytes, `num_indexes` for one byte, and
+/// `indexes` for 256 `int32`s.
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_bsc_bwt_encode_full(
+    data: *mut u8, n: c_int, num_indexes: *mut u8, indexes: *mut c_int,
+) -> c_int {
+    if data.is_null() || num_indexes.is_null() || indexes.is_null() || n < 0 {
+        return FREEARC_ERRCODE_GENERAL;
+    }
+    let d = core::slice::from_raw_parts_mut(data, n as usize);
+    let idx = core::slice::from_raw_parts_mut(indexes, 256);
+    let mut ni: u8 = 0;
+    let r = bsc::bwt_enc::bsc_bwt_encode(d, n as usize, &mut ni, idx);
+    *num_indexes = ni;
+    r
+}
+
 /// `bsc_compress`: build one framed BSC block. Supports the ST3..ST6 block
 /// sorters; BWT needs libsais, which is unported, and returns NOT_SUPPORTED.
 ///

--- a/rust/difftest/bsc-bwt-encode-check.sh
+++ b/rust/difftest/bsc-bwt-encode-check.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Differential-test the forward BWT against libsais.
+#
+# This port is NOT a translation of libsais. Every suffix of a string has a
+# distinct length, so no two suffixes compare equal, so the suffix array is
+# totally ordered with no ties to break -- and the BWT and its primary index are
+# functions of that array. Any correct construction gives libsais's bytes.
+#
+# That was checked before the port was written, not assumed: a qsort/memcmp
+# suffix array reproduced libsais_bwt over 21 inputs, and a second experiment
+# confirmed the sampled-index convention the same way. This harness is what
+# holds the property afterwards, against the real SA-IS implementation.
+#
+# Three entry points are compared, because DArc reaches all of them:
+#
+#   b  libsais_bwt      the plain transform
+#   a  libsais_bwt_aux  the sampled indexes too -- libbsc.cpp's `indexes[256]`
+#                       is a stack array, so the aux path is ALWAYS taken
+#   f  bsc_bwt_encode   the libbsc wrapper, including the mod it derives from n
+#
+# The C reference comes from a pinned revision, not the working tree -- see
+# c-reference.sh for why.
+set -uo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$ROOT/rust/difftest/c-reference.sh"
+CREF="$(darc_c_reference "$ROOT")" || exit 1
+W="${TMPDIR:-/tmp}/bsc-bwt-enc.$$"; mkdir -p "$W"
+trap 'rm -rf "$W"' EXIT
+
+( cd "$ROOT/rust" && cargo build --release -p darc-codecs ) >/dev/null 2>&1 \
+  || { echo "cargo build failed" >&2; exit 1; }
+LIB="$ROOT/rust/target/release/libdarc_codecs.a"
+[ -f "$LIB" ] || { echo "the Rust staticlib is missing" >&2; exit 1; }
+
+cc() { local out="$1"; shift
+  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+    -I"$CREF" -I"$CREF/Compression" \
+    "$CREF/rust/difftest/bsc_bwt_enc_ref.cpp" "$CREF/rust/difftest/bsc_ccodec.cpp" \
+    "$CREF/Compression/BSC/libbsc/bwt/libsais/libsais.c" "$@" -o "$out"; }
+cc "$W/c"                    || { echo "C driver failed to build"    >&2; exit 1; }
+cc "$W/rs" -DUSE_RUST "$LIB" || { echo "Rust driver failed to build" >&2; exit 1; }
+[ -x "$W/c" ] && [ -x "$W/rs" ] || { echo "a driver is missing after a clean build" >&2; exit 1; }
+
+# The corpus targets what a suffix sorter is sensitive to: long runs (deep
+# recursion in SA-IS), periodic strings (many equal LMS substrings, so the
+# naming step cannot terminate early), a single repeated byte (the degenerate
+# case), sorted data, the full alphabet, and the small-n boundaries around the
+# aux sampling rate.
+python3 - "$W/in" <<'CORPUS'
+import os,sys
+d=sys.argv[1]; os.makedirs(d,exist_ok=True)
+def prng(seed,n):
+    s=seed; o=bytearray()
+    for _ in range(n): s=(s*1103515245+12345)&0xffffffff; o.append((s>>16)&0xff)
+    return bytes(o)
+w=lambda n,b: open(f"{d}/{n}","wb").write(b)
+w("text",        b"the quick brown fox jumps over the lazy dog. "*2000)
+w("runs",        b"".join(bytes([i%251])*200 for i in range(400)))
+w("longruns",    b"".join(bytes([i%7])*5000 for i in range(60)))
+w("noise",       prng(7, 150000))
+w("zeros",       b"\x00"*80000)
+w("one_byte",    b"Q"*40000)
+w("sorted",      bytes(sorted(prng(11, 120000))))
+w("full_alpha",  bytes(range(256))*300)
+w("ends_zero",   prng(3, 50000)[:-1] + b"\x00")
+# Periodic and near-periodic: the shapes that make LMS substrings collide, so
+# SA-IS must recurse rather than resolve names in one pass.
+w("periodic3",   b"abc"*30000)
+w("periodic2",   b"ab"*45000)
+w("fibonacci",   (lambda: (lambda f: f(f,24))(lambda f,k: b"a" if k==0 else (b"ab" if k==1 else f(f,k-1)+f(f,k-2))))())
+w("almost_per",  (b"abcabcabcabd"*8000))
+w("two_symbols", bytes((i*i)%2 for i in range(100000)))
+w("bwt_like",    bytes(sorted(prng(5, 90000))))
+for n in (2,3,4,5,17,255,256,257,1000,65535,65536):
+    w(f"n_{n}", (b"abracadabra"*10000)[:n])
+CORPUS
+
+fail=0; nb=0; na=0; nf=0; skipped_a=0
+
+run_mode() {           # $1 = mode letter, $2 = counter name
+  local mode="$1"
+  for f in "$W"/in/*; do
+    local bn; bn="$(basename "$f") mode=$mode"
+    "$W/c"  "$mode" < "$f" >| "$W/oc" 2>/dev/null; local rc_c=$?
+    "$W/rs" "$mode" < "$f" >| "$W/or" 2>/dev/null; local rc_r=$?
+    if [ "$rc_c" -ne "$rc_r" ]; then
+      echo "  $bn: C exited $rc_c, Rust $rc_r"; fail=$((fail+1)); continue
+    fi
+    # rc 4 is the driver declining: n is too small for the aux sampling rate.
+    if [ "$rc_c" -eq 4 ]; then skipped_a=$((skipped_a+1)); continue; fi
+    if [ "$rc_c" -ne 0 ]; then
+      echo "  $bn: both drivers failed with $rc_c"; fail=$((fail+1)); continue
+    fi
+    # Two empty files compare equal; a mode that produced nothing on both sides
+    # would pass silently. Every mode here emits at least the 4-byte index.
+    if [ ! -s "$W/oc" ]; then
+      echo "  $bn: the C driver produced no output"; fail=$((fail+1)); continue
+    fi
+    case "$mode" in
+      b) nb=$((nb+1)) ;; a) na=$((na+1)) ;; f) nf=$((nf+1)) ;;
+    esac
+    cmp -s "$W/oc" "$W/or" || { echo "  $bn: differs from the C"; fail=$((fail+1)); }
+  done
+}
+
+run_mode b
+run_mode a
+run_mode f
+
+# Coverage: the aux path must actually publish sampled indexes somewhere in the
+# corpus, otherwise mode 'a' is only re-testing the primary index. num_indexes
+# is byte 4 of mode 'f' output.
+with_indexes=0
+for f in "$W"/in/text "$W"/in/sorted "$W"/in/noise "$W"/in/periodic3; do
+  "$W/c" f < "$f" >| "$W/oc" 2>/dev/null || continue
+  ni=$(od -An -j4 -N1 -tu1 < "$W/oc" | tr -d ' ')
+  [ "${ni:-0}" -gt 0 ] && with_indexes=$((with_indexes+1))
+done
+
+[ "$nb" -gt 0 ] || { echo "no inputs were transformed -- the harness reached nothing"; exit 1; }
+[ "$with_indexes" -ge 3 ] || {
+  echo "only $with_indexes of 4 inputs published sampled indexes; the aux path is"
+  echo "not being exercised beyond its primary index"; fail=$((fail+1)); }
+[ "$fail" -eq 0 ] || { echo "bsc-bwt-encode: $fail failures"; exit 1; }
+echo "bsc-bwt-encode: $nb bwt + $na bwt_aux + $nf bsc_bwt_encode byte-identical to libsais"
+echo "bsc-bwt-encode: ($skipped_a too small for the aux rate; $with_indexes/4 published indexes)"

--- a/rust/difftest/bsc-full-check.sh
+++ b/rust/difftest/bsc-full-check.sh
@@ -93,4 +93,57 @@ done
 
 [ "$tested" -gt 0 ] || { echo "no blocks were coded -- harness reached nothing"; exit 1; }
 echo "bsc whole-codec: $total total differing ($tested coded blocks)"
-[ "$total" -eq 0 ] && echo "BSC whole-codec decode matches the C original byte for byte" || exit 1
+[ "$total" -eq 0 ] || exit 1
+echo "BSC whole-codec decode matches the C original byte for byte"
+
+# --- The ENCODER side ------------------------------------------------------
+# Everything above encodes with the C and only compares DECODE, so it would pass
+# with no Rust encoder in the tree at all. Mode `E` runs bsc_compress on both
+# sides and diffs the framed block, which is the only bar that matters for an
+# encoder: a legal-but-different encoding round-trips perfectly and still
+# changes every archive byte.
+enc_fail=0; enc_ok=0; enc_declined=0; bwt_ok=0
+for sorter in 1 3 4 5 6; do
+  for coder in 1 2 3; do
+    for lzp in "0 0" "16 128"; do
+      lname=$([ "$lzp" = "0 0" ] && echo noLZP || echo LZP)
+      sname=$([ "$sorter" = 1 ] && echo BWT || echo "ST$sorter")
+      cname=$([ "$coder" = 1 ] && echo static || { [ "$coder" = 2 ] && echo adaptive || echo fast; })
+      tag="$sname/$cname/$lname"
+      for f in "$W"/in/*; do
+        bn=$(basename "$f")
+        "$W/c"  E "$sorter" "$coder" $lzp < "$f" >| "$W/ec" 2>/dev/null; rc_c=$?
+        "$W/rs" E "$sorter" "$coder" $lzp < "$f" >| "$W/er" 2>/dev/null; rc_r=$?
+        if [ "$rc_c" -ne "$rc_r" ]; then
+          echo "  [$tag] $bn: C driver exited $rc_c, Rust $rc_r"; enc_fail=$((enc_fail+1)); continue
+        fi
+        [ "$rc_c" -eq 0 ] || { enc_declined=$((enc_declined+1)); continue; }
+        [ -s "$W/ec" ] || { echo "  [$tag] $bn: C produced no output"; enc_fail=$((enc_fail+1)); continue; }
+        enc_ok=$((enc_ok+1))
+        [ "$sorter" = 1 ] && bwt_ok=$((bwt_ok+1))
+        cmp -s "$W/ec" "$W/er" || { echo "  [$tag] $bn: ENCODED block differs from the C"; enc_fail=$((enc_fail+1)); }
+      done
+    done
+  done
+done
+
+# The BWT sorter is the point of this round; if it never coded, the encoder
+# comparison is only re-testing the ST paths.
+[ "$bwt_ok" -gt 0 ] || { echo "the BWT sorter coded nothing -- it is going untested"; exit 1; }
+
+# LZP coverage. `bsc_compress` silently drops back to mode & 0xff when LZP does
+# not pay, so "the LZP cases passed" can mean "LZP never ran". Require the
+# LZP-on block to actually DIFFER from the LZP-off one, which it cannot do
+# unless the LZP stage changed the data.
+lzp_live=0
+for f in "$W"/in/*; do
+  "$W/c" E 1 1 0 0     < "$f" >| "$W/l0" 2>/dev/null || continue
+  "$W/c" E 1 1 16 128  < "$f" >| "$W/l1" 2>/dev/null || continue
+  cmp -s "$W/l0" "$W/l1" || lzp_live=$((lzp_live+1))
+done
+[ "$lzp_live" -ge 3 ] || {
+  echo "LZP changed the encoded block for only $lzp_live inputs; the LZP-enabled"
+  echo "configurations are passing without the LZP stage ever running"; exit 1; }
+[ "$enc_fail" -eq 0 ] || { echo "bsc encoder: $enc_fail differing of $enc_ok"; exit 1; }
+echo "bsc encoder: $enc_ok/$enc_ok framed blocks byte-identical to the C ($bwt_ok via BWT, $enc_declined declined by both)"
+echo "bsc encoder: LZP genuinely changed the block for $lzp_live inputs"

--- a/rust/difftest/bsc_bwt_enc_ref.cpp
+++ b/rust/difftest/bsc_bwt_enc_ref.cpp
@@ -1,0 +1,113 @@
+/* Reference driver for differential-testing the forward BWT.
+ *
+ *     bsc_bwt_enc_ref <mode>  <in >out
+ *
+ * Built twice: plain drives the C (libsais), `-DUSE_RUST` the Rust port.
+ *
+ *   b  libsais_bwt      -- 4-byte LE index, then the packed transform
+ *   a  libsais_bwt_aux  -- 4-byte LE rc, 4-byte LE count, the I[] array,
+ *                          then the packed transform
+ *   f  bsc_bwt_encode   -- 4-byte LE index, 1-byte num_indexes, the published
+ *                          indexes, then the transform
+ *
+ * The index is emitted alongside the bytes so a single `cmp` covers both. A
+ * port that produced the right transform under a wrong primary index would
+ * still make every archive undecodable.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+extern "C" {
+int32_t libsais_bwt (const uint8_t *T, uint8_t *U, int32_t *A, int32_t n, int32_t fs, int32_t *freq);
+int32_t libsais_bwt_aux (const uint8_t *T, uint8_t *U, int32_t *A, int32_t n, int32_t fs, int32_t *freq, int32_t r, int32_t *I);
+int bsc_bwt_encode (unsigned char *T, int n, unsigned char *num_indexes, int *indexes, int features);
+int darc_bsc_init (int features);
+#ifdef USE_RUST
+int darc_rs_bsc_bwt_encode (const uint8_t *input, uint8_t *output, int n);
+int darc_rs_bsc_bwt_aux_encode (const uint8_t *input, uint8_t *output, int n, int r, int *I);
+int darc_rs_bsc_bwt_encode_full (uint8_t *data, int n, unsigned char *num_indexes, int *indexes);
+#endif
+}
+
+static void put4 (int32_t v) {
+  unsigned char b[4] = { (unsigned char)( (uint32_t)v        & 0xff),
+                         (unsigned char)(((uint32_t)v >>  8) & 0xff),
+                         (unsigned char)(((uint32_t)v >> 16) & 0xff),
+                         (unsigned char)(((uint32_t)v >> 24) & 0xff) };
+  fwrite (b, 1, 4, stdout);
+}
+
+int main (int argc, char **argv) {
+  if (argc < 2) return 2;
+  char mode = argv[1][0];
+  darc_bsc_init (0);
+
+  size_t cap = 1 << 20, len = 0;
+  unsigned char *in = (unsigned char *) malloc (cap);
+  if (!in) return 3;
+  for (;;) {
+    if (len == cap) { cap *= 2; in = (unsigned char *) realloc (in, cap); if (!in) return 3; }
+    size_t r = fread (in + len, 1, cap - len, stdin);
+    if (r == 0) break;
+    len += r;
+  }
+  int n = (int) len;
+  if (n <= 0) { free (in); return 0; }
+
+  unsigned char *U = (unsigned char *) malloc ((size_t) n);
+  int32_t *A = (int32_t *) malloc ((size_t) n * sizeof (int32_t));
+  if (!U || !A) return 3;
+
+  if (mode == 'b') {
+#ifdef USE_RUST
+    int index = darc_rs_bsc_bwt_encode (in, U, n);
+#else
+    int index = libsais_bwt (in, U, A, n, 0, NULL);
+#endif
+    put4 (index);
+    if (index >= 0) fwrite (U, 1, (size_t) n, stdout);
+
+  } else if (mode == 'a') {
+    /* the same mod/r bwt.cpp derives from n */
+    int mod = n / 8;
+    mod |= mod >> 1;  mod |= mod >> 2;  mod |= mod >> 4;
+    mod |= mod >> 8;  mod |= mod >> 16; mod >>= 1;
+    int r = mod + 1;
+    if (r < 2) { free (in); return 4; }          /* n too small for the aux path */
+    int32_t I[256];
+    memset (I, 0, sizeof I);
+#ifdef USE_RUST
+    int rc = darc_rs_bsc_bwt_aux_encode (in, U, n, r, I);
+#else
+    int rc = libsais_bwt_aux (in, U, A, n, 0, NULL, r, I);
+#endif
+    int cnt = (n - 1) / r + 1;
+    put4 (rc);
+    put4 (cnt);
+    for (int j = 0; j < cnt && j < 256; j++) put4 (I[j]);
+    if (rc == 0) fwrite (U, 1, (size_t) n, stdout);
+
+  } else if (mode == 'f') {
+    unsigned char num_indexes = 0;
+    int indexes[256];
+    memset (indexes, 0, sizeof indexes);
+    memcpy (U, in, (size_t) n);
+#ifdef USE_RUST
+    int index = darc_rs_bsc_bwt_encode_full (U, n, &num_indexes, indexes);
+#else
+    int index = bsc_bwt_encode (U, n, &num_indexes, indexes, 0);
+#endif
+    put4 (index);
+    fwrite (&num_indexes, 1, 1, stdout);
+    for (int t = 0; t < num_indexes; t++) put4 (indexes[t]);
+    if (index >= 0) fwrite (U, 1, (size_t) n, stdout);
+
+  } else {
+    return 2;
+  }
+
+  free (in); free (U); free (A);
+  return 0;
+}

--- a/rust/difftest/bsc_full_ref.cpp
+++ b/rust/difftest/bsc_full_ref.cpp
@@ -24,6 +24,8 @@ int darc_bsc_compress (const unsigned char *in, unsigned char *out, int n, int l
 int darc_bsc_decompress (const unsigned char *in, int inSize, unsigned char *out, int outSize, int features);
 #ifdef USE_RUST
 int darc_rs_bsc_decompress_block (const unsigned char *in, int inSize, unsigned char *out, int outCap);
+int darc_rs_bsc_compress (const unsigned char *in, int inSize, unsigned char *out, int outSize,
+                          int lzpHashSize, int lzpMinLen, int blockSorter, int coder);
 #endif
 }
 
@@ -42,13 +44,43 @@ static unsigned char *slurp (size_t *outLen) {
 }
 
 int main (int argc, char **argv) {
-  if (argc < 2 || (argv[1][0] != 'e' && argv[1][0] != 'd')) {
-    fprintf(stderr, "usage: %s e SORTER CODER HASH MINLEN | d SIZE\n", argv[0]); return 2;
+  if (argc < 2 || (argv[1][0] != 'e' && argv[1][0] != 'd' && argv[1][0] != 'E')) {
+    fprintf(stderr, "usage: %s e|E SORTER CODER HASH MINLEN | d SIZE\n", argv[0]); return 2;
   }
   darc_bsc_init(0);
 
   size_t len = 0;
   unsigned char *in = slurp(&len);
+
+  /* `E` is the ENCODER-side comparison: it emits the framed block that
+   * bsc_compress produced, so the two builds can be diffed byte for byte.
+   * Mode `e` always uses the C, because the decode test needs a block the C
+   * definitely agrees with; only `E` switches implementation under USE_RUST.
+   * Without this mode nothing exercised the Rust encoder at all -- the decode
+   * test encodes with the C and would pass with no Rust encoder in the tree. */
+  if (argv[1][0] == 'E') {
+    int n      = (int)len;
+    int sorter = argc > 2 ? atoi(argv[2]) : 1;
+    int coder  = argc > 3 ? atoi(argv[3]) : 1;
+    int hash   = argc > 4 ? atoi(argv[4]) : 0;
+    int minlen = argc > 5 ? atoi(argv[5]) : 0;
+    if (n <= 0) { free(in); return 6; }
+
+    size_t cap = (size_t)n + (1 << 16);
+    unsigned char *out = (unsigned char *)malloc(cap);
+    if (!out) { free(in); return 3; }
+#ifdef USE_RUST
+    int csize = darc_rs_bsc_compress(in, n, out, (int)cap, hash, minlen, sorter, coder);
+#else
+    int csize = darc_bsc_compress(in, out, n, hash, minlen, sorter, coder, 0);
+#endif
+    /* The return code is emitted even on refusal, so that one side declining
+     * while the other codes shows up as a difference rather than as a skip. */
+    fwrite(&csize, sizeof(int), 1, stdout);
+    if (csize > 0) fwrite(out, 1, (size_t)csize, stdout);
+    free(in); free(out);
+    return 0;
+  }
 
   if (argv[1][0] == 'e') {
     int n      = (int)len;


### PR DESCRIPTION
Completes the BSC encoder. Every block sorter the C has a CPU encoder for — BWT and ST3–ST6 — now has a byte-identical Rust implementation, closing the series that ran through #86, #87, #88, #89, #90 and #91.

## Why this is not a translation of libsais

libsais is **8,532 lines**: SIMD induction, OpenMP partitioning, context pooling, 16- and 64-bit variants. Almost none of that is *semantics* — it is engineering to make one particular answer arrive quickly.

The answer is unique. Every suffix of a string has a distinct length, so no two suffixes compare equal, so the suffix array is totally ordered **with no ties to break** — and the BWT and its primary index are functions of that array. Any correct construction therefore emits libsais's bytes.

**That was tested before a line was written, not assumed.** A `qsort`/`memcmp` suffix array — the slowest correct construction there is — reproduced `libsais_bwt` exactly over 21 inputs, including the shapes where a tie-break would surface: `banana`, `mississippi`, `abcabcabc`×1000, `ab`×4000, all-zeros, single-byte, full alphabet, already-sorted. A second experiment confirmed the sampled-index convention the same way. Had either come back false, this would have had to mirror libsais's structure and the PR would look entirely different.

So what landed is **SA-IS**: linear time, ~250 lines, the algorithm libsais is itself an optimised implementation of.

## Verified

| Harness | Result |
|---|---|
| `bsc-bwt-encode-check.sh` | 26 `libsais_bwt` + 22 `libsais_bwt_aux` + 26 `bsc_bwt_encode` byte-identical |
| `bsc-full-check.sh` | 750/750 framed blocks byte-identical (**150 via BWT**) |

All three entry points are compared because DArc reaches all three — libbsc.cpp's `indexes[256]` is a stack array, so the `_aux` path is *always* taken, never the plain one.

Four sabotages confirm the harness bites, each against a baseline proven green first:

| Sabotage | Diffs |
|---|---|
| aux sampled-index off-by-one | 44 |
| S/L type propagation flipped | 25 |
| LMS definition off by one | 8 |
| primary index shifted | 26 |

## A gap this closes, and how it surfaced

`bsc-full-check.sh` encoded with the **C** and compared only *decode*. It would have passed with no Rust encoder in the tree at all — and in fact **no committed driver called `darc_rs_bsc_compress`**. The "48/48 `bsc_compress`" figure I reported alongside the ST sorters in #91 came from a harness that was never committed. The export existed; nothing exercised it.

Mode `E` now runs `bsc_compress` on **both** sides and diffs the framed block. That is the only bar that matters for an encoder: a legal-but-different encoding round-trips perfectly and still changes every archive byte.

It also closes the **LZP gap left open in #91**, where both sides declined so nothing was compared. Here all 750 code, and a liveness assertion requires the LZP-on block to actually *differ* from the LZP-off one — otherwise "the LZP cases passed" can mean "LZP never ran". It currently fires on 12 inputs.

## Next

`Compression/BSC` can now be deleted — that is a separate diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
