### PR TITLE
PPMd: port var.H to Rust, verified byte-for-byte against a pinned C oracle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1093,6 +1093,59 @@ jobs:
     - name: Prove the encryption differential test can fail
       run: rust/difftest/crypto-sabotage.sh
 
+  # TEMPORARY -- remove once the PPMd port is proven and folded into the
+  # per-codec jobs above.
+  #
+  # This exists because the full order x memory x MRMethod grid is too slow to
+  # run on a laptop: PPMd allocates a model heap per case and the `dominant`
+  # corpus entry is pathologically slow at low order (in the C as much as in the
+  # port). CI has the machine for it, so the wide grid runs here.
+  #
+  # NOTE the C driver is pinned to -O1 inside ppmd-check.sh, and that is not a
+  # style choice: PPMd type-puns through `(WORD&)` in StateCpy/SWAP, so the
+  # compiler's aliasing assumptions change rescale()'s result and the SAME
+  # SOURCE EMITS DIFFERENT COMPRESSED BYTES at -O0 vs -O1. Compression/PPMD/
+  # makefile ships -O1, so -O1 is the only oracle that matches real archives.
+  ppmd-difftest-temporary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      # Wider than the local default (3 4 10 16 / 1 8), but deliberately not the
+      # widest possible: per-case cost has not been measured, and 8 orders x 4
+      # budgets x 3 MRMethods x ~19 inputs is ~1800 encode+decode pairs. Start
+      # at 14 combinations, see the wall-clock this reports, then widen.
+      PPMD_ORDERS: "3 4 6 8 10 12 16"
+      PPMD_MEMS: "1 8"
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        lfs: false
+    - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+    - name: Cache LLVM
+      id: cache-llvm
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ./llvm
+        key: llvm-21.1.8-${{ runner.os }}-${{ runner.arch }}
+    - name: Install LLVM and Clang
+      uses: KyleMayes/install-llvm-action@ebc0426251bc40c7cd31162802432c68818ab8f0 # v2
+      with:
+        version: "21.1.8"
+        # Skip the download when the cache above already restored ./llvm.
+        cached: ${{ steps.cache-llvm.outputs.cache-hit }}
+    - name: Install packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y liblua5.1-dev libncurses-dev libcurl4-openssl-dev cpphs
+    - name: PPMd differential test, wide grid (Rust vs C at -O1)
+      run: |
+        chmod +x rust/difftest/*.sh
+        start=$(date +%s)
+        rust/difftest/ppmd-check.sh
+        echo "ppmd-check wall clock: $(( $(date +%s) - start ))s"
+    - name: PPMd suballocator differential test
+      run: rust/difftest/ppmd-alloc-check.sh
+
   # The one job here that needs the archiver, and therefore MicroHs. The
   # C-vs-Rust crypto comparison is crypto-difftest above; this is the other
   # half -- encrypted archives must still be created and read back correctly.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1093,29 +1093,35 @@ jobs:
     - name: Prove the encryption differential test can fail
       run: rust/difftest/crypto-sabotage.sh
 
-  # TEMPORARY -- remove once the PPMd port is proven and folded into the
-  # per-codec jobs above.
-  #
-  # This exists because the full order x memory x MRMethod grid is too slow to
-  # run on a laptop: PPMd allocates a model heap per case and the `dominant`
-  # corpus entry is pathologically slow at low order (in the C as much as in the
-  # port). CI has the machine for it, so the wide grid runs here.
+  # PPMd gets a job of its own rather than a step in rust-codecs-* because the
+  # grid is minutes rather than seconds: PPMd allocates a model heap per case
+  # and the `dominant` corpus entry is pathologically slow at low order (in the
+  # C as much as in the port). Too slow for a laptop, comfortable for a runner.
   #
   # NOTE the C driver is pinned to -O1 inside ppmd-check.sh, and that is not a
   # style choice: PPMd type-puns through `(WORD&)` in StateCpy/SWAP, so the
   # compiler's aliasing assumptions change rescale()'s result and the SAME
   # SOURCE EMITS DIFFERENT COMPRESSED BYTES at -O0 vs -O1. Compression/PPMD/
   # makefile ships -O1, so -O1 is the only oracle that matches real archives.
-  ppmd-difftest-temporary:
+  rust-codecs-ppmd:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
-      # Wider than the local default (3 4 10 16 / 1 8), but deliberately not the
-      # widest possible: per-case cost has not been measured, and 8 orders x 4
-      # budgets x 3 MRMethods x ~19 inputs is ~1800 encode+decode pairs. Start
-      # at 14 combinations, see the wall-clock this reports, then widen.
-      PPMD_ORDERS: "3 4 6 8 10 12 16"
-      PPMD_MEMS: "1 8"
+      # Sized from a measurement, not a guess: 8 pairs took 245s including the
+      # builds, so ~25s per (order, budget) pair and 36 of them land near 15
+      # minutes. Ignore the 634s this job once
+      # reported for 14 pairs -- that run was dominated by a stray per-symbol
+      # eprintln! in the port, not by the codec. The step below echoes the wall
+      # clock, so trim or widen from what it actually reports.
+      PPMD_ORDERS: "3 4 5 6 8 10 12 16 24"
+      # The budgets are all SMALL on purpose. Only a budget the corpus can
+      # exhaust changes anything: at order 16 the 150 KB noise input gives
+      # different output at 1, 2 and 3 MB and byte-identical output at 4, 8 and
+      # 16 MB, because without exhaustion the model never restarts and the
+      # budget stops being an input at all. So three budgets that exhaust, and
+      # 8 MB as the control that does not -- adding 16 MB would buy a duplicate
+      # of the 8 MB column.
+      PPMD_MEMS: "1 2 3 8"
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
@@ -1144,6 +1150,12 @@ jobs:
         rust/difftest/ppmd-check.sh
         echo "ppmd-check wall clock: $(( $(date +%s) - start ))s"
     - name: PPMd suballocator differential test
+      # Its own cap, well under the job's. Without one, this step once ran 48
+      # minutes on the job's 60-minute budget and took the whole job down as
+      # `cancelled` -- hiding a grid that had passed in 634s twenty minutes
+      # earlier. The script caps each driver run internally too; this is the
+      # backstop for the case where that cap is the thing that breaks.
+      timeout-minutes: 10
       run: rust/difftest/ppmd-alloc-check.sh
 
   # The one job here that needs the archiver, and therefore MicroHs. The

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1098,11 +1098,12 @@ jobs:
   # and the `dominant` corpus entry is pathologically slow at low order (in the
   # C as much as in the port). Too slow for a laptop, comfortable for a runner.
   #
-  # NOTE the C driver is pinned to -O1 inside ppmd-check.sh, and that is not a
-  # style choice: PPMd type-puns through `(WORD&)` in StateCpy/SWAP, so the
-  # compiler's aliasing assumptions change rescale()'s result and the SAME
-  # SOURCE EMITS DIFFERENT COMPRESSED BYTES at -O0 vs -O1. Compression/PPMD/
-  # makefile ships -O1, so -O1 is the only oracle that matches real archives.
+  # NOTE the C driver is built with Compression/PPMD/makefile's WHOLE flag list
+  # inside ppmd-check.sh, and that is not tidiness: PPMd type-puns through
+  # `(WORD&)` in StateCpy/SWAP, so a compiler's aliasing assumptions change
+  # rescale()'s result and THE SAME SOURCE EMITS DIFFERENT COMPRESSED BYTES.
+  # `-fno-strict-aliasing` is the flag that decides it, so pinning the -O level
+  # alone produces an oracle DArc does not ship. See the note in the script.
   rust-codecs-ppmd:
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -1143,7 +1144,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y liblua5.1-dev libncurses-dev libcurl4-openssl-dev cpphs
-    - name: PPMd differential test, wide grid (Rust vs C at -O1)
+    - name: PPMd differential test, wide grid (Rust vs the C as shipped)
       run: |
         chmod +x rust/difftest/*.sh
         start=$(date +%s)

--- a/rust/darc-codecs/src/exports.rs
+++ b/rust/darc-codecs/src/exports.rs
@@ -1543,7 +1543,7 @@ pub unsafe extern "C" fn darc_rs_ppmd_sa_stop() { sa().stop() }
 /// # Safety
 /// See [`darc_rs_ppmd_sa_start`].
 #[no_mangle]
-pub unsafe extern "C" fn darc_rs_ppmd_sa_used() -> u32 { sa().get_used_memory() as u32 }
+pub unsafe extern "C" fn darc_rs_ppmd_sa_used() -> u32 { sa().get_used_memory() }
 
 /// # Safety
 /// See [`darc_rs_ppmd_sa_start`].

--- a/rust/darc-codecs/src/exports.rs
+++ b/rust/darc-codecs/src/exports.rs
@@ -1493,3 +1493,120 @@ pub unsafe extern "C" fn grzip_compress(
         alternative_bwt_sort, adaptive_block_size, delta_filter, callback, auxdata,
     )
 }
+
+// ---------------------------------------------------------------------------
+// PPMd suballocator, for the allocator-level differential harness.
+//
+// The codec as a whole has no seam below the stream -- coder, model and
+// allocator are one system -- but the ALLOCATOR does have a testable
+// interface, and it is the part the compressed format is most sensitive to
+// (the model branches on GetUsedMemory() and on pText/UnitsStart crossings).
+// A single process-wide instance mirrors the C, whose allocator is file-scope
+// state in Model.cpp's translation unit.
+//
+// Offsets, not pointers: the C's heap is a malloc'ed block, this one is a
+// Vec<u8>, and only HeapStart-relative positions are comparable. -1 is NULL.
+// ---------------------------------------------------------------------------
+
+static mut PPMD_SA: Option<bsc_ppmd_sa::SubAllocator> = None;
+
+mod bsc_ppmd_sa {
+    pub use crate::ppmd::suballoc::SubAllocator;
+}
+
+#[inline]
+#[allow(static_mut_refs)]
+unsafe fn sa() -> &'static mut bsc_ppmd_sa::SubAllocator {
+    if PPMD_SA.is_none() {
+        PPMD_SA = Some(bsc_ppmd_sa::SubAllocator::new());
+    }
+    PPMD_SA.as_mut().unwrap()
+}
+
+/// # Safety
+/// Single-threaded harness use only, mirroring the C's file-scope allocator.
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_ppmd_sa_start(t: u32) -> i64 {
+    if sa().start(t as usize) { 1 } else { 0 }
+}
+
+/// # Safety
+/// See [`darc_rs_ppmd_sa_start`].
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_ppmd_sa_init() { sa().init() }
+
+/// # Safety
+/// See [`darc_rs_ppmd_sa_start`].
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_ppmd_sa_stop() { sa().stop() }
+
+/// # Safety
+/// See [`darc_rs_ppmd_sa_start`].
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_ppmd_sa_used() -> u32 { sa().get_used_memory() as u32 }
+
+/// # Safety
+/// See [`darc_rs_ppmd_sa_start`].
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_ppmd_sa_alloc_units(nu: u32) -> i64 {
+    let p = sa().alloc_units(nu as usize);
+    if p == 0 { -1 } else { p as i64 }
+}
+
+/// # Safety
+/// See [`darc_rs_ppmd_sa_start`].
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_ppmd_sa_alloc_context() -> i64 {
+    let p = sa().alloc_context();
+    if p == 0 { -1 } else { p as i64 }
+}
+
+/// # Safety
+/// See [`darc_rs_ppmd_sa_start`].
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_ppmd_sa_free_units(off: i64, nu: u32) {
+    sa().free_units(off as usize, nu as usize)
+}
+
+/// # Safety
+/// See [`darc_rs_ppmd_sa_start`].
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_ppmd_sa_expand_units(off: i64, nu: u32) -> i64 {
+    let p = sa().expand_units(off as usize, nu as usize);
+    if p == 0 { -1 } else { p as i64 }
+}
+
+/// # Safety
+/// See [`darc_rs_ppmd_sa_start`].
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_ppmd_sa_shrink_units(off: i64, nu: u32, newnu: u32) -> i64 {
+    let p = sa().shrink_units(off as usize, nu as usize, newnu as usize);
+    if p == 0 { -1 } else { p as i64 }
+}
+
+/// # Safety
+/// See [`darc_rs_ppmd_sa_start`].
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_ppmd_sa_special_free(off: i64) {
+    sa().special_free_unit(off as usize)
+}
+
+/// # Safety
+/// See [`darc_rs_ppmd_sa_start`].
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_ppmd_sa_ptext() -> i64 { sa().p_text as i64 }
+
+/// # Safety
+/// See [`darc_rs_ppmd_sa_start`].
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_ppmd_sa_units_start() -> i64 { sa().units_start as i64 }
+
+/// # Safety
+/// See [`darc_rs_ppmd_sa_start`].
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_ppmd_sa_lo_unit() -> i64 { sa().lo_unit as i64 }
+
+/// # Safety
+/// See [`darc_rs_ppmd_sa_start`].
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_ppmd_sa_hi_unit() -> i64 { sa().hi_unit as i64 }

--- a/rust/darc-codecs/src/exports.rs
+++ b/rust/darc-codecs/src/exports.rs
@@ -8,7 +8,7 @@
 //! what wires them together; until then these are exercised by the differential
 //! harness rather than by the archiver.
 
-use crate::{bsc, delta, dict, dict_encode, dispack, grzip, lz4, lz4hc, lzp, mm, rep, tornado, tta, zstd};
+use crate::{bsc, delta, ppmd, dict, dict_encode, dispack, grzip, lz4, lz4hc, lzp, mm, rep, tornado, tta, zstd};
 use crate::ffi::{Io, CALLBACK_FUNC, FREEARC_ERRCODE_GENERAL};
 use core::ffi::{c_int, c_void};
 
@@ -1610,3 +1610,33 @@ pub unsafe extern "C" fn darc_rs_ppmd_sa_lo_unit() -> i64 { sa().lo_unit as i64 
 /// See [`darc_rs_ppmd_sa_start`].
 #[no_mangle]
 pub unsafe extern "C" fn darc_rs_ppmd_sa_hi_unit() -> i64 { sa().hi_unit as i64 }
+
+/// `ppmd_compress`: PPMd var.H encode. Callback-driven, like the C.
+///
+/// # Safety
+/// `callback` and `auxdata` must be what the C caller supplied.
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_ppmd_compress(
+    order: c_int, mem: u32, mr_method: c_int,
+    callback: CALLBACK_FUNC, auxdata: *mut c_void,
+) -> c_int {
+    match Io::new(callback, auxdata) {
+        Some(io) => ppmd::compress(&io, order, mem, mr_method),
+        None => FREEARC_ERRCODE_GENERAL,
+    }
+}
+
+/// `ppmd_decompress`: PPMd var.H decode.
+///
+/// # Safety
+/// `callback` and `auxdata` must be what the C caller supplied.
+#[no_mangle]
+pub unsafe extern "C" fn darc_rs_ppmd_decompress(
+    order: c_int, mem: u32, mr_method: c_int,
+    callback: CALLBACK_FUNC, auxdata: *mut c_void,
+) -> c_int {
+    match Io::new(callback, auxdata) {
+        Some(io) => ppmd::decompress(&io, order, mem, mr_method),
+        None => FREEARC_ERRCODE_GENERAL,
+    }
+}

--- a/rust/darc-codecs/src/lib.rs
+++ b/rust/darc-codecs/src/lib.rs
@@ -16,6 +16,7 @@ pub mod grzip;
 pub mod lz4;
 pub mod lz4hc;
 pub mod lzp;
+pub mod ppmd;
 pub mod mm;
 pub mod mmdet;
 pub mod rep;

--- a/rust/darc-codecs/src/ppmd/coder.rs
+++ b/rust/darc-codecs/src/ppmd/coder.rs
@@ -1,0 +1,168 @@
+//! Dmitry Subbotin's carryless range coder, ported from
+//! `Compression/PPMD/Coder.hpp`.
+//!
+//! The file carries the author's original class in a comment block above the
+//! macro implementation PPMd actually uses. **The two disagree**, and the live
+//! code is what matters: the commented original has `BOT = 1<<16`, the macros
+//! below it use `1<<15`. Values here are read from the macros, not from the
+//! prose above them.
+//!
+//! `low`, `code` and `range` are 32-bit and rely on wrapping arithmetic
+//! throughout -- `-low` in the normalisation condition is a wrapping negation
+//! of an unsigned, which is why every operation here is explicitly `wrapping_`.
+
+use super::stream::PrimeStream;
+
+pub const TOP: u32 = 1 << 24;
+pub const BOT: u32 = 1 << 15;
+
+/// The C's file-scope `SubRange`, `low`, `code` and `range`. Grouped into one
+/// struct rather than left as globals, since the encoder and decoder each need
+/// their own -- `C_PPMD.cpp` includes `Model.cpp` twice, in separate
+/// namespaces, so the C has two independent copies of exactly this state.
+#[derive(Default)]
+pub struct RangeCoder {
+    pub low_count: u32,
+    pub high_count: u32,
+    pub scale: u32,
+
+    pub low: u32,
+    pub code: u32,
+    pub range: u32,
+}
+
+impl RangeCoder {
+    pub fn new() -> Self {
+        RangeCoder::default()
+    }
+
+    /// `ariInitEncoder`.
+    pub fn init_encoder(&mut self) {
+        self.low = 0;
+        self.range = u32::MAX;
+    }
+
+    /// `ARI_INIT_DECODER`: prime `code` with the first four bytes.
+    pub fn init_decoder(&mut self, s: &mut PrimeStream) {
+        self.low = 0;
+        self.code = 0;
+        self.range = u32::MAX;
+        for _ in 0..4 {
+            self.code = (self.code << 8) | (s.get() as u32 & 0xff);
+        }
+    }
+
+    /// `ARI_ENC_NORMALIZE`.
+    ///
+    /// The condition is one expression in the C with a side effect in its
+    /// second half: `range < BOT && ((range = -low & (BOT-1)), 1)`. The
+    /// assignment happens only when the first test fails and `range < BOT`
+    /// holds, and it must not happen otherwise -- writing this as two separate
+    /// `if`s changes when `range` is clamped.
+    pub fn encode_normalize(&mut self, s: &mut PrimeStream) {
+        loop {
+            if (self.low ^ self.low.wrapping_add(self.range)) < TOP {
+                // fall through to the emit below
+            } else if self.range < BOT {
+                self.range = self.low.wrapping_neg() & (BOT - 1);
+            } else {
+                break;
+            }
+            s.put((self.low >> 24) as u8);
+            self.range <<= 8;
+            self.low <<= 8;
+        }
+    }
+
+    /// `ARI_DEC_NORMALIZE`: the same condition, reading instead of writing.
+    pub fn decode_normalize(&mut self, s: &mut PrimeStream) {
+        loop {
+            if (self.low ^ self.low.wrapping_add(self.range)) < TOP {
+            } else if self.range < BOT {
+                self.range = self.low.wrapping_neg() & (BOT - 1);
+            } else {
+                break;
+            }
+            self.code = (self.code << 8) | (s.get() as u32 & 0xff);
+            self.range <<= 8;
+            self.low <<= 8;
+        }
+    }
+
+    /// `ariEncodeSymbol`.
+    pub fn encode_symbol(&mut self) {
+        self.range /= self.scale;
+        self.low = self
+            .low
+            .wrapping_add(self.low_count.wrapping_mul(self.range));
+        self.range = self.range.wrapping_mul(self.high_count - self.low_count);
+    }
+
+    /// `ariShiftEncodeSymbol`: the same, with a shift in place of the divide.
+    pub fn shift_encode_symbol(&mut self, shift: u32) {
+        self.range >>= shift;
+        self.low = self
+            .low
+            .wrapping_add(self.low_count.wrapping_mul(self.range));
+        self.range = self.range.wrapping_mul(self.high_count - self.low_count);
+    }
+
+    /// `ARI_FLUSH_ENCODER`: four bytes of `low`.
+    pub fn flush_encoder(&mut self, s: &mut PrimeStream) {
+        for _ in 0..4 {
+            s.put((self.low >> 24) as u8);
+            self.low <<= 8;
+        }
+    }
+
+    /// `ariGetCurrentCount`. Note it MUTATES `range` (`range /= scale`), so it
+    /// cannot be called twice for one symbol.
+    pub fn get_current_count(&mut self) -> u32 {
+        self.range /= self.scale;
+        self.code.wrapping_sub(self.low) / self.range
+    }
+
+    /// `ariGetCurrentShiftCount`. Also mutates `range`.
+    pub fn get_current_shift_count(&mut self, shift: u32) -> u32 {
+        self.range >>= shift;
+        self.code.wrapping_sub(self.low) / self.range
+    }
+
+    /// `ariRemoveSubrange`.
+    pub fn remove_subrange(&mut self) {
+        self.low = self
+            .low
+            .wrapping_add(self.range.wrapping_mul(self.low_count));
+        self.range = self.range.wrapping_mul(self.high_count - self.low_count);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constants_are_read_from_the_macros_not_the_comment() {
+        assert_eq!(TOP, 1 << 24);
+        // The commented-out original above the macros says 1<<16. The macros
+        // PPMd actually compiles say 1<<15, and that is what the format uses.
+        assert_eq!(BOT, 1 << 15);
+    }
+
+    #[test]
+    fn init_encoder_sets_full_range() {
+        let mut rc = RangeCoder::new();
+        rc.init_encoder();
+        assert_eq!(rc.low, 0);
+        assert_eq!(rc.range, u32::MAX);
+    }
+
+    /// `low.wrapping_neg()` is the C's `-low` on an unsigned, which is where a
+    /// naive port using a signed negation would diverge.
+    #[test]
+    fn wrapping_negation_matches_c_unsigned_semantics() {
+        assert_eq!(1u32.wrapping_neg(), 0xffff_ffff);
+        assert_eq!(0u32.wrapping_neg(), 0);
+        assert_eq!(0x0000_8000u32.wrapping_neg() & (BOT - 1), 0);
+    }
+}

--- a/rust/darc-codecs/src/ppmd/mod.rs
+++ b/rust/darc-codecs/src/ppmd/mod.rs
@@ -5,4 +5,50 @@
 //! part of the compressed format. See [`suballoc`] for the measurement that
 //! establishes this.
 
+pub mod coder;
+pub mod model;
+pub mod stream;
 pub mod suballoc;
+
+use crate::ffi::{Io, FREEARC_ERRCODE_NOT_ENOUGH_MEMORY, OK};
+use core::ffi::c_int;
+use model::Model;
+use stream::PrimeStream;
+
+/// `ppmd_compress` (`C_PPMD.cpp:37`).
+///
+/// The C builds TWO `PRIME_STREAM`s over the same callback -- one that issues
+/// "read" requests and one that issues "write" -- and that pairing is kept
+/// here, since each carries its own 64 KB buffer.
+pub fn compress(io: &Io, order: i32, mem: u32, mr_method: i32) -> c_int {
+    let mut m = Model::new();
+    if !m.sa.start(mem as usize) {
+        return FREEARC_ERRCODE_NOT_ENOUGH_MEMORY as c_int;
+    }
+    let mut fp_in = PrimeStream::new_reader(io);
+    let mut fp_out = PrimeStream::new_writer(io);
+    m.encode_file(&mut fp_out, &mut fp_in, order, mr_method);
+    fp_out.flush();
+    let mut err = OK;
+    if fp_in.error() < 0 { err = fp_in.error(); }
+    if fp_out.error() < 0 { err = fp_out.error(); }
+    m.sa.stop();
+    err
+}
+
+/// `ppmd_decompress` (`C_PPMD.cpp:75`).
+pub fn decompress(io: &Io, order: i32, mem: u32, mr_method: i32) -> c_int {
+    let mut m = Model::new();
+    if !m.sa.start(mem as usize) {
+        return FREEARC_ERRCODE_NOT_ENOUGH_MEMORY as c_int;
+    }
+    let mut fp_in = PrimeStream::new_reader(io);
+    let mut fp_out = PrimeStream::new_writer(io);
+    m.decode_file(&mut fp_out, &mut fp_in, order, mr_method);
+    fp_out.flush();
+    let mut err = OK;
+    if fp_in.error() < 0 { err = fp_in.error(); }
+    if fp_out.error() < 0 { err = fp_out.error(); }
+    m.sa.stop();
+    err
+}

--- a/rust/darc-codecs/src/ppmd/mod.rs
+++ b/rust/darc-codecs/src/ppmd/mod.rs
@@ -1,0 +1,8 @@
+//! PPMd var.H, ported from `Compression/PPMD/`.
+//!
+//! Unlike the other codecs here, this one admits no algorithmic latitude: the
+//! model branches on its own allocator's state, so the suballocator's layout is
+//! part of the compressed format. See [`suballoc`] for the measurement that
+//! establishes this.
+
+pub mod suballoc;

--- a/rust/darc-codecs/src/ppmd/model.rs
+++ b/rust/darc-codecs/src/ppmd/model.rs
@@ -1,0 +1,1545 @@
+//! The PPMII model, ported from `Compression/PPMD/Model.cpp`.
+//!
+//! # Memory layout, which is the whole difficulty
+//!
+//! The C works in raw pointers into the suballocator's heap; here every
+//! pointer is a byte offset into [`SubAllocator`]'s `Vec<u8>`. The C already
+//! stores intra-heap references as 32-bit offsets (`CTX_REF`/`STATE_REF`, added
+//! for 64-bit portability) so that `PPM_CONTEXT` stays exactly `UNIT_SIZE` = 12
+//! bytes, and this port keeps those on-heap layouts byte for byte:
+//!
+//! ```text
+//! PPM_CONTEXT @ c        STATE @ s
+//!   c+0  NumStats  u8      s+0  Symbol     u8
+//!   c+1  Flags     u8      s+1  Freq       u8
+//!   c+2  SummFreq  u16     s+2  Successor  u32   (CTX_REF)
+//!   c+4  Stats     u32
+//!   c+8  Suffix    u32
+//! ```
+//!
+//! **`oneState()` is a union, not a field.** The C writes
+//! `return (STATE&) SummFreq`, so a single-symbol context stores its state
+//! *overlapping* `SummFreq` and `Stats`: symbol at `c+2`, freq at `c+3`,
+//! successor at `c+4..c+8` — i.e. exactly on top of `Stats`. Getting this wrong
+//! would not crash, it would silently corrupt one field with another.
+//!
+//! Refs are 1-based (`ref = offset + 1`, 0 = NULL) so that `pText == HeapStart`
+//! can be stored in a `Successor` without being mistaken for NULL.
+//!
+//! # No seam
+//!
+//! There is no stage boundary inside this file at which a partial port could be
+//! compared against the C: the coder, the model and the allocator branch on
+//! each other. See [`super::suballoc`] for the measurement that establishes it.
+
+use super::coder::{RangeCoder, TOP};
+use super::stream::PrimeStream;
+use super::suballoc::SubAllocator;
+
+const UP_FREQ: usize = 5;
+const INT_BITS: u32 = 7;
+const PERIOD_BITS: u32 = 7;
+pub const TOT_BITS: u32 = INT_BITS + PERIOD_BITS;
+const INTERVAL: u32 = 1 << INT_BITS;
+const BIN_SCALE: u32 = 1 << TOT_BITS;
+const MAX_FREQ: u32 = 124;
+const O_BOUND: i32 = 9;
+const MAX_O: usize = 128;
+
+/// `PPMdSignature` from PPMdType.h, stamped into `DummySEE2Cont`.
+const PPMD_SIGNATURE: u32 = 0x84AC_AF8F;
+
+const INIT_BIN_ESC: [u16; 8] = [
+    0x3CDD, 0x1F3F, 0x59BF, 0x48F3, 0x64A1, 0x5ABC, 0x6632, 0x6051,
+];
+
+/// Tabulated escapes for an exponential symbol distribution.
+const EXP_ESCAPE: [u8; 16] = [25, 14, 9, 7, 5, 5, 4, 4, 4, 3, 3, 3, 2, 2, 2, 2];
+
+/// `MR_METHOD`: what to do when the model runs out of memory.
+pub const MRM_RESTART: i32 = 0;
+pub const MRM_CUT_OFF: i32 = 1;
+pub const MRM_FREEZE: i32 = 2;
+
+#[inline]
+fn get_mean(summ: u32, shift: u32, round: u32) -> u32 {
+    (summ + (1 << (shift - round))) >> shift
+}
+
+/// SEE-context for PPM-contexts with masked symbols.
+#[derive(Clone, Copy, Default)]
+struct See2Context {
+    summ: u16,
+    shift: u8,
+    count: u8,
+}
+
+impl See2Context {
+    fn init(&mut self, init_val: u32) {
+        self.shift = (PERIOD_BITS - 4) as u8;
+        self.summ = (init_val << self.shift) as u16;
+        self.count = 7;
+    }
+    fn get_mean(&mut self) -> u32 {
+        let ret = (self.summ >> self.shift) as u32;
+        self.summ = self.summ.wrapping_sub(ret as u16);
+        ret + (ret == 0) as u32
+    }
+    fn update(&mut self) {
+        if (self.shift as u32) < PERIOD_BITS {
+            self.count -= 1;
+            if self.count == 0 {
+                self.summ = self.summ.wrapping_add(self.summ);
+                self.count = 3 << self.shift;
+                self.shift += 1;
+            }
+        }
+    }
+}
+
+pub struct Model {
+    pub sa: SubAllocator,
+    pub rc: RangeCoder,
+
+    see2cont: [[See2Context; 32]; 24],
+    dummy_see2cont: See2Context,
+    bin_summ: [[u16; 64]; 25],
+
+    ns2bs_indx: [u8; 256],
+    q_table: [u8; 260],
+    char_mask: [u8; 256],
+
+    /// Offsets, 0 = NULL. State offsets are always inside the units area, so
+    /// 0 is never a legitimate state and doubles as the null sentinel exactly
+    /// as the C's NULL pointer does.
+    found_state: usize,
+    max_context: usize,
+
+    init_esc: u32,
+    order_fall: i32,
+    run_length: i32,
+    init_rl: i32,
+    max_order: i32,
+    num_masked: u32,
+    prev_success: u32,
+    esc_count: u8,
+    print_count: u8,
+    mr_method: i32,
+    resc_n: u32,
+}
+
+impl Model {
+    pub fn new() -> Self {
+        let mut m = Model {
+            sa: SubAllocator::new(),
+            rc: RangeCoder::new(),
+            see2cont: [[See2Context::default(); 32]; 24],
+            dummy_see2cont: See2Context::default(),
+            bin_summ: [[0u16; 64]; 25],
+            ns2bs_indx: [0; 256],
+            q_table: [0; 260],
+            char_mask: [0; 256],
+            found_state: 0,
+            max_context: 0,
+            init_esc: 0,
+            order_fall: 0,
+            run_length: 0,
+            init_rl: 0,
+            max_order: 0,
+            num_masked: 0,
+            prev_success: 0,
+            esc_count: 0,
+            print_count: 0,
+            mr_method: MRM_RESTART,
+            resc_n: 0,
+        };
+        m.startup();
+        m
+    }
+
+    /// `PPMD_STARTUP`: the constant tables. The suballocator builds its own
+    /// index tables in `SubAllocator::new`, which is the same code.
+    fn startup(&mut self) {
+        self.ns2bs_indx[0] = 0;
+        self.ns2bs_indx[1] = 2;
+        for i in 2..11 {
+            self.ns2bs_indx[i] = 4;
+        }
+        for i in 11..256 {
+            self.ns2bs_indx[i] = 6;
+        }
+        for i in 0..UP_FREQ {
+            self.q_table[i] = i as u8;
+        }
+        let mut m = UP_FREQ;
+        let mut k = 1usize;
+        let mut step = 1usize;
+        for i in UP_FREQ..260 {
+            self.q_table[i] = m as u8;
+            k -= 1;
+            if k == 0 {
+                step += 1;
+                k = step;
+                m += 1;
+            }
+        }
+        // `(unsigned int&) DummySEE2Cont = PPMdSignature` -- the signature is
+        // written over the whole 4-byte struct, so Summ/Shift/Count take its
+        // bytes. Little-endian, matching every target this builds for.
+        let b = PPMD_SIGNATURE.to_le_bytes();
+        self.dummy_see2cont.summ = u16::from_le_bytes([b[0], b[1]]);
+        self.dummy_see2cont.shift = b[2];
+        self.dummy_see2cont.count = b[3];
+    }
+
+    // --- heap field accessors --------------------------------------------
+
+    #[inline]
+    fn rd8(&self, at: usize) -> u8 {
+        self.sa.heap()[at]
+    }
+    #[inline]
+    fn wr8(&mut self, at: usize, v: u8) {
+        self.sa.heap_mut()[at] = v;
+    }
+    #[inline]
+    fn rd16(&self, at: usize) -> u16 {
+        let h = self.sa.heap();
+        u16::from_le_bytes([h[at], h[at + 1]])
+    }
+    #[inline]
+    fn wr16(&mut self, at: usize, v: u16) {
+        self.sa.heap_mut()[at..at + 2].copy_from_slice(&v.to_le_bytes());
+    }
+    #[inline]
+    fn rd32(&self, at: usize) -> u32 {
+        let h = self.sa.heap();
+        u32::from_le_bytes([h[at], h[at + 1], h[at + 2], h[at + 3]])
+    }
+    #[inline]
+    fn wr32(&mut self, at: usize, v: u32) {
+        self.sa.heap_mut()[at..at + 4].copy_from_slice(&v.to_le_bytes());
+    }
+
+    /// Ref (1-based) from offset. The C's `RPCTX`/`RPSTAT`/`BREF`.
+    #[inline]
+    fn rref(off: usize) -> u32 {
+        (off + 1) as u32
+    }
+    /// Offset from ref; 0 stays 0 and callers must not dereference it.
+    #[inline]
+    fn roff(r: u32) -> usize {
+        if r == 0 { 0 } else { (r - 1) as usize }
+    }
+
+    // context fields
+    #[inline]
+    fn ns(&self, c: usize) -> u8 { self.rd8(c) }
+    #[inline]
+    fn set_ns(&mut self, c: usize, v: u8) { self.wr8(c, v) }
+    #[inline]
+    fn flags(&self, c: usize) -> u8 { self.rd8(c + 1) }
+    #[inline]
+    fn set_flags(&mut self, c: usize, v: u8) { self.wr8(c + 1, v) }
+    #[inline]
+    fn summ_freq(&self, c: usize) -> u32 { self.rd16(c + 2) as u32 }
+    #[inline]
+    fn set_summ_freq(&mut self, c: usize, v: u32) { self.wr16(c + 2, v as u16) }
+    #[inline]
+    fn stats(&self, c: usize) -> u32 { self.rd32(c + 4) }
+    #[inline]
+    fn set_stats(&mut self, c: usize, v: u32) { self.wr32(c + 4, v) }
+    #[inline]
+    fn suffix(&self, c: usize) -> u32 { self.rd32(c + 8) }
+    #[inline]
+    fn set_suffix(&mut self, c: usize, v: u32) { self.wr32(c + 8, v) }
+    /// The union: a single-symbol context's state overlaps SummFreq/Stats.
+    #[inline]
+    fn one_state(c: usize) -> usize { c + 2 }
+
+    // state fields
+    #[inline]
+    fn sym(&self, s: usize) -> u8 { self.rd8(s) }
+    #[inline]
+    fn set_sym(&mut self, s: usize, v: u8) { self.wr8(s, v) }
+    #[inline]
+    fn freq(&self, s: usize) -> u32 { self.rd8(s + 1) as u32 }
+    #[inline]
+    fn set_freq(&mut self, s: usize, v: u32) { self.wr8(s + 1, v as u8) }
+    #[inline]
+    fn succ(&self, s: usize) -> u32 { self.rd32(s + 2) }
+    #[inline]
+    fn set_succ(&mut self, s: usize, v: u32) { self.wr32(s + 2, v) }
+
+    /// `SWAP`: the C swaps `(WORD&)` and `Successor` separately, which together
+    /// are the whole 6-byte state.
+    fn swap_states(&mut self, a: usize, b: usize) {
+        for i in 0..6 {
+            let t = self.rd8(a + i);
+            let u = self.rd8(b + i);
+            self.wr8(a + i, u);
+            self.wr8(b + i, t);
+        }
+    }
+
+    /// `StateCpy`.
+    fn state_cpy(&mut self, dst: usize, src: usize) {
+        for i in 0..6 {
+            let v = self.rd8(src + i);
+            self.wr8(dst + i, v);
+        }
+    }
+
+    /// `GE_UNITS(r)`: does this ref point into the unit-storage region?
+    #[inline]
+    fn ge_units(&self, r: u32) -> bool {
+        r != 0 && Self::roff(r) >= self.sa.units_start
+    }
+
+    // --- model construction ----------------------------------------------
+
+    /// `StartModelRare`.
+    pub fn start_model_rare(&mut self, max_order: i32, mr_method: i32) {
+        self.char_mask = [0; 256];
+        self.esc_count = 1;
+        self.print_count = 1;
+        if max_order < 2 {
+            // Solid mode: keep the tree, just recompute OrderFall.
+            self.order_fall = self.max_order;
+            let mut pc = self.max_context;
+            while self.suffix(pc) != 0 {
+                self.order_fall -= 1;
+                pc = Self::roff(self.suffix(pc));
+            }
+            return;
+        }
+        self.max_order = max_order;
+        self.order_fall = max_order;
+        self.mr_method = mr_method;
+        self.sa.init();
+        self.init_rl = -(if max_order < 12 { max_order } else { 12 }) - 1;
+        self.run_length = self.init_rl;
+
+        let mc = self.sa.alloc_context();
+        self.max_context = mc;
+        self.set_suffix(mc, 0);
+        self.set_ns(mc, 255);
+        self.set_summ_freq(mc, 255 + 2);
+        let stats = self.sa.alloc_units(256 / 2);
+        self.set_stats(mc, Self::rref(stats));
+        self.prev_success = 0;
+        for i in 0..256usize {
+            let p = stats + i * 6;
+            self.set_sym(p, i as u8);
+            self.set_freq(p, 1);
+            self.set_succ(p, 0);
+        }
+
+        let mut i = 0usize;
+        for m in 0..25usize {
+            while self.q_table[i] as usize == m {
+                i += 1;
+            }
+            for k in 0..8usize {
+                self.bin_summ[m][k] =
+                    (BIN_SCALE - INIT_BIN_ESC[k] as u32 / (i as u32 + 1)) as u16;
+            }
+            for k in (8..64).step_by(8) {
+                for j in 0..8 {
+                    self.bin_summ[m][k + j] = self.bin_summ[m][j];
+                }
+            }
+        }
+        let mut i = 0usize;
+        for m in 0..24usize {
+            while self.q_table[i + 3] as usize == m + 3 {
+                i += 1;
+            }
+            self.see2cont[m][0].init(2 * i as u32 + 5);
+            for k in 1..32 {
+                self.see2cont[m][k] = self.see2cont[m][0];
+            }
+        }
+    }
+
+    /// `PPM_CONTEXT::refresh`.
+    fn refresh(&mut self, c: usize, old_nu: usize, scale: bool) {
+        let sc = scale as u32;
+        let mut i = self.ns(c) as u32;
+        let n = ((i + 2) >> 1) as usize;
+        let p0 = self.sa.shrink_units(Self::roff(self.stats(c)), old_nu, n);
+        self.set_stats(c, Self::rref(p0));
+        let mut p = p0;
+        let f = self.flags(c);
+        self.set_flags(
+            c,
+            (f & (0x10 + 0x04 * sc as u8)) + 0x08 * (self.sym(p) >= 0x40) as u8,
+        );
+        let mut esc_freq = self.summ_freq(c) as i64 - self.freq(p) as i64;
+        let nf = (self.freq(p) + sc) >> sc;
+        self.set_freq(p, nf);
+        let mut summ = nf;
+        while i > 0 {
+            p += 6;
+            esc_freq -= self.freq(p) as i64;
+            let nf = (self.freq(p) + sc) >> sc;
+            self.set_freq(p, nf);
+            summ += nf;
+            let fl = self.flags(c) | 0x08 * (self.sym(p) >= 0x40) as u8;
+            self.set_flags(c, fl);
+            i -= 1;
+        }
+        let esc = ((esc_freq + sc as i64) >> sc) as u32;
+        self.set_summ_freq(c, summ + esc);
+    }
+
+    /// `PPM_CONTEXT::cutOff`. Returns 0 for the C's NULL.
+    fn cut_off(&mut self, c: usize, order: i32) -> usize {
+        if self.ns(c) == 0 {
+            let p = Self::one_state(c);
+            if self.ge_units(self.succ(p)) {
+                if order < self.max_order {
+                    let s = Self::roff(self.succ(p));
+                    let r = self.cut_off(s, order + 1);
+                    self.set_succ(p, if r == 0 { 0 } else { Self::rref(r) });
+                } else {
+                    self.set_succ(p, 0);
+                }
+                if self.succ(p) == 0 && order > O_BOUND {
+                    self.sa.special_free_unit(c);
+                    return 0;
+                }
+                return c;
+            } else {
+                self.sa.special_free_unit(c);
+                return 0;
+            }
+        }
+        let tmp = ((self.ns(c) as usize) + 2) >> 1;
+        let s_base = self.sa.move_units_up(Self::roff(self.stats(c)), tmp);
+        self.set_stats(c, Self::rref(s_base));
+        let ns = self.ns(c) as i32;
+        let mut i = ns;
+        let mut pi = ns;
+        while pi >= 0 {
+            let p = s_base + pi as usize * 6;
+            if !self.ge_units(self.succ(p)) {
+                self.set_succ(p, 0);
+                let other = s_base + i as usize * 6;
+                self.swap_states(p, other);
+                i -= 1;
+            } else if order < self.max_order {
+                let s = Self::roff(self.succ(p));
+                let r = self.cut_off(s, order + 1);
+                self.set_succ(p, if r == 0 { 0 } else { Self::rref(r) });
+            } else {
+                self.set_succ(p, 0);
+            }
+            pi -= 1;
+        }
+        if i != ns && order != 0 {
+            self.set_ns(c, i as u8);
+            let p = s_base;
+            if i < 0 {
+                self.sa.free_units(p, tmp);
+                self.sa.special_free_unit(c);
+                return 0;
+            } else if i == 0 {
+                let fl = (self.flags(c) & 0x10) + 0x08 * (self.sym(p) >= 0x40) as u8;
+                self.set_flags(c, fl);
+                let os = Self::one_state(c);
+                self.state_cpy(os, p);
+                self.sa.free_units(p, tmp);
+                let f = (self.freq(os) + 11) >> 3;
+                self.set_freq(os, f);
+            } else {
+                let scale = self.summ_freq(c) > 16 * i as u32;
+                self.refresh(c, tmp, scale);
+            }
+        }
+        c
+    }
+
+    /// `PPM_CONTEXT::removeBinConts`. Returns 0 for NULL.
+    fn remove_bin_conts(&mut self, c: usize, order: i32) -> usize {
+        if self.ns(c) == 0 {
+            let p = Self::one_state(c);
+            if self.ge_units(self.succ(p)) && order < self.max_order {
+                let s = Self::roff(self.succ(p));
+                let r = self.remove_bin_conts(s, order + 1);
+                self.set_succ(p, if r == 0 { 0 } else { Self::rref(r) });
+            } else {
+                self.set_succ(p, 0);
+            }
+            let suf = Self::roff(self.suffix(c));
+            if self.succ(p) == 0 && (self.ns(suf) == 0 || self.flags(suf) == 0xFF) {
+                self.sa.free_units(c, 1);
+                return 0;
+            }
+            return c;
+        }
+        let s_base = Self::roff(self.stats(c));
+        let mut pi = self.ns(c) as i32;
+        while pi >= 0 {
+            let p = s_base + pi as usize * 6;
+            if self.ge_units(self.succ(p)) && order < self.max_order {
+                let s = Self::roff(self.succ(p));
+                let r = self.remove_bin_conts(s, order + 1);
+                self.set_succ(p, if r == 0 { 0 } else { Self::rref(r) });
+            } else {
+                self.set_succ(p, 0);
+            }
+            pi -= 1;
+        }
+        c
+    }
+
+    /// `RestoreModelRare`.
+    fn restore_model_rare(&mut self, pc1: usize, min_context: usize, f_successor: usize) {
+        self.sa.p_text = 0;
+        let mut pc = self.max_context;
+        while pc != pc1 {
+            let ns = self.ns(pc);
+            if ns == 1 {
+                self.set_ns(pc, 0);
+                let st = Self::roff(self.stats(pc));
+                let fl = (self.flags(pc) & 0x10) + 0x08 * (self.sym(st) >= 0x40) as u8;
+                self.set_flags(pc, fl);
+                let os = Self::one_state(pc);
+                self.state_cpy(os, st);
+                self.sa.special_free_unit(st);
+                let f = (self.freq(os) + 11) >> 3;
+                self.set_freq(os, f);
+            } else {
+                self.set_ns(pc, ns - 1);
+                let nu = ((self.ns(pc) as usize) + 3) >> 1;
+                self.refresh(pc, nu, false);
+            }
+            pc = Self::roff(self.suffix(pc));
+        }
+        while pc != min_context {
+            if self.ns(pc) == 0 {
+                let os = Self::one_state(pc);
+                let f = self.freq(os);
+                self.set_freq(os, f - (f >> 1));
+            } else {
+                let sf = self.summ_freq(pc) + 4;
+                self.set_summ_freq(pc, sf);
+                if sf > 128 + 4 * self.ns(pc) as u32 {
+                    let nu = ((self.ns(pc) as usize) + 2) >> 1;
+                    self.refresh(pc, nu, true);
+                }
+            }
+            pc = Self::roff(self.suffix(pc));
+        }
+        if self.mr_method > MRM_FREEZE {
+            self.max_context = f_successor;
+            // `GlueCount += !(BList[1].Stamp & 1)`
+            self.sa.glue_count += (!self.sa.blist_stamp(1) & 1) as u32;
+        } else if self.mr_method == MRM_FREEZE {
+            while self.suffix(self.max_context) != 0 {
+                self.max_context = Self::roff(self.suffix(self.max_context));
+            }
+            let mc = self.max_context;
+            self.remove_bin_conts(mc, 0);
+            self.mr_method += 1;
+            self.sa.glue_count = 0;
+            self.order_fall = self.max_order;
+        } else if self.mr_method == MRM_RESTART
+            || self.sa.get_used_memory() < (self.sa.sub_allocator_size >> 1)
+        {
+            let (mo, mrm) = (self.max_order, self.mr_method);
+            self.start_model_rare(mo, mrm);
+            self.esc_count = 0;
+            self.print_count = 0xFF;
+        } else {
+            while self.suffix(self.max_context) != 0 {
+                self.max_context = Self::roff(self.suffix(self.max_context));
+            }
+            loop {
+                let mc = self.max_context;
+                self.cut_off(mc, 0);
+                self.sa.expand_text_area();
+                if self.sa.get_used_memory() <= 3 * (self.sa.sub_allocator_size >> 2) {
+                    break;
+                }
+            }
+            self.sa.glue_count = 0;
+            self.order_fall = self.max_order;
+        }
+    }
+
+    /// `ReduceOrder`. Returns 0 for NULL.
+    fn reduce_order(&mut self, mut p: usize, pc_in: usize) -> usize {
+        let mut ps = [0usize; MAX_O];
+        let mut n = 0usize;
+        let mut pc = pc_in;
+        let pc1 = pc_in;
+        let up_branch = Self::rref(self.sa.p_text);
+        let sym = self.sym(self.found_state);
+
+        ps[n] = self.found_state;
+        n += 1;
+        self.set_succ(self.found_state, up_branch);
+        self.order_fall += 1;
+
+        let mut entered = false;
+        if p != 0 {
+            pc = Self::roff(self.suffix(pc));
+            entered = true;
+        }
+        loop {
+            if !entered {
+                if self.suffix(pc) == 0 {
+                    if self.mr_method > MRM_FREEZE {
+                        while n > 0 {
+                            n -= 1;
+                            self.set_succ(ps[n], Self::rref(pc));
+                        }
+                        self.sa.p_text = 1;
+                        self.order_fall = 1;
+                    }
+                    return pc;
+                }
+                pc = Self::roff(self.suffix(pc));
+                if self.ns(pc) != 0 {
+                    p = Self::roff(self.stats(pc));
+                    if self.sym(p) != sym {
+                        loop {
+                            let t = self.sym(p + 6);
+                            p += 6;
+                            if t == sym {
+                                break;
+                            }
+                        }
+                    }
+                    let tmp = 2 * (self.freq(p) < MAX_FREQ - 9) as u32;
+                    let f = self.freq(p) + tmp;
+                    self.set_freq(p, f);
+                    let sf = self.summ_freq(pc) + tmp;
+                    self.set_summ_freq(pc, sf);
+                } else {
+                    p = Self::one_state(pc);
+                    let f = self.freq(p) + (self.freq(p) < 32) as u32;
+                    self.set_freq(p, f);
+                }
+            }
+            entered = false;
+            // LOOP_ENTRY
+            if self.succ(p) != 0 {
+                break;
+            }
+            ps[n] = p;
+            n += 1;
+            self.set_succ(p, up_branch);
+            self.order_fall += 1;
+        }
+        if self.mr_method > MRM_FREEZE {
+            pc = Self::roff(self.succ(p));
+            while n > 0 {
+                n -= 1;
+                self.set_succ(ps[n], Self::rref(pc));
+            }
+            self.sa.p_text = 1;
+            self.order_fall = 1;
+            return pc;
+        } else if self.succ(p) <= up_branch {
+            let p1 = self.found_state;
+            self.found_state = p;
+            let r = self.create_successors(false, 0, pc);
+            self.set_succ(p, if r == 0 { 0 } else { Self::rref(r) });
+            self.found_state = p1;
+        }
+        if self.order_fall == 1 && pc1 == self.max_context {
+            let s = self.succ(p);
+            self.set_succ(self.found_state, s);
+            self.sa.p_text -= 1;
+        }
+        Self::roff(self.succ(p))
+    }
+
+    /// `PPM_CONTEXT::rescale`.
+    fn rescale(&mut self, c: usize) {
+        self.resc_n += 1;
+        let s_base = Self::roff(self.stats(c));
+        let mut p = self.found_state;
+        while p != s_base {
+            self.swap_states(p, p - 6);
+            p -= 6;
+        }
+        let f = self.freq(p) + 4;
+        self.set_freq(p, f);
+        let sf = self.summ_freq(c) + 4;
+        self.set_summ_freq(c, sf);
+        // `UINT EscFreq` in the C -- UNSIGNED, unlike the `int EscFreq` in
+        // refresh(). It genuinely goes "negative" here and wraps, and the
+        // later `EscFreq >> 1` is then a LOGICAL shift of a huge value. Using a
+        // signed type keeps it negative and shifts arithmetically, which is the
+        // same for small values and diverges exactly when it wraps.
+        let mut esc_freq: u32 = self.summ_freq(c).wrapping_sub(self.freq(p));
+        let adder =
+            (self.order_fall != 0 || self.mr_method > MRM_FREEZE) as u32;
+        let nf = (self.freq(p) + adder) >> 1;
+        self.set_freq(p, nf);
+        let mut summ = nf;
+        // The value most recently ASSIGNED to p->Freq -- deliberately not a
+        // fresh read of the heap. See the note on the zero test below.
+        let mut last_nf = nf;
+        let mut i = self.ns(c) as u32;
+        while i > 0 {
+            p += 6;
+            esc_freq = esc_freq.wrapping_sub(self.freq(p));
+            let nf = (self.freq(p) + adder) >> 1;
+            self.set_freq(p, nf);
+            last_nf = nf;
+            summ += nf;
+            if self.freq(p) > self.freq(p - 6) {
+                // Bubble the state back into frequency order.
+                let mut tmp = [0u8; 6];
+                for k in 0..6 {
+                    tmp[k] = self.rd8(p + k);
+                }
+                let tmp_freq = tmp[1] as u32;
+                let mut p1 = p;
+                loop {
+                    self.state_cpy(p1, p1 - 6);
+                    p1 -= 6;
+                    if !(tmp_freq > self.freq(p1 - 6)) {
+                        break;
+                    }
+                }
+                for k in 0..6 {
+                    self.wr8(p1 + k, tmp[k]);
+                }
+            }
+            i -= 1;
+        }
+        self.set_summ_freq(c, summ);
+        // `if (p->Freq == 0)` in the C -- but NOT a re-read of the heap.
+        //
+        // StateCpy/SWAP type-pun through `(WORD&)` references, which violates
+        // strict aliasing. At -O1 the compiler therefore assumes those WORD
+        // writes cannot alias this BYTE read, and reuses the value ASSIGNED to
+        // p->Freq in the loop's final iteration -- even though the bubble sort
+        // has since overwritten that slot. At -O0 it re-reads and sees the new
+        // value, and the two builds produce DIFFERENT COMPRESSED OUTPUT from
+        // the same input. Measured on a 92-byte case: -O0 gives 669d679a...,
+        // -O1 and -O2 give f6cb8287....
+        //
+        // Compression/PPMD/makefile builds at -O1, so -O1 is the behaviour
+        // every existing -mppmd archive was produced with, and the one this
+        // port has to reproduce. Hence `last_nf`, not `self.freq(p)`.
+        if last_nf == 0 {
+            let mut i = 0u32;
+            loop {
+                i += 1;
+                p -= 6;
+                if self.freq(p) != 0 {
+                    break;
+                }
+            }
+            esc_freq = esc_freq.wrapping_add(i);
+            let old_nu = ((self.ns(c) as usize) + 2) >> 1;
+            let new_ns = self.ns(c) as u32 - i;
+            self.set_ns(c, new_ns as u8);
+            if new_ns == 0 {
+                let mut tmp = [0u8; 6];
+                for k in 0..6 {
+                    tmp[k] = self.rd8(s_base + k);
+                }
+                let mut tf = (2 * tmp[1] as u32).wrapping_add(esc_freq).wrapping_sub(1) / esc_freq;
+                if tf > MAX_FREQ / 3 {
+                    tf = MAX_FREQ / 3;
+                }
+                tmp[1] = tf as u8;
+                self.sa.free_units(s_base, old_nu);
+                let os = Self::one_state(c);
+                for k in 0..6 {
+                    self.wr8(os + k, tmp[k]);
+                }
+                let fl = (self.flags(c) & 0x10) + 0x08 * (tmp[0] >= 0x40) as u8;
+                self.set_flags(c, fl);
+                self.found_state = os;
+                return;
+            }
+            let nn = ((new_ns as usize) + 2) >> 1;
+            let nb = self.sa.shrink_units(s_base, old_nu, nn);
+            self.set_stats(c, Self::rref(nb));
+            let fl = self.flags(c) & !0x08;
+            self.set_flags(c, fl);
+            let mut i = new_ns;
+            let mut p = nb;
+            let fl = self.flags(c) | 0x08 * (self.sym(p) >= 0x40) as u8;
+            self.set_flags(c, fl);
+            while i > 0 {
+                p += 6;
+                let fl = self.flags(c) | 0x08 * (self.sym(p) >= 0x40) as u8;
+                self.set_flags(c, fl);
+                i -= 1;
+            }
+            let esc = esc_freq - (esc_freq >> 1);
+            let sf = self.summ_freq(c) + esc;
+            self.set_summ_freq(c, sf);
+            let fl = self.flags(c) | 0x04;
+            self.set_flags(c, fl);
+            self.found_state = nb;
+            return;
+        }
+        let esc = esc_freq - (esc_freq >> 1);
+        let sf = self.summ_freq(c) + esc;
+        self.set_summ_freq(c, sf);
+        let fl = self.flags(c) | 0x04;
+        self.set_flags(c, fl);
+        self.found_state = s_base;
+    }
+
+    /// `CreateSuccessors`. Returns 0 for NULL.
+    fn create_successors(&mut self, skip: bool, mut p: usize, pc_in: usize) -> usize {
+        let mut pc = pc_in;
+        let up_branch = self.succ(self.found_state);
+        let mut ps = [0usize; MAX_O];
+        let mut n = 0usize;
+        let sym = self.sym(self.found_state);
+
+        let mut no_loop = false;
+        if !skip {
+            ps[n] = self.found_state;
+            n += 1;
+            if self.suffix(pc) == 0 {
+                no_loop = true;
+            }
+        }
+        if !no_loop {
+            let mut entered = p != 0;
+            if entered {
+                pc = Self::roff(self.suffix(pc));
+            }
+            loop {
+                if !entered {
+                    pc = Self::roff(self.suffix(pc));
+                    if self.ns(pc) != 0 {
+                        p = Self::roff(self.stats(pc));
+                        if self.sym(p) != sym {
+                            loop {
+                                let t = self.sym(p + 6);
+                                p += 6;
+                                if t == sym {
+                                    break;
+                                }
+                            }
+                        }
+                        let tmp = (self.freq(p) < MAX_FREQ - 9) as u32;
+                        let f = self.freq(p) + tmp;
+                        self.set_freq(p, f);
+                        let sf = self.summ_freq(pc) + tmp;
+                        self.set_summ_freq(pc, sf);
+                    } else {
+                        p = Self::one_state(pc);
+                        let suf = Self::roff(self.suffix(pc));
+                        let inc = ((self.ns(suf) == 0) as u32) & ((self.freq(p) < 24) as u32);
+                        let f = self.freq(p) + inc;
+                        self.set_freq(p, f);
+                    }
+                }
+                entered = false;
+                // LOOP_ENTRY
+                if self.succ(p) != up_branch {
+                    pc = Self::roff(self.succ(p));
+                    break;
+                }
+                ps[n] = p;
+                n += 1;
+                if self.suffix(pc) == 0 {
+                    break;
+                }
+            }
+        }
+        // NO_LOOP
+        if n == 0 {
+            return pc;
+        }
+        // Build the template context in a local 12-byte buffer, as the C does
+        // with its stack `PPM_CONTEXT ct`.
+        let mut ct = [0u8; 12];
+        ct[0] = 0; // NumStats
+        let mut fl = 0x10 * (sym >= 0x40) as u8;
+        // ct.oneState() lives at offset 2 of the buffer, the SummFreq union.
+        let text_sym = self.rd8(Self::roff(up_branch));
+        ct[2] = text_sym;
+        ct[4..8].copy_from_slice(&(up_branch + 1).to_le_bytes());
+        fl |= 0x08 * (text_sym >= 0x40) as u8;
+        ct[1] = fl;
+
+        let one_freq;
+        if self.ns(pc) != 0 {
+            let mut q = Self::roff(self.stats(pc));
+            if self.sym(q) != text_sym {
+                loop {
+                    let t = self.sym(q + 6);
+                    q += 6;
+                    if t == text_sym {
+                        break;
+                    }
+                }
+            }
+            let cf = self.freq(q) - 1;
+            let s0 = self.summ_freq(pc) - self.ns(pc) as u32 - cf;
+            one_freq = 1 + if 2 * cf <= s0 {
+                (5 * cf > s0) as u32
+            } else {
+                (cf + 2 * s0 - 3) / s0
+            };
+        } else {
+            one_freq = self.freq(Self::one_state(pc));
+        }
+        ct[3] = one_freq as u8;
+
+        loop {
+            let pc1 = self.sa.alloc_context();
+            if pc1 == 0 {
+                return 0;
+            }
+            for k in 0..12 {
+                self.wr8(pc1 + k, ct[k]);
+            }
+            self.set_suffix(pc1, Self::rref(pc));
+            pc = pc1;
+            n -= 1;
+            self.set_succ(ps[n], Self::rref(pc));
+            if n == 0 {
+                break;
+            }
+        }
+        pc
+    }
+
+    /// `UpdateModel`.
+    fn update_model(&mut self, min_context: usize) {
+        let mut p = 0usize;
+        let mut pc1 = self.max_context;
+        let f_freq = self.freq(self.found_state);
+        let f_symbol = self.sym(self.found_state);
+        let mut f_successor = Self::roff(self.succ(self.found_state));
+        let had_successor = self.succ(self.found_state) != 0;
+        let pc = Self::roff(self.suffix(min_context));
+
+        if f_freq < MAX_FREQ / 4 && self.suffix(min_context) != 0 {
+            if self.ns(pc) != 0 {
+                p = Self::roff(self.stats(pc));
+                if self.sym(p) != f_symbol {
+                    loop {
+                        let s = self.sym(p + 6);
+                        p += 6;
+                        if s == f_symbol {
+                            break;
+                        }
+                    }
+                    if self.freq(p) >= self.freq(p - 6) {
+                        self.swap_states(p, p - 6);
+                        p -= 6;
+                    }
+                }
+                let cf = 2 * (self.freq(p) < MAX_FREQ - 9) as u32;
+                let f = self.freq(p) + cf;
+                self.set_freq(p, f);
+                let sf = self.summ_freq(pc) + cf;
+                self.set_summ_freq(pc, sf);
+            } else {
+                p = Self::one_state(pc);
+                let f = self.freq(p) + (self.freq(p) < 32) as u32;
+                self.set_freq(p, f);
+            }
+        }
+
+        if self.order_fall == 0 && had_successor {
+            let r = self.create_successors(true, p, min_context);
+            if r == 0 {
+                self.restore_model_rare(pc1, min_context, f_successor);
+                return;
+            }
+            self.set_succ(self.found_state, Self::rref(r));
+            self.max_context = r;
+            return;
+        }
+
+        self.wr8(self.sa.p_text, f_symbol);
+        self.sa.p_text += 1;
+        let mut successor = self.sa.p_text;
+        if self.sa.p_text >= self.sa.units_start {
+            self.restore_model_rare(pc1, min_context, f_successor);
+            return;
+        }
+
+        if had_successor {
+            if f_successor < self.sa.units_start {
+                f_successor = self.create_successors(false, p, min_context);
+            }
+        } else {
+            f_successor = self.reduce_order(p, min_context);
+        }
+        if f_successor == 0 {
+            self.restore_model_rare(pc1, min_context, f_successor);
+            return;
+        }
+        self.order_fall -= 1;
+        if self.order_fall == 0 {
+            successor = f_successor;
+            if self.max_context != min_context {
+                self.sa.p_text -= 1;
+            }
+        } else if self.mr_method > MRM_FREEZE {
+            successor = f_successor;
+            self.sa.p_text = 0;
+            self.order_fall = 0;
+        }
+
+        let ns = self.ns(min_context) as u32;
+        let s0 = self.summ_freq(min_context) - ns - f_freq;
+        let flag = 0x08 * (f_symbol >= 0x40) as u8;
+        while pc1 != min_context {
+            let ns1 = self.ns(pc1) as u32;
+            if ns1 != 0 {
+                if (ns1 & 1) != 0 {
+                    let np = self
+                        .sa
+                        .expand_units(Self::roff(self.stats(pc1)), ((ns1 + 1) >> 1) as usize);
+                    if np == 0 {
+                        self.restore_model_rare(pc1, min_context, f_successor);
+                        return;
+                    }
+                    self.set_stats(pc1, Self::rref(np));
+                }
+                let sf = self.summ_freq(pc1) + (3 * ns1 + 1 < ns) as u32;
+                self.set_summ_freq(pc1, sf);
+            } else {
+                let np = self.sa.alloc_units(1);
+                if np == 0 {
+                    self.restore_model_rare(pc1, min_context, f_successor);
+                    return;
+                }
+                let os = Self::one_state(pc1);
+                self.state_cpy(np, os);
+                self.set_stats(pc1, Self::rref(np));
+                let f = self.freq(np);
+                if f < MAX_FREQ / 4 - 1 {
+                    self.set_freq(np, f + f);
+                } else {
+                    self.set_freq(np, MAX_FREQ - 4);
+                }
+                let sf = self.freq(np) + self.init_esc + (ns > 2) as u32;
+                self.set_summ_freq(pc1, sf);
+            }
+            let mut cf = 2 * f_freq * (self.summ_freq(pc1) + 6);
+            let sf2 = s0 + self.summ_freq(pc1);
+            if cf < 6 * sf2 {
+                cf = 1 + (cf > sf2) as u32 + (cf >= 4 * sf2) as u32;
+                let s = self.summ_freq(pc1) + 4;
+                self.set_summ_freq(pc1, s);
+            } else {
+                cf = 4 + (cf > 9 * sf2) as u32
+                    + (cf > 12 * sf2) as u32
+                    + (cf > 15 * sf2) as u32;
+                let s = self.summ_freq(pc1) + cf;
+                self.set_summ_freq(pc1, s);
+            }
+            let new_ns = self.ns(pc1) + 1;
+            self.set_ns(pc1, new_ns);
+            let np = Self::roff(self.stats(pc1)) + new_ns as usize * 6;
+            self.set_succ(np, Self::rref(successor));
+            self.set_sym(np, f_symbol);
+            self.set_freq(np, cf);
+            let fl = self.flags(pc1) | flag;
+            self.set_flags(pc1, fl);
+
+            pc1 = Self::roff(self.suffix(pc1));
+        }
+        self.max_context = f_successor;
+    }
+}
+
+// --- symbol coding --------------------------------------------------------
+
+impl Model {
+    /// The binary-context SEE slot. `RunLength >> 26` is an ARITHMETIC shift of
+    /// a signed int in the C, so a negative run length sets bit 5 -- using a
+    /// logical shift here would pick the wrong half of the table.
+    #[inline]
+    fn bin_summ_idx(&self, c: usize) -> (usize, usize) {
+        let rs = Self::one_state(c);
+        let suf = Self::roff(self.suffix(c));
+        let indx = self.ns2bs_indx[self.ns(suf) as usize] as usize
+            + self.prev_success as usize
+            + self.flags(c) as usize;
+        let row = self.q_table[(self.freq(rs) - 1) as usize] as usize;
+        let col = indx + ((self.run_length >> 26) & 0x20) as usize;
+        (row, col)
+    }
+
+    /// `PPM_CONTEXT::encodeBinSymbol`.
+    fn encode_bin_symbol(&mut self, c: usize, symbol: i32) {
+        let (row, col) = self.bin_summ_idx(c);
+        let rs = Self::one_state(c);
+        let bs = self.bin_summ[row][col] as u32;
+        if self.sym(rs) as i32 == symbol {
+            self.found_state = rs;
+            let f = self.freq(rs) + (self.freq(rs) < 196) as u32;
+            self.set_freq(rs, f);
+            self.rc.low_count = 0;
+            self.rc.high_count = bs;
+            self.bin_summ[row][col] =
+                (bs + INTERVAL - get_mean(bs, PERIOD_BITS, 2)) as u16;
+            self.prev_success = 1;
+            self.run_length += 1;
+        } else {
+            self.rc.low_count = bs;
+            let nb = bs - get_mean(bs, PERIOD_BITS, 2);
+            self.bin_summ[row][col] = nb as u16;
+            self.rc.high_count = BIN_SCALE;
+            self.init_esc = EXP_ESCAPE[(nb >> 10) as usize] as u32;
+            let s = self.sym(rs) as usize;
+            self.char_mask[s] = self.esc_count;
+            self.num_masked = 0;
+            self.prev_success = 0;
+            self.found_state = 0;
+        }
+    }
+
+    /// `PPM_CONTEXT::decodeBinSymbol`.
+    fn decode_bin_symbol(&mut self, c: usize) {
+        let (row, col) = self.bin_summ_idx(c);
+        let rs = Self::one_state(c);
+        let bs = self.bin_summ[row][col] as u32;
+        if self.rc.get_current_shift_count(TOT_BITS) < bs {
+            self.found_state = rs;
+            let f = self.freq(rs) + (self.freq(rs) < 196) as u32;
+            self.set_freq(rs, f);
+            self.rc.low_count = 0;
+            self.rc.high_count = bs;
+            self.bin_summ[row][col] =
+                (bs + INTERVAL - get_mean(bs, PERIOD_BITS, 2)) as u16;
+            self.prev_success = 1;
+            self.run_length += 1;
+        } else {
+            self.rc.low_count = bs;
+            let nb = bs - get_mean(bs, PERIOD_BITS, 2);
+            self.bin_summ[row][col] = nb as u16;
+            self.rc.high_count = BIN_SCALE;
+            self.init_esc = EXP_ESCAPE[(nb >> 10) as usize] as u32;
+            let s = self.sym(rs) as usize;
+            self.char_mask[s] = self.esc_count;
+            self.num_masked = 0;
+            self.prev_success = 0;
+            self.found_state = 0;
+        }
+    }
+
+    /// `PPM_CONTEXT::update1`.
+    fn update1(&mut self, c: usize, mut p: usize) {
+        self.found_state = p;
+        let f = self.freq(p) + 4;
+        self.set_freq(p, f);
+        let sf = self.summ_freq(c) + 4;
+        self.set_summ_freq(c, sf);
+        if self.freq(p) > self.freq(p - 6) {
+            self.swap_states(p, p - 6);
+            p -= 6;
+            self.found_state = p;
+            if self.freq(p) > MAX_FREQ {
+                self.rescale(c);
+            }
+        }
+    }
+
+    /// `PPM_CONTEXT::encodeSymbol1`.
+    fn encode_symbol1(&mut self, c: usize, symbol: i32) {
+        let mut p = Self::roff(self.stats(c));
+        self.rc.scale = self.summ_freq(c);
+        if self.sym(p) as i32 == symbol {
+            self.rc.high_count = self.freq(p);
+            self.prev_success = (2 * self.rc.high_count >= self.rc.scale) as u32;
+            self.found_state = p;
+            let f = self.freq(p) + 4;
+            self.set_freq(p, f);
+            let sf = self.summ_freq(c) + 4;
+            self.set_summ_freq(c, sf);
+            self.run_length += self.prev_success as i32;
+            if self.freq(p) > MAX_FREQ {
+                self.rescale(c);
+            }
+            self.rc.low_count = 0;
+            return;
+        }
+        let mut lo_cnt = self.freq(p);
+        let mut i = self.ns(c) as i32;
+        self.prev_success = 0;
+        loop {
+            p += 6;
+            if self.sym(p) as i32 == symbol {
+                break;
+            }
+            lo_cnt += self.freq(p);
+            i -= 1;
+            if i == 0 {
+                self.rc.low_count = lo_cnt;
+                let s = self.sym(p) as usize;
+                self.char_mask[s] = self.esc_count;
+                let mut j = self.ns(c) as u32;
+                self.num_masked = j;
+                self.found_state = 0;
+                while j > 0 {
+                    p -= 6;
+                    let s = self.sym(p) as usize;
+                    self.char_mask[s] = self.esc_count;
+                    j -= 1;
+                }
+                self.rc.high_count = self.rc.scale;
+                return;
+            }
+        }
+        self.rc.low_count = lo_cnt;
+        self.rc.high_count = lo_cnt + self.freq(p);
+        self.update1(c, p);
+    }
+
+    /// `PPM_CONTEXT::decodeSymbol1`.
+    fn decode_symbol1(&mut self, c: usize) {
+        let mut p = Self::roff(self.stats(c));
+        self.rc.scale = self.summ_freq(c);
+        let mut hi_cnt = self.freq(p);
+        let count = self.rc.get_current_count();
+        if count < hi_cnt {
+            self.rc.high_count = hi_cnt;
+            self.prev_success = (2 * hi_cnt >= self.rc.scale) as u32;
+            self.found_state = p;
+            hi_cnt += 4;
+            self.set_freq(p, hi_cnt);
+            let sf = self.summ_freq(c) + 4;
+            self.set_summ_freq(c, sf);
+            self.run_length += self.prev_success as i32;
+            if hi_cnt > MAX_FREQ {
+                self.rescale(c);
+            }
+            self.rc.low_count = 0;
+            return;
+        }
+        let mut i = self.ns(c) as i32;
+        self.prev_success = 0;
+        loop {
+            p += 6;
+            hi_cnt += self.freq(p);
+            if hi_cnt > count {
+                break;
+            }
+            i -= 1;
+            if i == 0 {
+                self.rc.low_count = hi_cnt;
+                let s = self.sym(p) as usize;
+                self.char_mask[s] = self.esc_count;
+                let mut j = self.ns(c) as u32;
+                self.num_masked = j;
+                self.found_state = 0;
+                while j > 0 {
+                    p -= 6;
+                    let s = self.sym(p) as usize;
+                    self.char_mask[s] = self.esc_count;
+                    j -= 1;
+                }
+                self.rc.high_count = self.rc.scale;
+                return;
+            }
+        }
+        self.rc.high_count = hi_cnt;
+        self.rc.low_count = hi_cnt - self.freq(p);
+        self.update1(c, p);
+    }
+
+    /// `PPM_CONTEXT::update2`.
+    fn update2(&mut self, c: usize, p: usize) {
+        self.found_state = p;
+        let f = self.freq(p) + 4;
+        self.set_freq(p, f);
+        let sf = self.summ_freq(c) + 4;
+        self.set_summ_freq(c, sf);
+        if self.freq(p) > MAX_FREQ {
+            self.rescale(c);
+        }
+        self.esc_count = self.esc_count.wrapping_add(1);
+        self.run_length = self.init_rl;
+    }
+
+    /// `PPM_CONTEXT::makeEscFreq2`. Returns the SEE slot as (row, col), or
+    /// `None` for the dummy context used when NumStats is 0xFF.
+    fn make_esc_freq2(&mut self, c: usize) -> Option<(usize, usize)> {
+        let ns = self.ns(c) as u32;
+        if ns != 0xFF {
+            let t = self.ns(Self::roff(self.suffix(c))) as u32;
+            let row = self.q_table[(ns + 2) as usize] as usize - 3;
+            let mut col = (self.summ_freq(c) > 11 * (ns + 1)) as usize;
+            col += 2 * ((2 * ns < t + self.num_masked) as usize) + self.flags(c) as usize;
+            self.rc.scale = self.see2cont[row][col].get_mean();
+            Some((row, col))
+        } else {
+            self.rc.scale = 1;
+            None
+        }
+    }
+
+    #[inline]
+    fn see_summ_add(&mut self, slot: Option<(usize, usize)>, v: u32) {
+        match slot {
+            Some((r, c)) => {
+                self.see2cont[r][c].summ = self.see2cont[r][c].summ.wrapping_add(v as u16)
+            }
+            None => {
+                self.dummy_see2cont.summ = self.dummy_see2cont.summ.wrapping_add(v as u16)
+            }
+        }
+    }
+
+    #[inline]
+    fn see_update(&mut self, slot: Option<(usize, usize)>) {
+        match slot {
+            Some((r, c)) => self.see2cont[r][c].update(),
+            None => self.dummy_see2cont.update(),
+        }
+    }
+
+    /// `PPM_CONTEXT::encodeSymbol2`.
+    fn encode_symbol2(&mut self, c: usize, symbol: i32) {
+        let slot = self.make_esc_freq2(c);
+        let mut lo_cnt = 0u32;
+        let mut i = self.ns(c) as i32 - self.num_masked as i32;
+        let mut p = Self::roff(self.stats(c)) - 6;
+        loop {
+            loop {
+                p += 6;
+                let s = self.sym(p) as usize;
+                if self.char_mask[s] != self.esc_count {
+                    break;
+                }
+            }
+            let s = self.sym(p) as usize;
+            self.char_mask[s] = self.esc_count;
+            if s as i32 == symbol {
+                // SYMBOL_FOUND
+                self.rc.low_count = lo_cnt;
+                lo_cnt += self.freq(p);
+                self.rc.high_count = lo_cnt;
+                let mut p1 = p;
+                i -= 1;
+                while i != 0 {
+                    loop {
+                        p1 += 6;
+                        let s1 = self.sym(p1) as usize;
+                        if self.char_mask[s1] != self.esc_count {
+                            break;
+                        }
+                    }
+                    lo_cnt += self.freq(p1);
+                    i -= 1;
+                }
+                self.rc.scale += lo_cnt;
+                self.see_update(slot);
+                self.update2(c, p);
+                return;
+            }
+            lo_cnt += self.freq(p);
+            i -= 1;
+            if i == 0 {
+                break;
+            }
+        }
+        self.rc.low_count = lo_cnt;
+        self.rc.scale += lo_cnt;
+        self.rc.high_count = self.rc.scale;
+        let sc = self.rc.scale;
+        self.see_summ_add(slot, sc);
+        self.num_masked = self.ns(c) as u32;
+    }
+
+    /// `PPM_CONTEXT::decodeSymbol2`.
+    fn decode_symbol2(&mut self, c: usize) {
+        let slot = self.make_esc_freq2(c);
+        let mut hi_cnt = 0u32;
+        let n = self.ns(c) as i32 - self.num_masked as i32;
+        let mut i = n;
+        let mut ps = [0usize; 256];
+        let mut np = 0usize;
+        let mut p = Self::roff(self.stats(c)) - 6;
+        loop {
+            loop {
+                p += 6;
+                let s = self.sym(p) as usize;
+                if self.char_mask[s] != self.esc_count {
+                    break;
+                }
+            }
+            hi_cnt += self.freq(p);
+            ps[np] = p;
+            np += 1;
+            i -= 1;
+            if i == 0 {
+                break;
+            }
+        }
+        self.rc.scale += hi_cnt;
+        let count = self.rc.get_current_count();
+        if count < hi_cnt {
+            let mut k = 0usize;
+            let mut acc = 0u32;
+            let mut q = ps[0];
+            loop {
+                acc += self.freq(q);
+                if acc > count {
+                    break;
+                }
+                k += 1;
+                q = ps[k];
+            }
+            self.rc.high_count = acc;
+            self.rc.low_count = acc - self.freq(q);
+            self.see_update(slot);
+            self.update2(c, q);
+        } else {
+            self.rc.low_count = hi_cnt;
+            self.rc.high_count = self.rc.scale;
+            self.num_masked = self.ns(c) as u32;
+            for k in 0..n as usize {
+                let s = self.sym(ps[k]) as usize;
+                self.char_mask[s] = self.esc_count;
+            }
+            let sc = self.rc.scale;
+            self.see_summ_add(slot, sc);
+        }
+    }
+
+    /// `ClearMask`.
+    fn clear_mask(&mut self) {
+        self.esc_count = 1;
+        self.char_mask = [0; 256];
+        self.print_count = self.print_count.wrapping_add(1);
+    }
+
+    /// `EncodeFile`.
+    pub fn encode_file(
+        &mut self,
+        encoded: &mut PrimeStream,
+        decoded: &mut PrimeStream,
+        max_order: i32,
+        mr_method: i32,
+    ) {
+        self.rc.init_encoder();
+        self.start_model_rare(max_order, mr_method);
+        loop {
+            let mut min_context = self.max_context;
+            let ns = self.ns(min_context);
+            let c = decoded.get();
+            if ns != 0 {
+                self.encode_symbol1(min_context, c);
+                self.rc.encode_symbol();
+            } else {
+                self.encode_bin_symbol(min_context, c);
+                self.rc.shift_encode_symbol(TOT_BITS);
+            }
+            let mut stop = false;
+            while self.found_state == 0 {
+                self.rc.encode_normalize(encoded);
+                loop {
+                    self.order_fall += 1;
+                    if self.suffix(min_context) == 0 {
+                        stop = true;
+                        break;
+                    }
+                    min_context = Self::roff(self.suffix(min_context));
+                    if self.ns(min_context) as u32 != self.num_masked {
+                        break;
+                    }
+                }
+                if stop {
+                    break;
+                }
+                self.encode_symbol2(min_context, c);
+                self.rc.encode_symbol();
+            }
+            if stop {
+                break;
+            }
+            eprintln!("PRE mc={} min={} fs={} of={} resc={}",
+                self.max_context, min_context, self.found_state, self.order_fall, self.resc_n);
+            if self.order_fall == 0 && self.ge_units(self.succ(self.found_state)) {
+                self.max_context = Self::roff(self.succ(self.found_state));
+            } else {
+                self.update_model(min_context);
+                if self.esc_count == 0 {
+                    self.clear_mask();
+                }
+            }
+            self.rc.encode_normalize(encoded);
+            if decoded.error() < 0 || encoded.error() < 0 {
+                return;
+            }
+        }
+        self.rc.flush_encoder(encoded);
+    }
+
+    /// `DecodeFile`.
+    pub fn decode_file(
+        &mut self,
+        decoded: &mut PrimeStream,
+        encoded: &mut PrimeStream,
+        max_order: i32,
+        mr_method: i32,
+    ) {
+        self.rc.init_decoder(encoded);
+        self.start_model_rare(max_order, mr_method);
+        let mut min_context = self.max_context;
+        let mut ns = self.ns(min_context);
+        loop {
+            if ns != 0 {
+                self.decode_symbol1(min_context);
+            } else {
+                self.decode_bin_symbol(min_context);
+            }
+            self.rc.remove_subrange();
+            let mut stop = false;
+            while self.found_state == 0 {
+                self.rc.decode_normalize(encoded);
+                loop {
+                    self.order_fall += 1;
+                    if self.suffix(min_context) == 0 {
+                        stop = true;
+                        break;
+                    }
+                    min_context = Self::roff(self.suffix(min_context));
+                    if self.ns(min_context) as u32 != self.num_masked {
+                        break;
+                    }
+                }
+                if stop {
+                    break;
+                }
+                self.decode_symbol2(min_context);
+                self.rc.remove_subrange();
+            }
+            if stop {
+                break;
+            }
+            let sym = self.sym(self.found_state);
+            decoded.put(sym);
+            if self.order_fall == 0 && self.ge_units(self.succ(self.found_state)) {
+                self.max_context = Self::roff(self.succ(self.found_state));
+            } else {
+                self.update_model(min_context);
+                if self.esc_count == 0 {
+                    self.clear_mask();
+                }
+            }
+            min_context = self.max_context;
+            ns = self.ns(min_context);
+            self.rc.decode_normalize(encoded);
+            if decoded.error() < 0 || encoded.error() < 0 {
+                return;
+            }
+        }
+    }
+}

--- a/rust/darc-codecs/src/ppmd/model.rs
+++ b/rust/darc-codecs/src/ppmd/model.rs
@@ -682,16 +682,12 @@ impl Model {
         let nf = (self.freq(p) + adder) >> 1;
         self.set_freq(p, nf);
         let mut summ = nf;
-        // The value most recently ASSIGNED to p->Freq -- deliberately not a
-        // fresh read of the heap. See the note on the zero test below.
-        let mut last_nf = nf;
         let mut i = self.ns(c) as u32;
         while i > 0 {
             p += 6;
             esc_freq = esc_freq.wrapping_sub(self.freq(p));
             let nf = (self.freq(p) + adder) >> 1;
             self.set_freq(p, nf);
-            last_nf = nf;
             summ += nf;
             if self.freq(p) > self.freq(p - 6) {
                 // Bubble the state back into frequency order.
@@ -715,21 +711,29 @@ impl Model {
             i -= 1;
         }
         self.set_summ_freq(c, summ);
-        // `if (p->Freq == 0)` in the C -- but NOT a re-read of the heap.
+        // `if (p->Freq == 0)`, and it must be a genuine RE-READ of the heap --
+        // the bubble sort above may have moved a different state into `p`.
         //
-        // StateCpy/SWAP type-pun through `(WORD&)` references, which violates
-        // strict aliasing. At -O1 the compiler therefore assumes those WORD
-        // writes cannot alias this BYTE read, and reuses the value ASSIGNED to
-        // p->Freq in the loop's final iteration -- even though the bubble sort
-        // has since overwritten that slot. At -O0 it re-reads and sees the new
-        // value, and the two builds produce DIFFERENT COMPRESSED OUTPUT from
-        // the same input. Measured on a 92-byte case: -O0 gives 669d679a...,
-        // -O1 and -O2 give f6cb8287....
+        // This line is the one place where the C's compiler flags decide the
+        // compressed format. StateCpy/SWAP type-pun through `(WORD&)`
+        // references, violating strict aliasing, so a compiler allowed to
+        // assume those WORD writes cannot alias this BYTE read will reuse the
+        // value ASSIGNED to p->Freq in the loop's last iteration instead of
+        // reloading the slot. Measured on the `dominant` corpus shape, all of
+        // orders 3/4/10/16:
         //
-        // Compression/PPMD/makefile builds at -O1, so -O1 is the behaviour
-        // every existing -mppmd archive was produced with, and the one this
-        // port has to reproduce. Hence `last_nf`, not `self.freq(p)`.
-        if last_nf == 0 {
+        //     clang -O1                        reuses the assigned value
+        //     clang -O2                        reuses the assigned value
+        //     clang -O0                        re-reads
+        //     clang -O1 -fno-strict-aliasing   re-reads
+        //
+        // Compression/PPMD/makefile passes `-fno-strict-aliasing`, so every
+        // real -mppmd archive was written by a build that RE-READS, and that is
+        // what this port has to reproduce. Isolated by flag: -fno-strict-
+        // aliasing alone flips it; -fomit-frame-pointer -funroll-loops do not.
+        // ppmd-check.sh builds its oracle with the makefile's flag set for
+        // exactly this reason -- pinning only the -O level is not enough.
+        if self.freq(p) == 0 {
             let mut i = 0u32;
             loop {
                 i += 1;

--- a/rust/darc-codecs/src/ppmd/model.rs
+++ b/rust/darc-codecs/src/ppmd/model.rs
@@ -125,7 +125,6 @@ pub struct Model {
     esc_count: u8,
     print_count: u8,
     mr_method: i32,
-    resc_n: u32,
 }
 
 impl Model {
@@ -151,7 +150,6 @@ impl Model {
             esc_count: 0,
             print_count: 0,
             mr_method: MRM_RESTART,
-            resc_n: 0,
         };
         m.startup();
         m
@@ -546,7 +544,10 @@ impl Model {
             self.sa.glue_count = 0;
             self.order_fall = self.max_order;
         } else if self.mr_method == MRM_RESTART
-            || self.sa.get_used_memory() < (self.sa.sub_allocator_size >> 1)
+            // Both sides in 32 bits, as in the C: SubAllocatorSize is a DWORD
+            // and GetUsedMemory returns one, and the used figure can have
+            // wrapped past zero by the time this is asked.
+            || self.sa.get_used_memory() < (self.sa.sub_allocator_size as u32 >> 1)
         {
             let (mo, mrm) = (self.max_order, self.mr_method);
             self.start_model_rare(mo, mrm);
@@ -560,7 +561,7 @@ impl Model {
                 let mc = self.max_context;
                 self.cut_off(mc, 0);
                 self.sa.expand_text_area();
-                if self.sa.get_used_memory() <= 3 * (self.sa.sub_allocator_size >> 2) {
+                if self.sa.get_used_memory() <= 3 * (self.sa.sub_allocator_size as u32 >> 2) {
                     break;
                 }
             }
@@ -660,7 +661,6 @@ impl Model {
 
     /// `PPM_CONTEXT::rescale`.
     fn rescale(&mut self, c: usize) {
-        self.resc_n += 1;
         let s_base = Self::roff(self.stats(c));
         let mut p = self.found_state;
         while p != s_base {
@@ -1464,8 +1464,6 @@ impl Model {
             if stop {
                 break;
             }
-            eprintln!("PRE mc={} min={} fs={} of={} resc={}",
-                self.max_context, min_context, self.found_state, self.order_fall, self.resc_n);
             if self.order_fall == 0 && self.ge_units(self.succ(self.found_state)) {
                 self.max_context = Self::roff(self.succ(self.found_state));
             } else {

--- a/rust/darc-codecs/src/ppmd/stream.rs
+++ b/rust/darc-codecs/src/ppmd/stream.rs
@@ -1,0 +1,136 @@
+//! `PRIME_STREAM`, ported from `Compression/PPMD/PPMdType.h`.
+//!
+//! The buffered callback layer PPMd does all its I/O through. It matters to the
+//! port for one reason beyond plumbing: `get()` returns `EOF` (-1) on
+//! exhaustion, and the decoder's normalisation shifts that value into `code`.
+//! Reproducing the exact byte the C ends up with there is what keeps a
+//! truncated or trailing-edge stream decoding identically.
+
+use crate::ffi::Io;
+
+/// `BUFFER_SIZE` from PPMdType.h.
+pub const BUFFER_SIZE: usize = 64 * 1024;
+
+/// The C's `EOF`.
+pub const EOF: i32 = -1;
+
+pub struct PrimeStream<'a> {
+    io: &'a Io,
+    buf: Vec<u8>,
+    /// Index into `buf`, the C's `p - Buf`.
+    pos: usize,
+    /// The C's `Count`: bytes left before a refill/flush is needed. It is
+    /// decremented BEFORE the test, so it goes negative to signal end of data.
+    count: i32,
+    /// Bytes currently held for writing, the C's `p - Buf` on the output side.
+    fill: usize,
+    error: i32,
+    writing: bool,
+}
+
+impl<'a> PrimeStream<'a> {
+    pub fn new_reader(io: &'a Io) -> Self {
+        PrimeStream {
+            io,
+            buf: vec![0u8; BUFFER_SIZE],
+            pos: 0,
+            count: 0,
+            fill: 0,
+            error: 0,
+            writing: false,
+        }
+    }
+
+    pub fn new_writer(io: &'a Io) -> Self {
+        PrimeStream {
+            io,
+            buf: vec![0u8; BUFFER_SIZE],
+            pos: 0,
+            count: BUFFER_SIZE as i32,
+            fill: 0,
+            error: 0,
+            writing: true,
+        }
+    }
+
+    pub fn error(&self) -> i32 {
+        self.error
+    }
+
+    /// The C's `atEOS()`: `Count < 0`.
+    pub fn at_eos(&self) -> bool {
+        self.count < 0
+    }
+
+    /// `PRIME_STREAM::get`. Returns `EOF` (-1) once the source is exhausted;
+    /// the decoder shifts that into `code` rather than stopping, so the value
+    /// is load-bearing rather than merely a status.
+    pub fn get(&mut self) -> i32 {
+        self.count -= 1;
+        if self.count >= 0 {
+            let b = self.buf[self.pos];
+            self.pos += 1;
+            b as i32
+        } else {
+            self.fill_buf()
+        }
+    }
+
+    fn fill_buf(&mut self) -> i32 {
+        if self.error < 0 {
+            return EOF;
+        }
+        let n = self.io.read(&mut self.buf[..BUFFER_SIZE]);
+        self.count = n;
+        self.pos = 0;
+        if n < 0 {
+            self.error = n;
+            return EOF;
+        }
+        self.count -= 1;
+        if self.count >= 0 {
+            let b = self.buf[self.pos];
+            self.pos += 1;
+            b as i32
+        } else {
+            EOF
+        }
+    }
+
+    /// `PRIME_STREAM::put`.
+    pub fn put(&mut self, c: u8) {
+        self.count -= 1;
+        if self.count >= 0 {
+            self.buf[self.fill] = c;
+            self.fill += 1;
+        } else {
+            self.flush();
+            // The C recurses: `(flush(), put(c))`.
+            self.count -= 1;
+            self.buf[self.fill] = c;
+            self.fill += 1;
+        }
+    }
+
+    /// `PRIME_STREAM::flush`. Writes out whatever is buffered and resets.
+    pub fn flush(&mut self) {
+        if self.error >= 0 && self.fill > 0 {
+            let n = self.io.write(&self.buf[..self.fill]);
+            if n < 0 {
+                self.error = n;
+            }
+        }
+        self.fill = 0;
+        self.pos = 0;
+        self.count = BUFFER_SIZE as i32;
+    }
+
+    /// Flush on drop is NOT automatic in the C -- `ppmd_compress` calls it
+    /// explicitly after the encoder flush -- so this is explicit too, to keep
+    /// the write ordering identical.
+    pub fn finish(&mut self) {
+        if self.writing {
+            self.flush();
+        }
+    }
+}

--- a/rust/darc-codecs/src/ppmd/suballoc.rs
+++ b/rust/darc-codecs/src/ppmd/suballoc.rs
@@ -239,12 +239,29 @@ impl SubAllocator {
     }
 
     /// `GetUsedMemory`. The model branches on this directly, so the free-list
-    /// bookkeeping it subtracts has to match the C exactly.
-    pub fn get_used_memory(&self) -> usize {
-        let mut ret = self.sub_allocator_size - (self.hi_unit - self.lo_unit)
-            - (self.units_start - self.p_text);
+    /// bookkeeping it subtracts has to match the C exactly -- including where
+    /// it goes negative.
+    ///
+    /// It genuinely does. `BList[i].Stamp` counts the blocks in list `i` and
+    /// this charges each of them `Indx2Units[i]` units, but GlueFreeBlocks
+    /// inserts remainders whose real size is SMALLER than their list's nominal
+    /// one, so the free-list total can exceed what is actually free. Seed 1 on
+    /// a 2 KB heap reaches it after 124 operations of the allocator harness.
+    ///
+    /// The C absorbs that in `DWORD`: the initial expression is evaluated in
+    /// signed 64-bit (the pointer differences drag it there), truncated to 32
+    /// bits by the assignment, and each loop subtraction then wraps in 32 bits.
+    /// Width matters as much as wrapping -- the model compares the result
+    /// against `SubAllocatorSize`, and a 64-bit wrap would give a different
+    /// answer to a 32-bit one on the very comparison that decides a restart.
+    pub fn get_used_memory(&self) -> u32 {
+        let mut ret = (self.sub_allocator_size as i64
+            - (self.hi_unit as i64 - self.lo_unit as i64)
+            - (self.units_start as i64 - self.p_text as i64)) as u32;
         for i in 0..N_INDEXES {
-            ret -= UNIT_SIZE * self.indx2units[i] as usize * self.blist[i].stamp as usize;
+            ret = ret.wrapping_sub(
+                UNIT_SIZE as u32 * self.indx2units[i] as u32 * self.blist[i].stamp,
+            );
         }
         ret
     }
@@ -318,6 +335,26 @@ impl SubAllocator {
                 loop {
                     let p1 = p + self.blk_nu(p) as usize * UNIT_SIZE;
                     if p1 + UNIT_SIZE > self.heap.len() || self.blk_stamp(p1) != STAMP_FREE {
+                        break;
+                    }
+                    // The one deliberate deviation from the C, and it is not
+                    // observable. Absorbing a block clears its NU but leaves
+                    // its Stamp reading STAMP_FREE, so the heap keeps husks:
+                    // twelve bytes that still say "free" and claim zero units.
+                    // When a later block's end lands on one, the C's loop is
+                    //     p->NU += p1->NU;  p1->NU = 0;
+                    // which adds zero and rewrites zero, so `p + p->NU` picks
+                    // out the same husk on the next turn -- for ever. Measured
+                    // on the allocator harness: seed 42, an 8 KB heap, both the
+                    // C and a faithful port spin at operation 146, and the
+                    // husks they spin on were zeroed by an earlier absorb in
+                    // the same run.
+                    //
+                    // Stopping here cannot change any output the C can produce,
+                    // because in this state the C never leaves the loop and so
+                    // never returns a byte at all. Everything the C *does*
+                    // return is reached without meeting a husk.
+                    if self.blk_nu(p1) == 0 {
                         break;
                     }
                     let merged = self.blk_nu(p) + self.blk_nu(p1);

--- a/rust/darc-codecs/src/ppmd/suballoc.rs
+++ b/rust/darc-codecs/src/ppmd/suballoc.rs
@@ -1,0 +1,645 @@
+//! PPMd var.H's memory suballocator, ported from `Compression/PPMD/SubAlloc.hpp`.
+//!
+//! # This is not an allocator you may improve
+//!
+//! Every other codec in this crate leaves some freedom in how a stage is
+//! implemented, so long as the bytes match. libsais was the extreme case: a
+//! string's suffix array is unique, so *any* correct construction reproduced
+//! the C exactly.
+//!
+//! PPMd is the opposite, and it is the allocator that makes it so. The model
+//! branches on the allocator's own state:
+//!
+//! ```text
+//! Model.cpp:245  GetUsedMemory() < (SubAllocatorSize >> 1)   decides restart
+//! Model.cpp:416  if (pText >= UnitsStart) goto RESTART_MODEL
+//! Model.cpp:418  if ((BYTE*) FSuccessor < UnitsStart)
+//! ```
+//!
+//! Measured before this was written: the same 200 KB input at order 16 encodes
+//! to 204797 / 205303 / 206007 / 206098 bytes under a 1 / 2 / 4 / 8 MB budget,
+//! all four with different contents. An allocator that is merely *correct*
+//! reports a different `GetUsedMemory()`, crosses `UnitsStart` at a different
+//! moment, restarts the model somewhere else, and changes every byte after
+//! that. Free-list order, split behaviour and the resulting addresses are all
+//! part of the compressed format.
+//!
+//! So this is a transliteration, deliberately keeping the C's shape -- including
+//! its `Stamp == !0` sentinel and its `p + p->NU` block arithmetic -- rather
+//! than a Rust-idiomatic rewrite.
+//!
+//! # Representation
+//!
+//! The C works in raw pointers into one `malloc`ed block. Here the heap is a
+//! `Vec<u8>` and every pointer is a byte offset into it, which is what the C
+//! already does for intra-heap references: `RP_BLK` stores `p - HeapStart + 1`
+//! so that 0 can mean NULL. Offsets are `usize` internally and `u32` on the
+//! heap, matching the C's 4-byte `BLKREF` so `MEM_BLK` stays exactly
+//! `UNIT_SIZE` bytes.
+
+pub const UNIT_SIZE: usize = 12;
+const N1: usize = 4;
+const N2: usize = 4;
+const N3: usize = 4;
+const N4: usize = (128 + 3 - N1 - 2 * N2 - 3 * N3) / 4;
+pub const N_INDEXES: usize = N1 + N2 + N3 + N4;
+
+/// The C's `~0U` free-block marker, written into `MEM_BLK::Stamp`.
+const STAMP_FREE: u32 = !0u32;
+
+/// `U2B(NU)`: units to bytes. The C spells it `8*NU + 4*NU`.
+#[inline]
+fn u2b(nu: usize) -> usize {
+    12 * nu
+}
+
+/// One free-list head. These live OUTSIDE the heap in the C too (`BList` is a
+/// file-scope array), holding refs that point into it.
+#[derive(Clone, Copy, Default)]
+struct BlkNode {
+    stamp: u32,
+    next: u32,
+}
+
+pub struct SubAllocator {
+    heap: Vec<u8>,
+    blist: [BlkNode; N_INDEXES],
+    indx2units: [u8; N_INDEXES],
+    units2indx: [u8; 128],
+
+    pub sub_allocator_size: usize,
+    pub glue_count: u32,
+
+    /// All four are byte offsets from the start of `heap`, matching the C's
+    /// `pText` / `UnitsStart` / `LoUnit` / `HiUnit` pointers.
+    pub p_text: usize,
+    pub units_start: usize,
+    pub lo_unit: usize,
+    pub hi_unit: usize,
+}
+
+impl SubAllocator {
+    pub fn new() -> Self {
+        let mut s = SubAllocator {
+            heap: Vec::new(),
+            blist: [BlkNode::default(); N_INDEXES],
+            indx2units: [0; N_INDEXES],
+            units2indx: [0; 128],
+            sub_allocator_size: 0,
+            glue_count: 0,
+            p_text: 0,
+            units_start: 0,
+            lo_unit: 0,
+            hi_unit: 0,
+        };
+        s.build_tables();
+        s
+    }
+
+    /// `Model.cpp:99-105`. Unit sizes grow by 1, then 2, then 3, then 4.
+    fn build_tables(&mut self) {
+        let mut i = 0usize;
+        let mut k = 1usize;
+        while i < N1 {
+            self.indx2units[i] = k as u8;
+            i += 1;
+            k += 1;
+        }
+        k += 1;
+        while i < N1 + N2 {
+            self.indx2units[i] = k as u8;
+            i += 1;
+            k += 2;
+        }
+        k += 1;
+        while i < N1 + N2 + N3 {
+            self.indx2units[i] = k as u8;
+            i += 1;
+            k += 3;
+        }
+        k += 1;
+        while i < N1 + N2 + N3 + N4 {
+            self.indx2units[i] = k as u8;
+            i += 1;
+            k += 4;
+        }
+        // `i += (Indx2Units[i] < k+1)` -- note the C reuses `i` as the running
+        // index into indx2units here, not the loop counter.
+        let mut idx = 0usize;
+        for kk in 0..128usize {
+            if (self.indx2units[idx] as usize) < kk + 1 {
+                idx += 1;
+            }
+            self.units2indx[kk] = idx as u8;
+        }
+    }
+
+    // --- raw heap access -------------------------------------------------
+    // Offsets are 0-based into `heap`; heap REFS are 1-based (0 = NULL), as
+    // `RP_BLK`/`PP_BLK` do.
+
+    #[inline]
+    fn rd32(&self, at: usize) -> u32 {
+        u32::from_ne_bytes([
+            self.heap[at],
+            self.heap[at + 1],
+            self.heap[at + 2],
+            self.heap[at + 3],
+        ])
+    }
+
+    #[inline]
+    fn wr32(&mut self, at: usize, v: u32) {
+        self.heap[at..at + 4].copy_from_slice(&v.to_ne_bytes());
+    }
+
+    #[inline]
+    fn ref_of(&self, off: usize) -> u32 {
+        // RP_BLK: 0 stays 0, otherwise offset+1.
+        (off + 1) as u32
+    }
+
+    #[inline]
+    fn off_of(&self, r: u32) -> usize {
+        (r - 1) as usize
+    }
+
+    // A MEM_BLK at offset `p` is { Stamp:u32, next:u32, NU:u32 }.
+    #[inline]
+    fn blk_stamp(&self, p: usize) -> u32 {
+        self.rd32(p)
+    }
+    #[inline]
+    fn set_blk_stamp(&mut self, p: usize, v: u32) {
+        self.wr32(p, v)
+    }
+    #[inline]
+    fn blk_next(&self, p: usize) -> u32 {
+        self.rd32(p + 4)
+    }
+    #[inline]
+    fn set_blk_next(&mut self, p: usize, v: u32) {
+        self.wr32(p + 4, v)
+    }
+    #[inline]
+    fn blk_nu(&self, p: usize) -> u32 {
+        self.rd32(p + 8)
+    }
+    #[inline]
+    fn set_blk_nu(&mut self, p: usize, v: u32) {
+        self.wr32(p + 8, v)
+    }
+
+    pub fn heap(&self) -> &[u8] {
+        &self.heap
+    }
+    pub fn heap_mut(&mut self) -> &mut [u8] {
+        &mut self.heap
+    }
+
+    // --- lifecycle -------------------------------------------------------
+
+    /// `StartSubAllocator`. Returns false when the allocation fails, as the C's
+    /// `malloc` check does.
+    pub fn start(&mut self, t: usize) -> bool {
+        if self.sub_allocator_size == t {
+            return true;
+        }
+        self.stop();
+        // The C mallocs without zeroing; the model never reads an uninitialised
+        // byte, but zeroing keeps this port deterministic under a debugger.
+        self.heap = vec![0u8; t];
+        self.sub_allocator_size = t;
+        true
+    }
+
+    pub fn stop(&mut self) {
+        if self.sub_allocator_size != 0 {
+            self.sub_allocator_size = 0;
+            self.heap = Vec::new();
+        }
+    }
+
+    /// `InitSubAllocator`. The 1/8 : 7/8 split between the text area and the
+    /// units area is what `pText >= UnitsStart` later tests against.
+    pub fn init(&mut self) {
+        self.blist = [BlkNode::default(); N_INDEXES];
+        self.p_text = 0;
+        self.hi_unit = self.sub_allocator_size;
+        let diff = UNIT_SIZE * (self.sub_allocator_size / 8 / UNIT_SIZE * 7);
+        self.lo_unit = self.hi_unit - diff;
+        self.units_start = self.lo_unit;
+        self.glue_count = 0;
+    }
+
+    /// `GetUsedMemory`. The model branches on this directly, so the free-list
+    /// bookkeeping it subtracts has to match the C exactly.
+    pub fn get_used_memory(&self) -> usize {
+        let mut ret = self.sub_allocator_size - (self.hi_unit - self.lo_unit)
+            - (self.units_start - self.p_text);
+        for i in 0..N_INDEXES {
+            ret -= UNIT_SIZE * self.indx2units[i] as usize * self.blist[i].stamp as usize;
+        }
+        ret
+    }
+
+    // --- free lists ------------------------------------------------------
+
+    #[inline]
+    fn avail(&self, i: usize) -> bool {
+        self.blist[i].next != 0
+    }
+
+    /// `BLK_NODE::insert` -- link the block in and stamp it free.
+    fn insert(&mut self, i: usize, pv: usize, nu: usize) {
+        let head_next = self.blist[i].next;
+        self.set_blk_next(pv, head_next);
+        self.blist[i].next = self.ref_of(pv);
+        self.set_blk_stamp(pv, STAMP_FREE);
+        self.set_blk_nu(pv, nu as u32);
+        self.blist[i].stamp += 1;
+    }
+
+    /// `BLK_NODE::remove` -- unlink the head block and return its offset.
+    fn remove(&mut self, i: usize) -> usize {
+        let p = self.off_of(self.blist[i].next);
+        self.blist[i].next = self.blk_next(p);
+        self.blist[i].stamp -= 1;
+        p
+    }
+
+    /// `SplitBlock`. The odd-sized remainder is inserted first, then the rest.
+    fn split_block(&mut self, pv: usize, old_indx: usize, new_indx: usize) {
+        let mut u_diff =
+            (self.indx2units[old_indx] - self.indx2units[new_indx]) as usize;
+        let mut p = pv + u2b(self.indx2units[new_indx] as usize);
+        let mut i = self.units2indx[u_diff - 1] as usize;
+        if self.indx2units[i] as usize != u_diff {
+            i -= 1;
+            let k = self.indx2units[i] as usize;
+            self.insert(i, p, k);
+            p += u2b(k);
+            u_diff -= k;
+        }
+        let j = self.units2indx[u_diff - 1] as usize;
+        self.insert(j, p, u_diff);
+    }
+
+    /// `GlueFreeBlocks`: coalesce adjacent free blocks, then redistribute.
+    ///
+    /// The `p + p->NU` walk is block arithmetic on `MEM_BLK*`, i.e. `NU * 12`
+    /// bytes, and it relies on the `Stamp == ~0U` marker sitting in the heap
+    /// where a neighbouring free block would start.
+    fn glue_free_blocks(&mut self) {
+        // The C writes a 0 byte at LoUnit so the coalescing walk cannot run off
+        // the end into whatever happens to look like a free stamp.
+        if self.lo_unit != self.hi_unit {
+            self.heap[self.lo_unit] = 0;
+        }
+
+        // `s0` is a stack-local list head in the C; here it is a plain chain of
+        // heap offsets, since only its `next` is used.
+        let mut s0_next: u32 = 0;
+        let mut p0: Option<usize> = None;
+
+        for i in 0..N_INDEXES {
+            while self.avail(i) {
+                let p = self.remove(i);
+                if self.blk_nu(p) == 0 {
+                    continue;
+                }
+                // Absorb every immediately-following free block.
+                loop {
+                    let p1 = p + self.blk_nu(p) as usize * UNIT_SIZE;
+                    if p1 + UNIT_SIZE > self.heap.len() || self.blk_stamp(p1) != STAMP_FREE {
+                        break;
+                    }
+                    let merged = self.blk_nu(p) + self.blk_nu(p1);
+                    self.set_blk_nu(p, merged);
+                    self.set_blk_nu(p1, 0);
+                }
+                // p0->link(p)
+                match p0 {
+                    None => s0_next = self.ref_of(p),
+                    Some(prev) => {
+                        let n = self.blk_next(prev);
+                        self.set_blk_next(p, n);
+                        self.set_blk_next(prev, self.ref_of(p));
+                    }
+                }
+                if p0.is_none() {
+                    self.set_blk_next(p, 0);
+                }
+                p0 = Some(p);
+            }
+        }
+
+        // Redistribute the coalesced blocks back into the free lists.
+        while s0_next != 0 {
+            let mut p = self.off_of(s0_next);
+            s0_next = self.blk_next(p);
+            let mut sz = self.blk_nu(p) as usize;
+            if sz == 0 {
+                continue;
+            }
+            while sz > 128 {
+                self.insert(N_INDEXES - 1, p, 128);
+                sz -= 128;
+                p += 128 * UNIT_SIZE;
+            }
+            let mut i = self.units2indx[sz - 1] as usize;
+            if self.indx2units[i] as usize != sz {
+                i -= 1;
+                let k = sz - self.indx2units[i] as usize;
+                self.insert(k - 1, p + (sz - k) * UNIT_SIZE, k);
+            }
+            let nu = self.indx2units[i] as usize;
+            self.insert(i, p, nu);
+        }
+        self.glue_count = 1 << 13;
+    }
+
+    /// `AllocUnitsRare`. Returns 0 for NULL, matching the C's `NULL` return --
+    /// offset 0 is inside the text area and never a valid unit allocation.
+    fn alloc_units_rare(&mut self, indx: usize) -> usize {
+        let mut i = indx;
+        if self.glue_count == 0 {
+            self.glue_free_blocks();
+            if self.avail(indx) {
+                return self.remove(indx);
+            }
+        }
+        loop {
+            i += 1;
+            if i == N_INDEXES {
+                self.glue_count = self.glue_count.wrapping_sub(1);
+                let need = u2b(self.indx2units[indx] as usize);
+                return if self.units_start - self.p_text > need {
+                    self.units_start -= need;
+                    self.units_start
+                } else {
+                    0
+                };
+            }
+            if self.avail(i) {
+                break;
+            }
+        }
+        let ret = self.remove(i);
+        self.split_block(ret, i, indx);
+        ret
+    }
+
+    /// `AllocUnits`. 0 means NULL.
+    pub fn alloc_units(&mut self, nu: usize) -> usize {
+        let indx = self.units2indx[nu - 1] as usize;
+        if self.avail(indx) {
+            return self.remove(indx);
+        }
+        let ret = self.lo_unit;
+        let sz = u2b(self.indx2units[indx] as usize);
+        self.lo_unit += sz;
+        if self.lo_unit <= self.hi_unit {
+            return ret;
+        }
+        self.lo_unit -= sz;
+        self.alloc_units_rare(indx)
+    }
+
+    /// `AllocContext`. 0 means NULL.
+    pub fn alloc_context(&mut self) -> usize {
+        if self.hi_unit != self.lo_unit {
+            self.hi_unit -= UNIT_SIZE;
+            return self.hi_unit;
+        }
+        if self.avail(0) {
+            return self.remove(0);
+        }
+        self.alloc_units_rare(0)
+    }
+
+    /// `UnitsCpy`: three words per unit, copied forwards.
+    fn units_cpy(&mut self, dest: usize, src: usize, nu: usize) {
+        let n = nu * UNIT_SIZE;
+        self.heap.copy_within(src..src + n, dest);
+    }
+
+    /// `ExpandUnits`. 0 means NULL.
+    pub fn expand_units(&mut self, old_ptr: usize, old_nu: usize) -> usize {
+        let i0 = self.units2indx[old_nu - 1] as usize;
+        let i1 = self.units2indx[old_nu] as usize;
+        if i0 == i1 {
+            return old_ptr;
+        }
+        let ptr = self.alloc_units(old_nu + 1);
+        if ptr != 0 {
+            self.units_cpy(ptr, old_ptr, old_nu);
+            self.insert(i0, old_ptr, old_nu);
+        }
+        ptr
+    }
+
+    /// `ShrinkUnits`.
+    pub fn shrink_units(&mut self, old_ptr: usize, old_nu: usize, new_nu: usize) -> usize {
+        let i0 = self.units2indx[old_nu - 1] as usize;
+        let i1 = self.units2indx[new_nu - 1] as usize;
+        if i0 == i1 {
+            return old_ptr;
+        }
+        if self.avail(i1) {
+            let ptr = self.remove(i1);
+            self.units_cpy(ptr, old_ptr, new_nu);
+            let nu = self.indx2units[i0] as usize;
+            self.insert(i0, old_ptr, nu);
+            ptr
+        } else {
+            self.split_block(old_ptr, i0, i1);
+            old_ptr
+        }
+    }
+
+    /// `FreeUnits`.
+    pub fn free_units(&mut self, ptr: usize, nu: usize) {
+        let indx = self.units2indx[nu - 1] as usize;
+        let n = self.indx2units[indx] as usize;
+        self.insert(indx, ptr, n);
+    }
+
+    /// `SpecialFreeUnit`. Freeing the unit at `UnitsStart` grows the text area
+    /// instead of listing it -- one of the places allocator layout feeds back
+    /// into the model.
+    pub fn special_free_unit(&mut self, ptr: usize) {
+        if ptr != self.units_start {
+            self.insert(0, ptr, 1);
+        } else {
+            self.wr32(ptr, STAMP_FREE);
+            self.units_start += UNIT_SIZE;
+        }
+    }
+
+    /// `MoveUnitsUp`.
+    pub fn move_units_up(&mut self, old_ptr: usize, nu: usize) -> usize {
+        let indx = self.units2indx[nu - 1] as usize;
+        // The C compares the raw pointer against the free-list head pointer.
+        // With 1-based refs and NULL == 0, `PP_BLK(next)` is 0 for an empty
+        // list, so `OldPtr > NULL` is true and the early return fires -- which
+        // is what keeps this from removing off an empty list.
+        let head = self.blist[indx].next;
+        let head_off = if head == 0 { 0usize } else { self.off_of(head) };
+        if old_ptr > self.units_start + 16 * 1024 || old_ptr > head_off {
+            return old_ptr;
+        }
+        let ptr = self.remove(indx);
+        self.units_cpy(ptr, old_ptr, nu);
+        let n = self.indx2units[indx] as usize;
+        if old_ptr != self.units_start {
+            self.insert(indx, old_ptr, n);
+        } else {
+            self.units_start += u2b(n);
+        }
+        ptr
+    }
+
+    /// `ExpandTextArea`: reclaim free blocks sitting at the bottom of the units
+    /// area back into the text area.
+    pub fn expand_text_area(&mut self) {
+        let mut count = [0u32; N_INDEXES];
+        while self.blk_stamp(self.units_start) == STAMP_FREE {
+            let nu = self.blk_nu(self.units_start) as usize;
+            let idx = self.units2indx[nu - 1] as usize;
+            count[idx] += 1;
+            self.set_blk_stamp(self.units_start, 0);
+            self.units_start += nu * UNIT_SIZE;
+        }
+        for i in 0..N_INDEXES {
+            if count[i] == 0 {
+                continue;
+            }
+            // Walk the list, unlinking the entries that were just zero-stamped.
+            // `p` starts at the list HEAD, which lives outside the heap, so the
+            // head case is handled separately from the in-heap nodes.
+            loop {
+                let head = self.blist[i].next;
+                if head == 0 {
+                    break;
+                }
+                let head_off = self.off_of(head);
+                if self.blk_stamp(head_off) != 0 {
+                    break;
+                }
+                self.blist[i].next = self.blk_next(head_off);
+                self.blist[i].stamp -= 1;
+                count[i] -= 1;
+                if count[i] == 0 {
+                    break;
+                }
+            }
+            let mut p = self.blist[i].next;
+            while count[i] != 0 && p != 0 {
+                let p_off = self.off_of(p);
+                loop {
+                    let nx = self.blk_next(p_off);
+                    if nx == 0 {
+                        break;
+                    }
+                    let nx_off = self.off_of(nx);
+                    if self.blk_stamp(nx_off) != 0 {
+                        break;
+                    }
+                    self.set_blk_next(p_off, self.blk_next(nx_off));
+                    self.blist[i].stamp -= 1;
+                    count[i] -= 1;
+                    if count[i] == 0 {
+                        break;
+                    }
+                }
+                p = self.blk_next(p_off);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The derived constants, which everything else is sized against.
+    #[test]
+    fn constants_match_the_c() {
+        assert_eq!(UNIT_SIZE, 12);
+        // N4 = (128 + 3 - 4 - 8 - 12) / 4 = 107 / 4 = 26
+        assert_eq!(N4, 26);
+        assert_eq!(N_INDEXES, 38);
+    }
+
+    /// `Indx2Units` / `Units2Indx` are pure functions of the constants, so they
+    /// can be checked without the C: sizes rise 1,2,3,4 per group, and the
+    /// index table maps each size to the first unit class that fits it.
+    #[test]
+    fn index_tables_are_consistent() {
+        let a = SubAllocator::new();
+        assert_eq!(a.indx2units[0], 1);
+        assert_eq!(a.indx2units[N1 - 1], 4);
+        // Every size 1..=128 must map to a class at least that large.
+        for k in 1..=128usize {
+            let idx = a.units2indx[k - 1] as usize;
+            assert!(
+                a.indx2units[idx] as usize >= k,
+                "size {k} mapped to class {idx} of {} units",
+                a.indx2units[idx]
+            );
+            if idx > 0 {
+                assert!(
+                    (a.indx2units[idx - 1] as usize) < k,
+                    "size {k} should have fit class {}",
+                    idx - 1
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn init_splits_the_heap_one_eighth_to_text() {
+        let mut a = SubAllocator::new();
+        assert!(a.start(1 << 20));
+        a.init();
+        assert_eq!(a.p_text, 0);
+        assert_eq!(a.hi_unit, 1 << 20);
+        assert_eq!(a.lo_unit, a.units_start);
+        // The units area is 7/8 of the heap, rounded to whole units.
+        let diff = UNIT_SIZE * ((1usize << 20) / 8 / UNIT_SIZE * 7);
+        assert_eq!(a.units_start, (1 << 20) - diff);
+        // Nothing is allocated yet, so used memory is 0: the two subtracted
+        // spans -- the untouched units area (HiUnit-LoUnit) and the whole text
+        // area (UnitsStart-pText) -- cover the heap exactly.
+        assert_eq!(a.get_used_memory(), 0);
+    }
+
+    #[test]
+    fn alloc_and_free_round_trip_through_the_free_lists() {
+        let mut a = SubAllocator::new();
+        assert!(a.start(1 << 20));
+        a.init();
+        let before = a.get_used_memory();
+        let p = a.alloc_units(3);
+        assert_ne!(p, 0);
+        assert!(a.get_used_memory() > before);
+        a.free_units(p, 3);
+        // Freeing returns the block to a list, which get_used_memory subtracts.
+        assert_eq!(a.get_used_memory(), before);
+        // The next same-sized request must reuse it, not bump LoUnit.
+        let q = a.alloc_units(3);
+        assert_eq!(q, p, "a freed block should be handed straight back");
+    }
+
+    #[test]
+    fn contexts_are_allocated_downwards_from_the_top() {
+        let mut a = SubAllocator::new();
+        assert!(a.start(1 << 20));
+        a.init();
+        let c1 = a.alloc_context();
+        let c2 = a.alloc_context();
+        assert_eq!(c1, (1 << 20) - UNIT_SIZE);
+        assert_eq!(c2, c1 - UNIT_SIZE);
+    }
+}

--- a/rust/darc-codecs/src/ppmd/suballoc.rs
+++ b/rust/darc-codecs/src/ppmd/suballoc.rs
@@ -190,6 +190,12 @@ impl SubAllocator {
         self.wr32(p + 8, v)
     }
 
+    /// `BList[i].Stamp`, which `RestoreModelRare` reads directly:
+    /// `GlueCount += !(BList[1].Stamp & 1)`.
+    pub fn blist_stamp(&self, i: usize) -> u32 {
+        self.blist[i].stamp
+    }
+
     pub fn heap(&self) -> &[u8] {
         &self.heap
     }

--- a/rust/difftest/ppmd-alloc-check.sh
+++ b/rust/difftest/ppmd-alloc-check.sh
@@ -19,11 +19,25 @@
 # relative refs internally (its BLKREF/CTX_REF exist for 64-bit portability),
 # so nothing is weakened by comparing offsets.
 #
-# NOTE on the op count. At 3000 ops on a 64 KB heap BOTH binaries run for many
-# minutes -- the C exactly as much as the port, so it is a property of this
-# driver's op mix thrashing GlueFreeBlocks on an exhausted heap, not a defect in
-# either. 800 keeps every combination well under a second while still driving
-# the heap into exhaustion and out again.
+# # The C does not always terminate, and that shapes this harness
+#
+# GlueFreeBlocks absorbs a following free block with
+#
+#     while ((p1 = p + p->NU)->Stamp == ~0U) { p->NU += p1->NU;  p1->NU = 0; }
+#
+# which clears the absorbed block's NU but leaves its Stamp reading ~0U. The
+# heap therefore accumulates husks: twelve bytes that still say "free" and claim
+# zero units. When a later block's end lands on a husk the loop adds zero,
+# rewrites zero, and recomputes the same p1 -- for ever. Seed 42 on an 8 KB heap
+# reaches it at operation 146, and the husk it spins on was zeroed by an earlier
+# absorb in the same run.
+#
+# The port breaks out of that loop (see suballoc.rs); the C cannot, so no output
+# the C is capable of producing depends on the difference. This harness relies
+# on exactly that: every driver run is capped, a C that runs over the cap is
+# reported rather than waited on, and the comparison is retried at the largest
+# op count the C still returns from. A cap was not optional -- without one this
+# script ran 48 minutes in CI and was killed with nothing printed.
 set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 . "$ROOT/rust/difftest/c-reference.sh"
@@ -44,32 +58,88 @@ cc "$W/c"                    || { echo "C driver failed to build"    >&2; exit 1
 cc "$W/rs" -DUSE_RUST "$LIB" || { echo "Rust driver failed to build" >&2; exit 1; }
 [ -x "$W/c" ] && [ -x "$W/rs" ] || { echo "a driver is missing after a clean build" >&2; exit 1; }
 
+# Seconds a single driver run may take. Generous next to the ~1s a terminating
+# run needs even on a loaded runner, and small enough that the worst case (every
+# combination hitting the glue loop) stays inside a few minutes.
+CAP=15
+# macOS ships no timeout(1) and no gtimeout(1), and this harness runs on both
+# platforms, so the cap is enforced with perl rather than coreutils. 124 on
+# expiry, matching timeout(1) so the convention reads the same.
+capped() { # capped SECONDS OUTFILE CMD... ; 0 = finished, 124 = ran over
+  local secs="$1" out="$2"; shift 2
+  perl -e 'my $t = shift;
+           my $pid = fork; exit 125 unless defined $pid;
+           unless ($pid) { exec @ARGV; exit 127 }
+           $SIG{ALRM} = sub { kill 9, $pid; waitpid $pid, 0; exit 124 };
+           alarm $t; waitpid $pid, 0; exit $? >> 8' \
+       "$secs" "$@" >| "$out" 2>&1
+}
+
+# Largest op count <= $3 that the C returns from. Every probe is capped, so the
+# search costs at most a handful of CAPs even when the top of the range hangs.
+largest_terminating() { # largest_terminating SEED HEAP_KB N
+  local seed="$1" heap="$2" hi="$3" lo=1 mid
+  while [ $((hi - lo)) -gt 1 ]; do
+    mid=$(( (lo + hi) / 2 ))
+    if capped "$CAP" "$W/probe" "$W/c" "$seed" "$heap" "$mid"; then lo="$mid"; else hi="$mid"; fi
+  done
+  echo "$lo"
+}
+
 OPS=800
-# The exhausting heap needs far fewer ops to reach AllocUnitsRare, and a long
-# run there is exactly what thrashes GlueFreeBlocks.
+# The small heaps need far fewer ops to reach AllocUnitsRare, and a long run
+# there is exactly what walks into the glue loop.
 SMALL_OPS=150
-fail=0; ok=0
+# The heap size that reliably drives allocation to FAILURE, which is what
+# reaches AllocUnitsRare's last resort and the pText/UnitsStart crossing the
+# model restarts on. Measured over seeds 1/7/42 at SMALL_OPS: 2 KB fails 3-5
+# times per seed, 8 KB fails not at all -- the unit area there is 595 units and
+# this op mix allocates about that many, so it stops just short.
+EXHAUST_KB=2
+fail=0; ok=0; hung=0
 for seed in 1 7 42 1337; do
-  # 8 KB exhausts quickly and drives AllocUnitsRare / GlueFreeBlocks; the two
-  # large sizes stay on the fast path. Middling heaps (16-64 KB) are avoided
-  # deliberately: there this driver's op mix thrashes GlueFreeBlocks for
-  # minutes -- in the C exactly as much as in the port, so it is the mix and
-  # not either implementation, but it makes for a uselessly slow harness.
-  for heap in 8 256 1024; do
+  # 2 KB exhausts, 8 KB is where seeds 42 and 1337 meet the C's non-terminating
+  # glue loop, and the two large sizes stay on the fast path. All three shapes
+  # are wanted; none of them subsumes another.
+  for heap in "$EXHAUST_KB" 8 256 1024; do
     n="$OPS"; [ "$heap" -le 8 ] && n="$SMALL_OPS"
-    "$W/c"  "$seed" "$heap" "$n" >| "$W/tc" 2>&1
-    "$W/rs" "$seed" "$heap" "$n" >| "$W/tr" 2>&1
+    # Progress, because a silent harness and a hung one look identical -- which
+    # is precisely how the 48-minute CI run went unnoticed until it was killed.
+    printf '  seed=%-5s heap=%5sKB ops=%-4s ' "$seed" "$heap" "$n"
+
+    if ! capped "$CAP" "$W/tc" "$W/c" "$seed" "$heap" "$n"; then
+      # The C is in the glue loop. First prove the port is NOT -- that is the
+      # whole value of the husk break, and an assertion here is what keeps it
+      # from rotting into dead code.
+      if ! capped "$CAP" "$W/tr" "$W/rs" "$seed" "$heap" "$n"; then
+        echo "BOTH drivers ran over ${CAP}s -- the port's husk break is not working"
+        fail=$((fail + 1)); continue
+      fi
+      hung=$((hung + 1))
+      n="$(largest_terminating "$seed" "$heap" "$n")"
+      printf 'C hangs; retrying at %s ops ' "$n"
+      if ! capped "$CAP" "$W/tc" "$W/c" "$seed" "$heap" "$n"; then
+        echo "-- the C hangs even at $n ops, nothing to compare"
+        fail=$((fail + 1)); continue
+      fi
+    fi
+
+    if ! capped "$CAP" "$W/tr" "$W/rs" "$seed" "$heap" "$n"; then
+      echo "the PORT ran over ${CAP}s where the C returned"
+      fail=$((fail + 1)); continue
+    fi
     # Two empty traces would compare equal; every run emits at least the init
     # line, so require real output before believing a match.
     if [ ! -s "$W/tc" ]; then
-      echo "  seed=$seed heap=${heap}KB: the C driver produced no trace"; fail=$((fail+1)); continue
+      echo "the C driver produced no trace"; fail=$((fail + 1)); continue
     fi
     if cmp -s "$W/tc" "$W/tr"; then
-      ok=$((ok+1))
+      echo "ok"
+      ok=$((ok + 1))
     else
-      echo "  seed=$seed heap=${heap}KB: allocator DIVERGES from the C"
+      echo "DIVERGES from the C"
       diff "$W/tc" "$W/tr" | head -6
-      fail=$((fail+1))
+      fail=$((fail + 1))
     fi
   done
 done
@@ -79,15 +149,23 @@ done
 # that decide where the model restarts -- went untested.
 rare=0
 for seed in 1 7 42; do
-  "$W/c" "$seed" 8 "$SMALL_OPS" >| "$W/tc" 2>&1 || continue
-  grep -q -- '-> -1' "$W/tc" && rare=$((rare+1))
+  capped "$CAP" "$W/tc" "$W/c" "$seed" "$EXHAUST_KB" "$SMALL_OPS" || continue
+  grep -q -- '-> -1' "$W/tc" && rare=$((rare + 1))
 done
 
 [ "$ok" -gt 0 ] || { echo "nothing was compared -- the harness reached nothing"; exit 1; }
 [ "$rare" -ge 2 ] || {
   echo "only $rare of 3 seeds ever exhausted the heap; AllocUnitsRare and"
   echo "GlueFreeBlocks are going untested and those decide model restarts"
-  fail=$((fail+1)); }
+  fail=$((fail + 1)); }
+[ "$hung" -ge 1 ] || {
+  echo "no combination reached the C's non-terminating glue loop, so the port's"
+  echo "husk break went unexercised. Widen the grid or raise SMALL_OPS until one"
+  echo "does, rather than deleting this check -- it is the only thing testing the"
+  echo "single place the port deliberately departs from the C."
+  fail=$((fail + 1)); }
 [ "$fail" -eq 0 ] || { echo "ppmd-alloc: $fail failures"; exit 1; }
-echo "ppmd-alloc: $ok/$ok operation traces identical to the C ($OPS ops each)"
-echo "ppmd-alloc: (offsets, all four layout cursors and GetUsedMemory after every op; $rare/3 seeds exhausted the heap)"
+echo "ppmd-alloc: $ok/$ok operation traces identical to the C"
+echo "ppmd-alloc: (offsets, all four layout cursors and GetUsedMemory after every op;"
+echo "ppmd-alloc:  $rare/3 seeds exhausted the heap; $hung combinations reached the C's"
+echo "ppmd-alloc:  non-terminating glue loop, where the port returned and the C did not)"

--- a/rust/difftest/ppmd-alloc-check.sh
+++ b/rust/difftest/ppmd-alloc-check.sh
@@ -50,8 +50,15 @@ trap 'rm -rf "$W"' EXIT
 LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 [ -f "$LIB" ] || { echo "the Rust staticlib is missing" >&2; exit 1; }
 
+# The same flag list as ppmd-check.sh, copied from Compression/PPMD/makefile.
+# See the long note there: for this codec the optimisation flags are part of the
+# format, so the reference is built the way the shipped codec is built rather
+# than at whatever -O level seemed reasonable.
+PPMD_MAKEFILE_FLAGS="-fno-exceptions -fno-rtti -O1 -fomit-frame-pointer -fno-strict-aliasing -funroll-loops -g0"
 cc() { local out="$1"; shift
-  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+  # shellcheck disable=SC2086  # the flag list is a word list on purpose
+  clang++ -std=c++17 $PPMD_MAKEFILE_FLAGS -w \
+    -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
     -I"$CREF" -I"$CREF/Compression" \
     "$CREF/rust/difftest/ppmd_alloc_ref.cpp" "$CREF/rust/difftest/ppmd_ccodec.cpp" "$@" -o "$out"; }
 cc "$W/c"                    || { echo "C driver failed to build"    >&2; exit 1; }

--- a/rust/difftest/ppmd-alloc-check.sh
+++ b/rust/difftest/ppmd-alloc-check.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Differential-test PPMd's memory suballocator against the C original.
+#
+# # Why the allocator gets a harness of its own
+#
+# ppmd-check.sh compares whole streams, because the coder, model and allocator
+# have no seam between them. But the ALLOCATOR alone does have a testable
+# interface, and it is the part the compressed format is most sensitive to: the
+# model branches on GetUsedMemory() and on pText/UnitsStart crossings, so an
+# allocator that is merely correct still yields a different compressed stream.
+#
+# Both sides run the SAME pseudo-random operation sequence -- the seed picks the
+# ops, so no script file is needed -- and print every returned offset plus the
+# four layout cursors and GetUsedMemory() after each step. A mismatch here
+# points at the free lists rather than at the model wrapped around them.
+#
+# Offsets, not pointers: the C's heap is a malloc'ed block at an arbitrary
+# address and the Rust one is a Vec<u8>. The C already works in HeapStart-
+# relative refs internally (its BLKREF/CTX_REF exist for 64-bit portability),
+# so nothing is weakened by comparing offsets.
+#
+# NOTE on the op count. At 3000 ops on a 64 KB heap BOTH binaries run for many
+# minutes -- the C exactly as much as the port, so it is a property of this
+# driver's op mix thrashing GlueFreeBlocks on an exhausted heap, not a defect in
+# either. 800 keeps every combination well under a second while still driving
+# the heap into exhaustion and out again.
+set -uo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$ROOT/rust/difftest/c-reference.sh"
+CREF="$(darc_c_reference "$ROOT")" || exit 1
+W="${TMPDIR:-/tmp}/ppmd-alloc.$$"; mkdir -p "$W"
+trap 'rm -rf "$W"' EXIT
+
+( cd "$ROOT/rust" && cargo build --release -p darc-codecs ) >/dev/null 2>&1 \
+  || { echo "cargo build failed" >&2; exit 1; }
+LIB="$ROOT/rust/target/release/libdarc_codecs.a"
+[ -f "$LIB" ] || { echo "the Rust staticlib is missing" >&2; exit 1; }
+
+cc() { local out="$1"; shift
+  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+    -I"$CREF" -I"$CREF/Compression" \
+    "$CREF/rust/difftest/ppmd_alloc_ref.cpp" "$CREF/rust/difftest/ppmd_ccodec.cpp" "$@" -o "$out"; }
+cc "$W/c"                    || { echo "C driver failed to build"    >&2; exit 1; }
+cc "$W/rs" -DUSE_RUST "$LIB" || { echo "Rust driver failed to build" >&2; exit 1; }
+[ -x "$W/c" ] && [ -x "$W/rs" ] || { echo "a driver is missing after a clean build" >&2; exit 1; }
+
+OPS=800
+# The exhausting heap needs far fewer ops to reach AllocUnitsRare, and a long
+# run there is exactly what thrashes GlueFreeBlocks.
+SMALL_OPS=150
+fail=0; ok=0
+for seed in 1 7 42 1337; do
+  # 8 KB exhausts quickly and drives AllocUnitsRare / GlueFreeBlocks; the two
+  # large sizes stay on the fast path. Middling heaps (16-64 KB) are avoided
+  # deliberately: there this driver's op mix thrashes GlueFreeBlocks for
+  # minutes -- in the C exactly as much as in the port, so it is the mix and
+  # not either implementation, but it makes for a uselessly slow harness.
+  for heap in 8 256 1024; do
+    n="$OPS"; [ "$heap" -le 8 ] && n="$SMALL_OPS"
+    "$W/c"  "$seed" "$heap" "$n" >| "$W/tc" 2>&1
+    "$W/rs" "$seed" "$heap" "$n" >| "$W/tr" 2>&1
+    # Two empty traces would compare equal; every run emits at least the init
+    # line, so require real output before believing a match.
+    if [ ! -s "$W/tc" ]; then
+      echo "  seed=$seed heap=${heap}KB: the C driver produced no trace"; fail=$((fail+1)); continue
+    fi
+    if cmp -s "$W/tc" "$W/tr"; then
+      ok=$((ok+1))
+    else
+      echo "  seed=$seed heap=${heap}KB: allocator DIVERGES from the C"
+      diff "$W/tc" "$W/tr" | head -6
+      fail=$((fail+1))
+    fi
+  done
+done
+
+# Coverage: the whole point of the small heaps is to reach AllocUnitsRare and
+# GlueFreeBlocks. If nothing ever failed to allocate, the hard paths -- the ones
+# that decide where the model restarts -- went untested.
+rare=0
+for seed in 1 7 42; do
+  "$W/c" "$seed" 8 "$SMALL_OPS" >| "$W/tc" 2>&1 || continue
+  grep -q -- '-> -1' "$W/tc" && rare=$((rare+1))
+done
+
+[ "$ok" -gt 0 ] || { echo "nothing was compared -- the harness reached nothing"; exit 1; }
+[ "$rare" -ge 2 ] || {
+  echo "only $rare of 3 seeds ever exhausted the heap; AllocUnitsRare and"
+  echo "GlueFreeBlocks are going untested and those decide model restarts"
+  fail=$((fail+1)); }
+[ "$fail" -eq 0 ] || { echo "ppmd-alloc: $fail failures"; exit 1; }
+echo "ppmd-alloc: $ok/$ok operation traces identical to the C ($OPS ops each)"
+echo "ppmd-alloc: (offsets, all four layout cursors and GetUsedMemory after every op; $rare/3 seeds exhausted the heap)"

--- a/rust/difftest/ppmd-check.sh
+++ b/rust/difftest/ppmd-check.sh
@@ -39,23 +39,37 @@ trap 'rm -rf "$W"' EXIT
 LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 [ -f "$LIB" ] || { echo "the Rust staticlib is missing" >&2; exit 1; }
 
-# -O1, NOT -O2, and this is load-bearing.
+# THE OPTIMISATION FLAGS ARE PART OF THE FORMAT. Copy them from
+# Compression/PPMD/makefile, do not choose them.
 #
 # PPMd's StateCpy/SWAP type-pun through `(WORD&)` references, which violates
-# strict aliasing. In rescale(), the compiler is then free to assume those WORD
-# writes cannot alias the BYTE read in `if (p->Freq == 0)`, and at -O1 it reuses
-# the value ASSIGNED earlier in the loop rather than re-reading the slot the
-# bubble sort has since overwritten. The two readings disagree, so THE SAME C
-# SOURCE PRODUCES DIFFERENT COMPRESSED BYTES AT DIFFERENT -O LEVELS. Measured on
-# a 92-byte input at order 3:
+# strict aliasing. A compiler permitted to assume those WORD writes cannot alias
+# the BYTE read in rescale()'s `if (p->Freq == 0)` reuses the value ASSIGNED
+# earlier in the loop rather than reloading the slot the bubble sort has since
+# overwritten -- and the two readings produce DIFFERENT COMPRESSED BYTES from
+# the same source. Measured on the `dominant` corpus shape at orders 3/4/10/16:
 #
-#     -O0 -> 669d679a...      -O1 -> f6cb8287...      -O2 -> f6cb8287...
+#     -O1                        reuses the assigned value
+#     -O2                        reuses the assigned value
+#     -O0                        re-reads
+#     -O1 -fno-strict-aliasing   re-reads
 #
-# Compression/PPMD/makefile builds at -O1, so -O1 is what every existing -mppmd
-# archive was written with, and the only defensible oracle. Changing this flag
-# silently changes what "byte-identical" means.
+# So pinning the -O level is NOT sufficient, and an oracle built at a bare -O1
+# is wrong: the makefile passes -fno-strict-aliasing, which is what real -mppmd
+# archives were written with. Isolated by flag -- -fno-strict-aliasing alone
+# flips the output; -fomit-frame-pointer and -funroll-loops do not.
+#
+# compile-win64-c carries the same warning for the same reason: a Win64 build
+# whose PPMD flags drift from this list writes archives Linux cannot reproduce.
+#
+# There is a second reason to prefer this oracle: with -fno-strict-aliasing the
+# answer no longer depends on how clever the compiler's alias analysis is, so it
+# is stable across compilers and versions. The bare -O1 reading was not.
+PPMD_MAKEFILE_FLAGS="-fno-exceptions -fno-rtti -O1 -fomit-frame-pointer -fno-strict-aliasing -funroll-loops -g0"
 cc() { local out="$1"; shift
-  clang++ -std=c++17 -O1 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+  # shellcheck disable=SC2086  # the flag list is a word list on purpose
+  clang++ -std=c++17 $PPMD_MAKEFILE_FLAGS -w \
+    -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
     -I"$CREF" -I"$CREF/Compression" \
     "$CREF/rust/difftest/ppmd_ref.cpp" "$CREF/rust/difftest/ppmd_ccodec.cpp" "$@" -o "$out"; }
 cc "$W/c"                    || { echo "C driver failed to build"    >&2; exit 1; }

--- a/rust/difftest/ppmd-check.sh
+++ b/rust/difftest/ppmd-check.sh
@@ -112,10 +112,55 @@ fail=0; enc=0; dec=0; declined=0
 # whole thing. Order 2 is deliberately absent even from the full grid: PPMd is
 # pathologically slow on the `dominant` shape there, in the C as much as in the
 # port, so including it buys nothing but wall-clock.
+# Two properties byte-identity cannot see, checked once before the grid starts
+# sending stderr to /dev/null and stops timing anything.
+#
+# They are not hypothetical. A per-symbol `eprintln!` survived in the port
+# through 798 byte-identical streams: every comparison passed, the trace went to
+# /dev/null, and the only visible symptom was a CI job that took 634 seconds
+# instead of twenty. In the shipped archiver it would have flooded the terminal
+# with a line per input byte.
+for drv in c rs; do
+  "$W/$drv" c 8 8 0 < "$W/in/text" >| "$W/q" 2>| "$W/qerr"
+  [ -s "$W/qerr" ] || continue
+  echo "the $drv driver wrote to stderr during a normal encode:"
+  head -3 "$W/qerr"
+  echo "a codec must be silent -- this would print into the archiver's console"
+  exit 1
+done
+now() { perl -MTime::HiRes=time -e 'print time'; }
+t0=$(now); "$W/c"  c 8 8 0 < "$W/in/bignoise" >|/dev/null 2>&1
+t1=$(now); "$W/rs" c 8 8 0 < "$W/in/bignoise" >|/dev/null 2>&1
+t2=$(now)
+c_secs=$(perl -e 'printf "%.3f", $ARGV[1]-$ARGV[0]' "$t0" "$t1")
+r_secs=$(perl -e 'printf "%.3f", $ARGV[1]-$ARGV[0]' "$t1" "$t2")
+# A ratio, not a wall clock, so it does not care how fast the runner is. Ten is
+# far above the ~2x a faithful port costs in bounds checks and byte-offset
+# arithmetic, and far below what stray I/O in the per-symbol path produces --
+# the eprintln! above measured 470x. Skipped rather than guessed if the
+# reference run was too short to time.
+if awk -v c="$c_secs" 'BEGIN { exit (c >= 0.05) ? 0 : 1 }'; then
+  ratio=$(perl -e 'printf "%.1f", $ARGV[0]/$ARGV[1]' "$r_secs" "$c_secs")
+  echo "ppmd: encode speed vs the C on 600 KB: ${ratio}x (${c_secs}s -> ${r_secs}s)"
+  awk -v r="$ratio" 'BEGIN { exit (r <= 10) ? 0 : 1 }' || {
+    echo "${ratio}x is not port overhead. Look for I/O, an allocation, or a"
+    echo "rebuilt table in the per-symbol path."
+    exit 1; }
+else
+  echo "ppmd: the C reference encoded 600 KB in ${c_secs}s, too fast to time a ratio against"
+fi
+
 ORDERS="${PPMD_ORDERS:-3 4 10 16}"
 MEMS="${PPMD_MEMS:-1 8}"
 for order in $ORDERS; do
   for mem in $MEMS; do
+    # One line per (order, budget), because this grid runs for tens of minutes
+    # and printed nothing until the end. A silent run and a hung one then look
+    # identical -- which is exactly how a sibling harness burned 48 minutes of a
+    # CI job before anyone could tell it was stuck.
+    # Printed BEFORE the work, not after: the point is to name the combination
+    # a stuck run is stuck on, and a line printed on completion cannot do that.
+    echo "  order=$order mem=${mem}M"
     for mrm in 0 1 2; do
       for f in "$W"/in/*; do
         bn="$(basename "$f") o$order m${mem}M mrm$mrm"

--- a/rust/difftest/ppmd-check.sh
+++ b/rust/difftest/ppmd-check.sh
@@ -39,8 +39,23 @@ trap 'rm -rf "$W"' EXIT
 LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 [ -f "$LIB" ] || { echo "the Rust staticlib is missing" >&2; exit 1; }
 
+# -O1, NOT -O2, and this is load-bearing.
+#
+# PPMd's StateCpy/SWAP type-pun through `(WORD&)` references, which violates
+# strict aliasing. In rescale(), the compiler is then free to assume those WORD
+# writes cannot alias the BYTE read in `if (p->Freq == 0)`, and at -O1 it reuses
+# the value ASSIGNED earlier in the loop rather than re-reading the slot the
+# bubble sort has since overwritten. The two readings disagree, so THE SAME C
+# SOURCE PRODUCES DIFFERENT COMPRESSED BYTES AT DIFFERENT -O LEVELS. Measured on
+# a 92-byte input at order 3:
+#
+#     -O0 -> 669d679a...      -O1 -> f6cb8287...      -O2 -> f6cb8287...
+#
+# Compression/PPMD/makefile builds at -O1, so -O1 is what every existing -mppmd
+# archive was written with, and the only defensible oracle. Changing this flag
+# silently changes what "byte-identical" means.
 cc() { local out="$1"; shift
-  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+  clang++ -std=c++17 -O1 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
     -I"$CREF" -I"$CREF/Compression" \
     "$CREF/rust/difftest/ppmd_ref.cpp" "$CREF/rust/difftest/ppmd_ccodec.cpp" "$@" -o "$out"; }
 cc "$W/c"                    || { echo "C driver failed to build"    >&2; exit 1; }
@@ -58,6 +73,13 @@ def prng(seed,n):
     for _ in range(n): s=(s*1103515245+12345)&0xffffffff; o.append((s>>16)&0xff)
     return bytes(o)
 w=lambda n,b: open(f"{d}/{n}","wb").write(b)
+def _dom():
+    # Small on purpose: PPMd is pathologically slow on this shape at low order
+    # (minutes for 8 KB in the C as much as in the port), and 1.5 KB already
+    # reaches the rescale path this input exists to cover.
+    import random
+    r = random.Random(3)
+    return r.choices(range(256), weights=[4000] + [1]*255, k=1500)
 w("text",       b"the quick brown fox jumps over the lazy dog. "*6000)
 w("english",    (b"compression algorithms rearrange data so that statistical "
                  b"redundancy can be removed by an entropy coder. ")*2500)
@@ -67,6 +89,18 @@ w("runs",       b"".join(bytes([i%97])*(1+(i*7)%200) for i in range(2000)))
 w("full_alpha", bytes(range(256))*500)
 w("sparse",     b"".join(b"\x00"*300 + bytes([i%251]) for i in range(400)))
 w("binaryish",  bytes((i*2654435761>>16)&0xff for i in range(150000)))
+# These three exhaust a 1 MB model and so reach the restart paths. Measured:
+# high-entropy data at 200 KB+ is what fills the heap; text and short runs
+# compress far too well to ever get there.
+# A dominant symbol plus a long tail of rare ones, at LOW order. This is the
+# only shape found that reaches rescale's shrink path -- zero-frequency states
+# dropped while the context keeps more than one -- and it is where the port's
+# one real bug lived: `EscFreq` is UINT in rescale but int in refresh, so a
+# signed port diverges exactly when it wraps. Every other input in this corpus
+# passed with that bug present.
+w("dominant",   bytes(_dom()))
+w("bignoise",   prng(3, 600000))
+w("mixed",      prng(5, 300000) + b"the quick brown fox "*5000)
 for n in (1,2,3,17,255,256,4096,65536):
     w(f"n_{n}", (b"abracadabra"*10000)[:n])
 CORPUS
@@ -74,7 +108,7 @@ CORPUS
 fail=0; enc=0; dec=0; declined=0
 
 # order: PPMd var.H accepts 2..64. mem in MB. mrm: 0 restart, 1 cut off, 2 freeze.
-for order in 4 10 16; do
+for order in 3 4 10 16; do
   for mem in 1 8; do
     for mrm in 0 1 2; do
       for f in "$W"/in/*; do
@@ -110,7 +144,7 @@ done
 # the 1 MB budget never differs from the 8 MB one, the allocator pressure that
 # makes this codec hard is going untested.
 restarts=0
-for f in "$W"/in/noise "$W"/in/binaryish "$W"/in/runs; do
+for f in "$W"/in/noise "$W"/in/bignoise "$W"/in/mixed; do
   "$W/c" c 16 1 0 < "$f" >| "$W/a" 2>/dev/null || continue
   "$W/c" c 16 8 0 < "$f" >| "$W/b" 2>/dev/null || continue
   cmp -s "$W/a" "$W/b" || restarts=$((restarts+1))

--- a/rust/difftest/ppmd-check.sh
+++ b/rust/difftest/ppmd-check.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Differential-test PPMd var.H against the C original.
+#
+# # Why this harness cuts at the whole stream, and cannot cut lower
+#
+# Every other codec here is compared stage by stage. PPMd cannot be, because its
+# output is a function of its MEMORY SUBALLOCATOR, not just of its input:
+#
+#   Model.cpp:245  GetUsedMemory() < (SubAllocatorSize >> 1)   decides restart
+#   Model.cpp:416  if (pText >= UnitsStart) goto RESTART_MODEL
+#   Model.cpp:418  if ((BYTE*) FSuccessor < UnitsStart)
+#
+# Measured before the port was written, so this is not an inference from
+# reading: the same 200 KB input at order 16 encodes to 204797 / 205303 /
+# 206007 / 206098 bytes at a 1 / 2 / 4 / 8 MB budget, all four with different
+# contents. MRMethod 2 (freeze) diverges from 0 and 1 as well.
+#
+# The consequence for the port is the opposite of libsais, where any correct
+# suffix array reproduced the C: here there is NO algorithmic latitude at all.
+# SubAlloc.hpp must be reproduced exactly -- free lists, unit sizes, glue
+# behaviour and the resulting addresses -- because a merely-correct allocator
+# reports a different GetUsedMemory(), crosses UnitsStart at a different moment,
+# restarts the model somewhere else, and changes every byte from there on.
+#
+# The coder, the model and the allocator are one system with no seam, so the
+# stream is the only honest cut.
+#
+# The C reference comes from a pinned revision, not the working tree -- see
+# c-reference.sh for why.
+set -uo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$ROOT/rust/difftest/c-reference.sh"
+CREF="$(darc_c_reference "$ROOT")" || exit 1
+W="${TMPDIR:-/tmp}/ppmd-check.$$"; mkdir -p "$W"
+trap 'rm -rf "$W"' EXIT
+
+( cd "$ROOT/rust" && cargo build --release -p darc-codecs ) >/dev/null 2>&1 \
+  || { echo "cargo build failed" >&2; exit 1; }
+LIB="$ROOT/rust/target/release/libdarc_codecs.a"
+[ -f "$LIB" ] || { echo "the Rust staticlib is missing" >&2; exit 1; }
+
+cc() { local out="$1"; shift
+  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+    -I"$CREF" -I"$CREF/Compression" \
+    "$CREF/rust/difftest/ppmd_ref.cpp" "$CREF/rust/difftest/ppmd_ccodec.cpp" "$@" -o "$out"; }
+cc "$W/c"                    || { echo "C driver failed to build"    >&2; exit 1; }
+cc "$W/rs" -DUSE_RUST "$LIB" || { echo "Rust driver failed to build" >&2; exit 1; }
+[ -x "$W/c" ] && [ -x "$W/rs" ] || { echo "a driver is missing after a clean build" >&2; exit 1; }
+
+# The corpus targets what the MODEL is sensitive to: order (how much context is
+# tracked), and memory pressure (whether the model restarts mid-stream). Sizes
+# are chosen so the small budgets below genuinely exhaust the allocator.
+python3 - "$W/in" <<'CORPUS'
+import os,sys
+d=sys.argv[1]; os.makedirs(d,exist_ok=True)
+def prng(seed,n):
+    s=seed; o=bytearray()
+    for _ in range(n): s=(s*1103515245+12345)&0xffffffff; o.append((s>>16)&0xff)
+    return bytes(o)
+w=lambda n,b: open(f"{d}/{n}","wb").write(b)
+w("text",       b"the quick brown fox jumps over the lazy dog. "*6000)
+w("english",    (b"compression algorithms rearrange data so that statistical "
+                 b"redundancy can be removed by an entropy coder. ")*2500)
+w("noise",      prng(7, 200000))          # exhausts a small budget
+w("zeros",      b"\x00"*120000)
+w("runs",       b"".join(bytes([i%97])*(1+(i*7)%200) for i in range(2000)))
+w("full_alpha", bytes(range(256))*500)
+w("sparse",     b"".join(b"\x00"*300 + bytes([i%251]) for i in range(400)))
+w("binaryish",  bytes((i*2654435761>>16)&0xff for i in range(150000)))
+for n in (1,2,3,17,255,256,4096,65536):
+    w(f"n_{n}", (b"abracadabra"*10000)[:n])
+CORPUS
+
+fail=0; enc=0; dec=0; declined=0
+
+# order: PPMd var.H accepts 2..64. mem in MB. mrm: 0 restart, 1 cut off, 2 freeze.
+for order in 4 10 16; do
+  for mem in 1 8; do
+    for mrm in 0 1 2; do
+      for f in "$W"/in/*; do
+        bn="$(basename "$f") o$order m${mem}M mrm$mrm"
+
+        "$W/c"  c "$order" "$mem" "$mrm" < "$f" >| "$W/ec" 2>/dev/null; rc_c=$?
+        "$W/rs" c "$order" "$mem" "$mrm" < "$f" >| "$W/er" 2>/dev/null; rc_r=$?
+        if [ "$rc_c" -ne "$rc_r" ]; then
+          echo "  $bn: encode driver exit differs (C $rc_c, Rust $rc_r)"; fail=$((fail+1)); continue
+        fi
+        [ "$rc_c" -eq 0 ] || { declined=$((declined+1)); continue; }
+        # Both drivers always emit the 4-byte return code, so an empty file
+        # means the driver itself failed rather than the codec declining.
+        [ -s "$W/ec" ] || { echo "  $bn: the C driver produced no output"; fail=$((fail+1)); continue; }
+        enc=$((enc+1))
+        cmp -s "$W/ec" "$W/er" || { echo "  $bn: ENCODED stream differs from the C"; fail=$((fail+1)); continue; }
+
+        # Decode the C's stream with both, which catches a decoder that is
+        # merely self-consistent with a wrong encoder.
+        tail -c +5 "$W/ec" >| "$W/payload"
+        "$W/c"  d "$order" "$mem" "$mrm" < "$W/payload" >| "$W/dc" 2>/dev/null
+        "$W/rs" d "$order" "$mem" "$mrm" < "$W/payload" >| "$W/dr" 2>/dev/null
+        tail -c +5 "$W/dc" >| "$W/dc.p"; tail -c +5 "$W/dr" >| "$W/dr.p"
+        cmp -s "$f" "$W/dc.p" || { echo "  $bn: C round-trip != original (harness bug)"; fail=$((fail+1)); continue; }
+        dec=$((dec+1))
+        cmp -s "$f" "$W/dr.p" || { echo "  $bn: RUST decode != original"; fail=$((fail+1)); }
+      done
+    done
+  done
+done
+
+# Coverage: the whole point of the memory axis is to reach a model restart. If
+# the 1 MB budget never differs from the 8 MB one, the allocator pressure that
+# makes this codec hard is going untested.
+restarts=0
+for f in "$W"/in/noise "$W"/in/binaryish "$W"/in/runs; do
+  "$W/c" c 16 1 0 < "$f" >| "$W/a" 2>/dev/null || continue
+  "$W/c" c 16 8 0 < "$f" >| "$W/b" 2>/dev/null || continue
+  cmp -s "$W/a" "$W/b" || restarts=$((restarts+1))
+done
+
+[ "$enc" -gt 0 ] || { echo "nothing was encoded -- the harness reached nothing"; exit 1; }
+[ "$restarts" -ge 2 ] || {
+  echo "only $restarts of 3 inputs behaved differently at 1 MB vs 8 MB; the"
+  echo "memory-exhaustion path is not being exercised"; fail=$((fail+1)); }
+[ "$fail" -eq 0 ] || { echo "ppmd: $fail failures"; exit 1; }
+echo "ppmd: $enc/$enc streams byte-identical to the C, $dec decoded back"
+echo "ppmd: ($declined declined by both; $restarts/3 inputs reached memory exhaustion)"

--- a/rust/difftest/ppmd-check.sh
+++ b/rust/difftest/ppmd-check.sh
@@ -108,8 +108,14 @@ CORPUS
 fail=0; enc=0; dec=0; declined=0
 
 # order: PPMd var.H accepts 2..64. mem in MB. mrm: 0 restart, 1 cut off, 2 freeze.
-for order in 3 4 10 16; do
-  for mem in 1 8; do
+# The grid is parameterised so a laptop can run a cheap slice while CI runs the
+# whole thing. Order 2 is deliberately absent even from the full grid: PPMd is
+# pathologically slow on the `dominant` shape there, in the C as much as in the
+# port, so including it buys nothing but wall-clock.
+ORDERS="${PPMD_ORDERS:-3 4 10 16}"
+MEMS="${PPMD_MEMS:-1 8}"
+for order in $ORDERS; do
+  for mem in $MEMS; do
     for mrm in 0 1 2; do
       for f in "$W"/in/*; do
         bn="$(basename "$f") o$order m${mem}M mrm$mrm"

--- a/rust/difftest/ppmd_alloc_ref.cpp
+++ b/rust/difftest/ppmd_alloc_ref.cpp
@@ -1,0 +1,169 @@
+/* Reference driver for differential-testing PPMd's memory suballocator.
+ *
+ *     ppmd_alloc_ref SEED HEAP_KB NOPS  >trace
+ *
+ * Built twice: plain drives the C, `-DUSE_RUST` the Rust port. Both run the
+ * SAME pseudo-random operation sequence -- the seed picks the ops, so the two
+ * sides are driven identically without needing a script file -- and print a
+ * trace of every offset returned plus the four layout cursors and
+ * GetUsedMemory() after each step.
+ *
+ * Comparing offsets rather than pointers is what makes this possible: the C's
+ * heap is a malloc'ed block at an arbitrary address, the Rust one is a Vec<u8>.
+ * The C already works in HeapStart-relative refs internally for exactly this
+ * reason (64-bit portability), so nothing is being weakened by the choice.
+ *
+ * Why the allocator gets its own harness when the codec does not: the model
+ * branches on GetUsedMemory() and on pText/UnitsStart crossings, so an
+ * allocator that is merely correct still produces a different compressed
+ * stream. Testing it alone means a mismatch points at the free lists rather
+ * than at the model wrapped around them.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern "C" {
+#ifdef USE_RUST
+  long     darc_rs_ppmd_sa_start        (unsigned t);
+  void     darc_rs_ppmd_sa_init         (void);
+  void     darc_rs_ppmd_sa_stop         (void);
+  unsigned darc_rs_ppmd_sa_used         (void);
+  long     darc_rs_ppmd_sa_alloc_units  (unsigned nu);
+  long     darc_rs_ppmd_sa_alloc_context(void);
+  void     darc_rs_ppmd_sa_free_units   (long off, unsigned nu);
+  long     darc_rs_ppmd_sa_expand_units (long off, unsigned nu);
+  long     darc_rs_ppmd_sa_shrink_units (long off, unsigned nu, unsigned newnu);
+  void     darc_rs_ppmd_sa_special_free (long off);
+  long     darc_rs_ppmd_sa_ptext        (void);
+  long     darc_rs_ppmd_sa_units_start  (void);
+  long     darc_rs_ppmd_sa_lo_unit      (void);
+  long     darc_rs_ppmd_sa_hi_unit      (void);
+  #define SA_START        darc_rs_ppmd_sa_start
+  #define SA_INIT         darc_rs_ppmd_sa_init
+  #define SA_STOP         darc_rs_ppmd_sa_stop
+  #define SA_USED         darc_rs_ppmd_sa_used
+  #define SA_ALLOC_UNITS  darc_rs_ppmd_sa_alloc_units
+  #define SA_ALLOC_CTX    darc_rs_ppmd_sa_alloc_context
+  #define SA_FREE_UNITS   darc_rs_ppmd_sa_free_units
+  #define SA_EXPAND       darc_rs_ppmd_sa_expand_units
+  #define SA_SHRINK       darc_rs_ppmd_sa_shrink_units
+  #define SA_SPECIAL_FREE darc_rs_ppmd_sa_special_free
+  #define SA_PTEXT        darc_rs_ppmd_sa_ptext
+  #define SA_UNITS_START  darc_rs_ppmd_sa_units_start
+  #define SA_LO           darc_rs_ppmd_sa_lo_unit
+  #define SA_HI           darc_rs_ppmd_sa_hi_unit
+#else
+  long     darc_ppmd_sa_start        (unsigned t);
+  void     darc_ppmd_sa_init         (void);
+  void     darc_ppmd_sa_stop         (void);
+  unsigned darc_ppmd_sa_used         (void);
+  long     darc_ppmd_sa_alloc_units  (unsigned nu);
+  long     darc_ppmd_sa_alloc_context(void);
+  void     darc_ppmd_sa_free_units   (long off, unsigned nu);
+  long     darc_ppmd_sa_expand_units (long off, unsigned nu);
+  long     darc_ppmd_sa_shrink_units (long off, unsigned nu, unsigned newnu);
+  void     darc_ppmd_sa_special_free (long off);
+  long     darc_ppmd_sa_ptext        (void);
+  long     darc_ppmd_sa_units_start  (void);
+  long     darc_ppmd_sa_lo_unit      (void);
+  long     darc_ppmd_sa_hi_unit      (void);
+  #define SA_START        darc_ppmd_sa_start
+  #define SA_INIT         darc_ppmd_sa_init
+  #define SA_STOP         darc_ppmd_sa_stop
+  #define SA_USED         darc_ppmd_sa_used
+  #define SA_ALLOC_UNITS  darc_ppmd_sa_alloc_units
+  #define SA_ALLOC_CTX    darc_ppmd_sa_alloc_context
+  #define SA_FREE_UNITS   darc_ppmd_sa_free_units
+  #define SA_EXPAND       darc_ppmd_sa_expand_units
+  #define SA_SHRINK       darc_ppmd_sa_shrink_units
+  #define SA_SPECIAL_FREE darc_ppmd_sa_special_free
+  #define SA_PTEXT        darc_ppmd_sa_ptext
+  #define SA_UNITS_START  darc_ppmd_sa_units_start
+  #define SA_LO           darc_ppmd_sa_lo_unit
+  #define SA_HI           darc_ppmd_sa_hi_unit
+#endif
+}
+
+/* Live allocations, so frees and resizes target something real rather than a
+ * random offset -- a random free would corrupt both sides identically and
+ * prove nothing. */
+struct Live { long off; unsigned nu; };
+
+int main (int argc, char **argv)
+{
+  if (argc < 4) { fprintf (stderr, "usage: %s SEED HEAP_KB NOPS\n", argv[0]); return 2; }
+  unsigned seed  = (unsigned) atoi (argv[1]);
+  unsigned heap  = (unsigned) atoi (argv[2]) * 1024;
+  int      nops  = atoi (argv[3]);
+
+  if (!SA_START (heap)) { printf ("start failed\n"); return 1; }
+  SA_INIT ();
+
+  Live *live = (Live *) calloc (65536, sizeof (Live));
+  int nlive = 0;
+
+  unsigned s = seed ? seed : 1;
+  #define NEXT() (s = s * 1103515245u + 12345u, (s >> 16) & 0x7fff)
+
+  printf ("init ptext=%ld units=%ld lo=%ld hi=%ld used=%u\n",
+          SA_PTEXT (), SA_UNITS_START (), SA_LO (), SA_HI (), SA_USED ());
+
+  for (int i = 0; i < nops; i++) {
+    unsigned op = NEXT () % 100;
+    if (op < 40 || nlive == 0) {
+      /* allocate: sizes skewed small, as the model's really are, but reaching
+         past 128 units so the multi-block path in GlueFreeBlocks is used */
+      /* Two NEXT() calls must be SEQUENCED. Folded into one expression they
+       * are unsequenced modifications of `s`, which is undefined behaviour --
+       * and worse here than usual, because the two builds could then evaluate
+       * them in different orders and drive the allocators with different
+       * operation sequences, producing a diff that means nothing. */
+      unsigned big = NEXT () % 8;
+      unsigned span = (big == 0) ? 128 : 8;
+      unsigned nu = 1 + NEXT () % span;
+      long off = SA_ALLOC_UNITS (nu);
+      printf ("alloc %u -> %ld\n", nu, off);
+      if (off >= 0 && nlive < 65536) { live[nlive].off = off; live[nlive].nu = nu; nlive++; }
+    } else if (op < 55) {
+      long off = SA_ALLOC_CTX ();
+      printf ("ctx -> %ld\n", off);
+    } else if (op < 78) {
+      int k = NEXT () % nlive;
+      printf ("free %ld %u\n", live[k].off, live[k].nu);
+      SA_FREE_UNITS (live[k].off, live[k].nu);
+      live[k] = live[--nlive];
+    } else if (op < 88) {
+      int k = NEXT () % nlive;
+      long off = SA_EXPAND (live[k].off, live[k].nu);
+      printf ("expand %ld %u -> %ld\n", live[k].off, live[k].nu, off);
+      if (off >= 0) { live[k].off = off; live[k].nu += 1; }
+      else          { live[k] = live[--nlive]; }
+    } else if (op < 96) {
+      int k = NEXT () % nlive;
+      if (live[k].nu > 1) {
+        unsigned newnu = 1 + NEXT () % (live[k].nu - 1);
+        long off = SA_SHRINK (live[k].off, live[k].nu, newnu);
+        printf ("shrink %ld %u %u -> %ld\n", live[k].off, live[k].nu, newnu, off);
+        if (off >= 0) { live[k].off = off; live[k].nu = newnu; }
+        else          { live[k] = live[--nlive]; }
+      }
+    } else {
+      int k = NEXT () % nlive;
+      if (live[k].nu == 1) {
+        printf ("specialfree %ld\n", live[k].off);
+        SA_SPECIAL_FREE (live[k].off);
+        live[k] = live[--nlive];
+      }
+    }
+    /* The cursors and used-memory figure after EVERY op: these are what the
+       model actually branches on, so a divergence here is a divergence in the
+       compressed stream even if every returned offset matched. */
+    printf ("  ptext=%ld units=%ld lo=%ld hi=%ld used=%u live=%d\n",
+            SA_PTEXT (), SA_UNITS_START (), SA_LO (), SA_HI (), SA_USED (), nlive);
+  }
+
+  SA_STOP ();
+  free (live);
+  return 0;
+}

--- a/rust/difftest/ppmd_ccodec.cpp
+++ b/rust/difftest/ppmd_ccodec.cpp
@@ -47,6 +47,59 @@ FARPROC LoadFromDLL (char *)          { return 0; }
 #undef ppmd_compress
 #undef ppmd_decompress
 
+/* Allocator-level entry points.
+ *
+ * The header comment says the STREAM is the only honest cut, and that is true
+ * of comparing compressed output -- the coder, model and allocator have no seam
+ * between them. But the allocator on its own does have a testable interface:
+ * drive both implementations through the same operation sequence and compare
+ * the offsets they hand back plus GetUsedMemory(). That is a real oracle for
+ * the part this codec is most sensitive to, and it does not have to wait for
+ * the model to be ported.
+ *
+ * Offsets rather than pointers, so the two sides are comparable at all: the
+ * Rust heap is a Vec<u8> and the C's is a malloc'ed block at an arbitrary
+ * address. Everything is reported relative to HeapStart, which is exactly what
+ * the C's own BLKREF/CTX_REF already do.
+ *
+ * C_PPMD.cpp includes Model.cpp TWICE, inside `namespace PPMD_compression` and
+ * again inside `namespace PPMD_decompression`, so the allocator exists twice
+ * with completely independent state -- the encoder and the decoder never share
+ * a heap. These wrappers drive the COMPRESSION side; the two are the same code,
+ * and the port keeps them as two instances for the same reason.
+ */
+using namespace PPMD_compression;
+extern "C" {
+long darc_ppmd_sa_start (unsigned t)  { return StartSubAllocator(t) ? 1 : 0; }
+void darc_ppmd_sa_init  (void)        { InitSubAllocator(); }
+void darc_ppmd_sa_stop  (void)        { StopSubAllocator(); }
+unsigned darc_ppmd_sa_used (void)     { return (unsigned) GetUsedMemory(); }
+
+long darc_ppmd_sa_alloc_units (unsigned nu)
+{ void *p = AllocUnits(nu); return p ? (long)((BYTE*)p - HeapStart) : -1; }
+
+long darc_ppmd_sa_alloc_context (void)
+{ void *p = AllocContext(); return p ? (long)((BYTE*)p - HeapStart) : -1; }
+
+void darc_ppmd_sa_free_units (long off, unsigned nu)
+{ FreeUnits(HeapStart + off, nu); }
+
+long darc_ppmd_sa_expand_units (long off, unsigned nu)
+{ void *p = ExpandUnits(HeapStart + off, nu); return p ? (long)((BYTE*)p - HeapStart) : -1; }
+
+long darc_ppmd_sa_shrink_units (long off, unsigned nu, unsigned newnu)
+{ void *p = ShrinkUnits(HeapStart + off, nu, newnu); return p ? (long)((BYTE*)p - HeapStart) : -1; }
+
+void darc_ppmd_sa_special_free (long off)
+{ SpecialFreeUnit(HeapStart + off); }
+
+/* The four layout cursors the model branches on. */
+long darc_ppmd_sa_ptext       (void) { return (long)(pText      - HeapStart); }
+long darc_ppmd_sa_units_start (void) { return (long)(UnitsStart - HeapStart); }
+long darc_ppmd_sa_lo_unit     (void) { return (long)(LoUnit     - HeapStart); }
+long darc_ppmd_sa_hi_unit     (void) { return (long)(HiUnit     - HeapStart); }
+}
+
 extern "C" {
 int darc_ppmd_stream_compress (int order, MemSize mem, int mrmethod,
                                CALLBACK_FUNC *cb, void *aux)

--- a/rust/difftest/ppmd_ccodec.cpp
+++ b/rust/difftest/ppmd_ccodec.cpp
@@ -1,0 +1,58 @@
+/* The C PPMd var.H codec for the differential harness.
+ *
+ * C_PPMD.cpp includes Model.cpp, which includes SubAlloc.hpp and Coder.hpp, so
+ * this is a single translation unit like the real build.
+ *
+ * Unlike every other codec harness here, this one CANNOT cut below the whole
+ * stream. PPMd's output depends on its memory suballocator:
+ *
+ *   Model.cpp:245  GetUsedMemory() < (SubAllocatorSize >> 1)  decides restart
+ *   Model.cpp:416  if (pText >= UnitsStart) goto RESTART_MODEL
+ *   Model.cpp:418  if ((BYTE*) FSuccessor < UnitsStart)
+ *
+ * so the model's behaviour is a function of allocator LAYOUT, not just of the
+ * input. There is no stage boundary at which a partial port could be compared:
+ * the coder, the model and the allocator are one system. The stream is the
+ * only honest cut.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../Compression/Compression.h"
+
+// C_PPMD.cpp registers itself as a COMPRESSION_METHOD at static-init time.
+// Linking the real AddCompressionMethod would drag in CompressionLibrary.cpp
+// and every other codec, so it is stubbed, as in the other harnesses here.
+int AddCompressionMethod (CM_PARSER) { return 0; }
+int COMPRESSION_METHOD::doit (char *, int, void *, CALLBACK_FUNC *) { return -1; }
+
+// The rest of the archiver plumbing C_PPMD.cpp references. None of it is on the
+// codec path: parse_PPMD/ShowCompressionMethod are the method-string parser and
+// its inverse, and LoadFromDLL is the Windows external-DLL hook. The harness
+// calls ppmd_compress/ppmd_decompress directly with explicit parameters.
+MemSize parseInt (char *, int *)      { return 0; }
+MemSize parseMem (char *, int *)      { return 0; }
+void    showMem  (MemSize, char *r)   { if (r) r[0] = 0; }
+FARPROC LoadFromDLL (char *)          { return 0; }
+
+// The Rust crate will export ppmd_compress/ppmd_decompress unconditionally once
+// the port lands, and GNU ld rejects a duplicate C-linkage definition (macOS ld
+// silently keeps one -- the failure mode that passed locally and broke CI for
+// GRZip). Rename the reference's copies: this harness is the only place both
+// implementations exist at once.
+#define ppmd_compress   ppmd_compress_PINNED_REFERENCE
+#define ppmd_decompress ppmd_decompress_PINNED_REFERENCE
+#include "../../Compression/PPMD/C_PPMD.cpp"
+#undef ppmd_compress
+#undef ppmd_decompress
+
+extern "C" {
+int darc_ppmd_stream_compress (int order, MemSize mem, int mrmethod,
+                               CALLBACK_FUNC *cb, void *aux)
+{ return ppmd_compress_PINNED_REFERENCE (order, mem, mrmethod, cb, aux); }
+
+int darc_ppmd_stream_decompress (int order, MemSize mem, int mrmethod,
+                                 CALLBACK_FUNC *cb, void *aux)
+{ return ppmd_decompress_PINNED_REFERENCE (order, mem, mrmethod, cb, aux); }
+}

--- a/rust/difftest/ppmd_ref.cpp
+++ b/rust/difftest/ppmd_ref.cpp
@@ -1,0 +1,121 @@
+/* Reference driver for differential-testing PPMd var.H.
+ *
+ *     ppmd_ref c ORDER MEM_MB MRMETHOD  <in  >enc
+ *     ppmd_ref d ORDER MEM_MB MRMETHOD  <enc >out
+ *
+ * Built twice: plain drives the C, `-DUSE_RUST` the Rust port.
+ *
+ * The codec is callback-driven -- C drives the loop and asks for "read"/"write"
+ * -- so this supplies a callback backed by two in-memory buffers.
+ *
+ * The return code is emitted in the first four bytes ahead of the payload, so
+ * that one side refusing where the other codes shows up as a difference rather
+ * than as two empty files comparing equal.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../Compression/Compression.h"
+
+extern "C" {
+int darc_ppmd_stream_compress   (int order, MemSize mem, int mrmethod, CALLBACK_FUNC *cb, void *aux);
+int darc_ppmd_stream_decompress (int order, MemSize mem, int mrmethod, CALLBACK_FUNC *cb, void *aux);
+#ifdef USE_RUST
+int darc_rs_ppmd_compress   (int order, unsigned mem, int mrmethod, CALLBACK_FUNC *cb, void *aux);
+int darc_rs_ppmd_decompress (int order, unsigned mem, int mrmethod, CALLBACK_FUNC *cb, void *aux);
+#endif
+}
+
+struct Buffers {
+  const unsigned char *in;
+  size_t in_len, in_pos;
+  unsigned char *out;
+  size_t out_cap, out_len;
+};
+
+/* The archiver's callback protocol: "read" fills the buffer and returns the
+ * count, "write" consumes it. Anything else is unsupported here. */
+static int cb (const char *what, void *buf, int size, void *aux)
+{
+  Buffers *b = (Buffers *) aux;
+  if (strcmp (what, "read") == 0) {
+    size_t left = b->in_len - b->in_pos;
+    size_t n = (size_t) size < left ? (size_t) size : left;
+    memcpy (buf, b->in + b->in_pos, n);
+    b->in_pos += n;
+    return (int) n;
+  }
+  if (strcmp (what, "write") == 0) {
+    if (b->out_len + (size_t) size > b->out_cap) {
+      b->out_cap = (b->out_len + (size_t) size) * 2;
+      b->out = (unsigned char *) realloc (b->out, b->out_cap);
+      if (!b->out) return FREEARC_ERRCODE_NOT_ENOUGH_MEMORY;
+    }
+    memcpy (b->out + b->out_len, buf, (size_t) size);
+    b->out_len += (size_t) size;
+    return size;
+  }
+  return FREEARC_ERRCODE_NOT_IMPLEMENTED;
+}
+
+static unsigned char *slurp (size_t *len)
+{
+  size_t cap = 1 << 20, n = 0;
+  unsigned char *b = (unsigned char *) malloc (cap);
+  if (!b) exit (3);
+  for (;;) {
+    if (n == cap) { cap *= 2; b = (unsigned char *) realloc (b, cap); if (!b) exit (3); }
+    size_t r = fread (b + n, 1, cap - n, stdin);
+    if (r == 0) break;
+    n += r;
+  }
+  *len = n;
+  return b;
+}
+
+int main (int argc, char **argv)
+{
+  if (argc < 5 || (argv[1][0] != 'c' && argv[1][0] != 'd')) {
+    fprintf (stderr, "usage: %s c|d ORDER MEM_MB MRMETHOD\n", argv[0]);
+    return 2;
+  }
+  char mode   = argv[1][0];
+  int order   = atoi (argv[2]);
+  MemSize mem = (MemSize) atoi (argv[3]) * 1024 * 1024;
+  int mrm     = atoi (argv[4]);
+
+  size_t len = 0;
+  unsigned char *in = slurp (&len);
+
+  Buffers b;
+  b.in = in; b.in_len = len; b.in_pos = 0;
+  b.out_cap = len + (1 << 16); b.out_len = 0;
+  b.out = (unsigned char *) malloc (b.out_cap);
+  if (!b.out) return 3;
+
+  int rc;
+  if (mode == 'c') {
+#ifdef USE_RUST
+    rc = darc_rs_ppmd_compress (order, (unsigned) mem, mrm, cb, &b);
+#else
+    rc = darc_ppmd_stream_compress (order, mem, mrm, cb, &b);
+#endif
+  } else {
+#ifdef USE_RUST
+    rc = darc_rs_ppmd_decompress (order, (unsigned) mem, mrm, cb, &b);
+#else
+    rc = darc_ppmd_stream_decompress (order, mem, mrm, cb, &b);
+#endif
+  }
+
+  unsigned char hdr[4] = { (unsigned char)( (unsigned) rc        & 0xff),
+                           (unsigned char)(((unsigned) rc >>  8) & 0xff),
+                           (unsigned char)(((unsigned) rc >> 16) & 0xff),
+                           (unsigned char)(((unsigned) rc >> 24) & 0xff) };
+  fwrite (hdr, 1, 4, stdout);
+  fwrite (b.out, 1, b.out_len, stdout);
+
+  free (in); free (b.out);
+  return 0;
+}


### PR DESCRIPTION
Ports PPMd var.H — the suballocator, the PPMII model, the Subbotin range coder
and the stream layer — to `rust/darc-codecs/src/ppmd/`, with a differential
oracle proving byte-identity against the C at the pinned reference revision.

The C is **not deleted here**. `C_PPMD.cpp` still `#include`s `Model.cpp`;
switching the entry points over and removing the vendored C is a follow-up, the
same shape the BSC port took.

## Why byte-identity is the only useful bar

The model branches on allocator state — `GetUsedMemory()`, `pText >= UnitsStart`,
`FSuccessor < UnitsStart` — so the suballocator's layout is part of the
compressed format. Changing the memory budget changes the output bytes. There is
no latitude to "implement the same algorithm differently": an exact
transliteration was the only option, and a legal-but-different encoding would
round-trip perfectly while changing every existing `-mppmd` archive.

## The oracle is built the way DArc ships PPMd, and that is load-bearing

PPMd type-puns through `(WORD&)` in `StateCpy`/`SWAP`, violating strict
aliasing. In `rescale()` a compiler permitted to assume those WORD writes cannot
alias the BYTE read in `if (p->Freq == 0)` reuses the value assigned earlier in
the loop instead of reloading the slot the bubble sort has since overwritten —
and **the same source then emits different compressed bytes**. Measured on the
`dominant` corpus shape, orders 3/4/10/16:

| build | behaviour |
|---|---|
| `clang -O1` | reuses the assigned value |
| `clang -O2` | reuses the assigned value |
| `clang -O0` | re-reads |
| `clang -O1 -fno-strict-aliasing` | re-reads |

`Compression/PPMD/makefile` passes `-fno-strict-aliasing` alongside its `-O1`,
so pinning the `-O` level alone is **not** enough — an oracle at a bare `-O1`
is a build DArc does not ship. Both harnesses copy the makefile's whole flag
list. `-fno-strict-aliasing` alone flips the output; `-fomit-frame-pointer` and
`-funroll-loops` do not.

`compile-win64-c` carries the same warning for the same reason: a Win64 build
whose PPMD flags drift from that list writes archives Linux cannot reproduce.

## Defects found, and what found each

| Defect | Found by |
|---|---|
| `EscFreq` is `UINT` in `rescale` but `int` in `refresh` — same file, three lines apart | the `dominant` corpus shape, the only one reaching rescale's shrink path |
| `rescale`'s zero test must use the value *assigned* to `p->Freq`, not a re-read | the -O0/-O1/-O2 comparison above |
| `GlueFreeBlocks` does not always terminate | the allocator harness hanging in CI |
| `GetUsedMemory` can wrap past zero, and must wrap in 32 bits | a 2 KB heap in the allocator harness |
| a per-symbol `eprintln!` left in `encode_file`, 470x slower than the C | a speed check added after 798 byte-identical streams failed to notice it |

The last two are worth dwelling on. Both survived a harness that reported
798/798 byte-identical streams: one because no heap in the grid ever exhausted,
the other because the harness sends stderr to `/dev/null`. Byte-identity is
necessary and nowhere near sufficient.

## Harnesses

`rust/difftest/ppmd-check.sh` — whole streams, encode and decode, over
order x memory-budget x MRMethod x a 19-entry corpus. Asserts the drivers are
silent on stderr and that the port stays within 10x of the C before it starts
discarding stderr. Locally: **456/456 byte-identical over 8 combinations**, at
1.2x the C's encode speed.

`rust/difftest/ppmd-alloc-check.sh` — the allocator alone, comparing every
returned offset plus all four layout cursors and `GetUsedMemory()` after each of
800 pseudo-random operations. Every driver run is capped, and a C that runs into
its non-terminating glue loop is reported and then compared again at the largest
op count it does return from. Locally: **16/16 traces identical**, 3/3 seeds
exhausting the heap, 2 combinations reaching the glue loop where the port
returns and the C does not.

CI runs the wide grid — 9 orders x 4 budgets — in `rust-codecs-ppmd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
