### PR TITLE
difftest: build every C oracle the way DArc builds the codec

### DIFF
--- a/rust/difftest/bsc-bwt-check.sh
+++ b/rust/difftest/bsc-bwt-check.sh
@@ -18,6 +18,10 @@ ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 # c-reference.sh for why.
 . "$ROOT/rust/difftest/c-reference.sh"
 CREF="$(darc_c_reference "$ROOT")" || exit 1
+# The reference is built the way DArc builds BSC: see darc_codec_cflags
+# in c-reference.sh for why the makefile's flags, not an -O level, are the
+# oracle.
+CFLAGS_C="$(darc_codec_cflags BSC)" || exit 1
 W="${TMPDIR:-/tmp}/bsc-bwt-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -28,7 +32,7 @@ LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 # libsais.c is its own translation unit (see bsc_ccodec.cpp). The Rust staticlib
 # trails the sources so it links on GNU ld.
 cc() { local out="$1"; shift
-  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+  clang++ -std=c++17 $CFLAGS_C -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
     -I"$CREF" -I"$CREF/Compression" \
     "$CREF/rust/difftest/bsc_bwt_ref.cpp" "$CREF/rust/difftest/bsc_ccodec.cpp" \
     "$CREF/Compression/BSC/libbsc/bwt/libsais/libsais.c" "$@" -o "$out"; }

--- a/rust/difftest/bsc-bwt-encode-check.sh
+++ b/rust/difftest/bsc-bwt-encode-check.sh
@@ -24,6 +24,10 @@ set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 . "$ROOT/rust/difftest/c-reference.sh"
 CREF="$(darc_c_reference "$ROOT")" || exit 1
+# The reference is built the way DArc builds BSC: see darc_codec_cflags
+# in c-reference.sh for why the makefile's flags, not an -O level, are the
+# oracle.
+CFLAGS_C="$(darc_codec_cflags BSC)" || exit 1
 W="${TMPDIR:-/tmp}/bsc-bwt-enc.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -33,7 +37,7 @@ LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 [ -f "$LIB" ] || { echo "the Rust staticlib is missing" >&2; exit 1; }
 
 cc() { local out="$1"; shift
-  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+  clang++ -std=c++17 $CFLAGS_C -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
     -I"$CREF" -I"$CREF/Compression" \
     "$CREF/rust/difftest/bsc_bwt_enc_ref.cpp" "$CREF/rust/difftest/bsc_ccodec.cpp" \
     "$CREF/Compression/BSC/libbsc/bwt/libsais/libsais.c" "$@" -o "$out"; }

--- a/rust/difftest/bsc-check.sh
+++ b/rust/difftest/bsc-check.sh
@@ -17,6 +17,10 @@ ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 # c-reference.sh for why.
 . "$ROOT/rust/difftest/c-reference.sh"
 CREF="$(darc_c_reference "$ROOT")" || exit 1
+# The reference is built the way DArc builds BSC: see darc_codec_cflags
+# in c-reference.sh for why the makefile's flags, not an -O level, are the
+# oracle.
+CFLAGS_C="$(darc_codec_cflags BSC)" || exit 1
 W="${TMPDIR:-/tmp}/bsc-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -27,7 +31,7 @@ LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 # libsais.c must be its own translation unit -- see bsc_ccodec.cpp. Trailing
 # args land after the sources so the Rust staticlib links on GNU ld.
 cc() { local out="$1"; shift
-  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+  clang++ -std=c++17 $CFLAGS_C -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
     -I"$CREF" -I"$CREF/Compression" \
     "$CREF/rust/difftest/bsc_ref.cpp" "$CREF/rust/difftest/bsc_ccodec.cpp" \
     "$CREF/Compression/BSC/libbsc/bwt/libsais/libsais.c" "$@" -o "$out"; }

--- a/rust/difftest/bsc-full-check.sh
+++ b/rust/difftest/bsc-full-check.sh
@@ -17,6 +17,10 @@ ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 # c-reference.sh for why.
 . "$ROOT/rust/difftest/c-reference.sh"
 CREF="$(darc_c_reference "$ROOT")" || exit 1
+# The reference is built the way DArc builds BSC: see darc_codec_cflags
+# in c-reference.sh for why the makefile's flags, not an -O level, are the
+# oracle.
+CFLAGS_C="$(darc_codec_cflags BSC)" || exit 1
 W="${TMPDIR:-/tmp}/bsc-full-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -25,7 +29,7 @@ trap 'rm -rf "$W"' EXIT
 LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 
 cc() { local out="$1"; shift
-  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+  clang++ -std=c++17 $CFLAGS_C -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
     -I"$CREF" -I"$CREF/Compression" \
     "$CREF/rust/difftest/bsc_full_ref.cpp" "$CREF/rust/difftest/bsc_ccodec.cpp" \
     "$CREF/Compression/BSC/libbsc/bwt/libsais/libsais.c" "$@" -o "$out"; }

--- a/rust/difftest/bsc-lzp-encode-check.sh
+++ b/rust/difftest/bsc-lzp-encode-check.sh
@@ -25,6 +25,10 @@ set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 . "$ROOT/rust/difftest/c-reference.sh"
 CREF="$(darc_c_reference "$ROOT")" || exit 1
+# The reference is built the way DArc builds BSC: see darc_codec_cflags
+# in c-reference.sh for why the makefile's flags, not an -O level, are the
+# oracle.
+CFLAGS_C="$(darc_codec_cflags BSC)" || exit 1
 W="${TMPDIR:-/tmp}/bsc-lzp-enc.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -35,7 +39,7 @@ LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 # libsais.c is its own translation unit (see bsc_ccodec.cpp). The Rust staticlib
 # trails the sources so it links on GNU ld.
 cc() { local out="$1"; shift
-  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+  clang++ -std=c++17 $CFLAGS_C -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
     -I"$CREF" -I"$CREF/Compression" \
     "$CREF/rust/difftest/bsc_lzp_enc_ref.cpp" "$CREF/rust/difftest/bsc_ccodec.cpp" \
     "$CREF/Compression/BSC/libbsc/bwt/libsais/libsais.c" "$@" -o "$out"; }

--- a/rust/difftest/bsc-qlfc-encode-check.sh
+++ b/rust/difftest/bsc-qlfc-encode-check.sh
@@ -16,6 +16,10 @@ set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 . "$ROOT/rust/difftest/c-reference.sh"
 CREF="$(darc_c_reference "$ROOT")" || exit 1
+# The reference is built the way DArc builds BSC: see darc_codec_cflags
+# in c-reference.sh for why the makefile's flags, not an -O level, are the
+# oracle.
+CFLAGS_C="$(darc_codec_cflags BSC)" || exit 1
 W="${TMPDIR:-/tmp}/bsc-qlfc-enc.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -24,7 +28,7 @@ trap 'rm -rf "$W"' EXIT
 LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 
 cc() { local out="$1"; shift
-  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+  clang++ -std=c++17 $CFLAGS_C -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
     -I"$CREF" -I"$CREF/Compression" \
     "$CREF/rust/difftest/bsc_ref.cpp" "$CREF/rust/difftest/bsc_ccodec.cpp" \
     "$CREF/Compression/BSC/libbsc/bwt/libsais/libsais.c" "$@" -o "$out"; }

--- a/rust/difftest/bsc-qlfc-transform-check.sh
+++ b/rust/difftest/bsc-qlfc-transform-check.sh
@@ -23,6 +23,10 @@ set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 . "$ROOT/rust/difftest/c-reference.sh"
 CREF="$(darc_c_reference "$ROOT")" || exit 1
+# The reference is built the way DArc builds BSC: see darc_codec_cflags
+# in c-reference.sh for why the makefile's flags, not an -O level, are the
+# oracle.
+CFLAGS_C="$(darc_codec_cflags BSC)" || exit 1
 W="${TMPDIR:-/tmp}/bsc-qlfc-tr.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -31,7 +35,7 @@ trap 'rm -rf "$W"' EXIT
 LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 
 cc() { local out="$1"; shift
-  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+  clang++ -std=c++17 $CFLAGS_C -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
     -I"$CREF" -I"$CREF/Compression" \
     "$CREF/rust/difftest/bsc_qlfc_transform_ref.cpp" "$CREF/rust/difftest/bsc_ccodec.cpp" \
     "$CREF/Compression/BSC/libbsc/bwt/libsais/libsais.c" "$@" -o "$out"; }

--- a/rust/difftest/bsc-st-check.sh
+++ b/rust/difftest/bsc-st-check.sh
@@ -22,6 +22,10 @@ ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 # c-reference.sh for why.
 . "$ROOT/rust/difftest/c-reference.sh"
 CREF="$(darc_c_reference "$ROOT")" || exit 1
+# The reference is built the way DArc builds BSC: see darc_codec_cflags
+# in c-reference.sh for why the makefile's flags, not an -O level, are the
+# oracle.
+CFLAGS_C="$(darc_codec_cflags BSC)" || exit 1
 W="${TMPDIR:-/tmp}/bsc-st-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -30,7 +34,7 @@ trap 'rm -rf "$W"' EXIT
 LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 
 cc() { local out="$1"; shift
-  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+  clang++ -std=c++17 $CFLAGS_C -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
     -I"$CREF" -I"$CREF/Compression" \
     "$CREF/rust/difftest/bsc_st_ref.cpp" "$CREF/rust/difftest/bsc_ccodec.cpp" \
     "$CREF/Compression/BSC/libbsc/bwt/libsais/libsais.c" "$@" -o "$out"; }

--- a/rust/difftest/bsc-st-encode-check.sh
+++ b/rust/difftest/bsc-st-encode-check.sh
@@ -16,6 +16,10 @@ set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 . "$ROOT/rust/difftest/c-reference.sh"
 CREF="$(darc_c_reference "$ROOT")" || exit 1
+# The reference is built the way DArc builds BSC: see darc_codec_cflags
+# in c-reference.sh for why the makefile's flags, not an -O level, are the
+# oracle.
+CFLAGS_C="$(darc_codec_cflags BSC)" || exit 1
 W="${TMPDIR:-/tmp}/bsc-st-enc.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -24,7 +28,7 @@ trap 'rm -rf "$W"' EXIT
 LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 
 cc() { local out="$1"; shift
-  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+  clang++ -std=c++17 $CFLAGS_C -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
     -I"$CREF" -I"$CREF/Compression" \
     "$CREF/rust/difftest/bsc_st_enc_ref.cpp" "$CREF/rust/difftest/bsc_ccodec.cpp" \
     "$CREF/Compression/BSC/libbsc/bwt/libsais/libsais.c" "$@" -o "$out"; }

--- a/rust/difftest/c-reference.sh
+++ b/rust/difftest/c-reference.sh
@@ -69,3 +69,48 @@ darc_c_reference() {
 
   echo "$cref"
 }
+
+# ── The oracle's optimisation flags ──────────────────────────────────────────
+#
+# Usage: darc_codec_cflags <Compression subdirectory>  → echoes its OPT_FLAGS
+#
+# These codecs are compiled by Compression/<codec>/makefile, and for at least
+# one of them THE OPTIMISATION FLAGS ARE PART OF THE ARCHIVE FORMAT. PPMd
+# type-puns through `(WORD&)` in StateCpy/SWAP, so a compiler permitted to
+# assume those writes cannot alias a neighbouring BYTE read reuses a cached
+# value where the source says to reload -- and emits different compressed bytes
+# for it. Measured, on the shape that discriminates:
+#
+#     -O1                        reuses      -O0                        re-reads
+#     -O2                        reuses      -O1 -fno-strict-aliasing   re-reads
+#
+# Every Compression/*/makefile passes -fno-strict-aliasing; every harness here
+# used to build its reference without it. So each oracle was a build DArc does
+# not ship, and for PPMd that produced a port matching the wrong C. Reading the
+# flags from the makefile instead of picking an -O level is the fix, and it is
+# the safer oracle besides: under -fno-strict-aliasing the answer stops
+# depending on how clever a given compiler's alias analysis is.
+#
+# Checked, not assumed: every harness was re-run against these flag sets, and
+# all 23 still pass. Only PPMd was ever sensitive to the difference.
+#
+# OPT_FLAGS only. CODE_FLAGS (-fno-exceptions/-fno-rtti/-W...) change codegen
+# and diagnostics but not the value semantics a byte-comparison can see, and
+# forcing them on the drivers would only constrain how the drivers themselves
+# may be written.
+#
+# Two makefile flags are deliberately absent because clang has no equivalent:
+# -fforce-addr (DisPack, LZ4 -- removed from GCC long ago) and
+# --param inline-unit-growth=999 (Tornado -- GCC-only).
+darc_codec_cflags() {
+  case "$1" in
+    PPMD)                    echo "-O1 -fomit-frame-pointer -fno-strict-aliasing -funroll-loops" ;;
+    GRZip)                   echo "-O2 -fomit-frame-pointer -fno-strict-aliasing -funroll-loops" ;;
+    4x4|Dict)                echo "-O3 -fomit-frame-pointer -fno-strict-aliasing" ;;
+    BSC|Delta|DisPack|LZ4|LZP|MM|REP|Tornado|_Encryption)
+                             echo "-O3 -fomit-frame-pointer -fno-strict-aliasing -funroll-loops" ;;
+    *) echo "darc_codec_cflags: no flag set recorded for '$1' -- read it from" >&2
+       echo "Compression/$1/makefile and add it here rather than guessing" >&2
+       return 1 ;;
+  esac
+}

--- a/rust/difftest/crypto-check.sh
+++ b/rust/difftest/crypto-check.sh
@@ -33,6 +33,10 @@ set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 . "$ROOT/rust/difftest/c-reference.sh"
 CREF="$(darc_c_reference "$ROOT")" || exit 1
+# The reference is built the way DArc builds _Encryption: see darc_codec_cflags
+# in c-reference.sh for why the makefile's flags, not an -O level, are the
+# oracle.
+CFLAGS_C="$(darc_codec_cflags _Encryption)" || exit 1
 W="${TMPDIR:-/tmp}/crypto-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -50,7 +54,7 @@ DEFS="-DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT"
 # that called darc_rs_docrypt directly stayed green.
 build_c() { # <output> <tree>
   local out="$1" tree="$2"
-  clang++ -std=c++17 -O2 -w $DEFS \
+  clang++ -std=c++17 $CFLAGS_C -w $DEFS \
     -I"$tree" -I"$tree/Compression" -I"$tree/Compression/_Encryption/headers" \
     "$tree/rust/difftest/crypto_ref.cpp" "$tree/rust/difftest/crypto_ccodec.cpp" \
     "$tree/Compression/Common.cpp" -o "$out"
@@ -72,7 +76,7 @@ build_c "$W/c32" "$CREF32" || { echo "building the 32-bit-ulong32 reference fail
 
 # The staticlib goes AFTER the sources that reference it: GNU ld resolves an
 # archive only against the undefined symbols it has already seen.
-clang++ -std=c++17 -O2 -w $DEFS -DDARC_RUST \
+clang++ -std=c++17 $CFLAGS_C -w $DEFS -DDARC_RUST \
   -I"$ROOT" -I"$ROOT/Compression" \
   "$ROOT/rust/difftest/crypto_ref.cpp" "$ROOT/rust/difftest/crypto_ccodec.cpp" \
   "$ROOT/Compression/Common.cpp" "$LIB" -o "$W/rs" \

--- a/rust/difftest/dispack-check.sh
+++ b/rust/difftest/dispack-check.sh
@@ -16,6 +16,10 @@ ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 # c-reference.sh for why.
 . "$ROOT/rust/difftest/c-reference.sh"
 CREF="$(darc_c_reference "$ROOT")" || exit 1
+# The reference is built the way DArc builds DisPack: see darc_codec_cflags
+# in c-reference.sh for why the makefile's flags, not an -O level, are the
+# oracle.
+CFLAGS_C="$(darc_codec_cflags DisPack)" || exit 1
 W="${TMPDIR:-/tmp}/dispack-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -24,7 +28,7 @@ trap 'rm -rf "$W"' EXIT
 LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 
 cc() { local out="$1"; shift
-  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+  clang++ -std=c++17 $CFLAGS_C -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
     -I"$CREF" -I"$CREF/Compression" \
     "$CREF/rust/difftest/dispack_ref.cpp" "$CREF/rust/difftest/dispack_ccodec.cpp" \
     "$CREF/Compression/Common.cpp" "$@" -o "$out"; }

--- a/rust/difftest/dispack-filter-check.sh
+++ b/rust/difftest/dispack-filter-check.sh
@@ -26,6 +26,10 @@ set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 . "$ROOT/rust/difftest/c-reference.sh"
 CREF="$(darc_c_reference "$ROOT")" || exit 1
+# The reference is built the way DArc builds DisPack: see darc_codec_cflags
+# in c-reference.sh for why the makefile's flags, not an -O level, are the
+# oracle.
+CFLAGS_C="$(darc_codec_cflags DisPack)" || exit 1
 W="${TMPDIR:-/tmp}/dispack-filter-check.$$"; mkdir -p "$W" "$W/in"
 trap 'rm -rf "$W"' EXIT
 
@@ -38,7 +42,7 @@ LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 # already seen, so a staticlib ahead of the sources links on macOS and fails on
 # Linux. That exact mistake shipped once.
 cc() { local out="$1" lib="$2"; shift 2
-  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+  clang++ -std=c++17 $CFLAGS_C -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
     -I"$CREF" -I"$CREF/Compression" "$@" \
     "$CREF/rust/difftest/dispack_filter_ref.cpp" \
     "$CREF/rust/difftest/dispack_ccodec.cpp" \

--- a/rust/difftest/grzip-check.sh
+++ b/rust/difftest/grzip-check.sh
@@ -15,6 +15,10 @@ ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 # c-reference.sh for why.
 . "$ROOT/rust/difftest/c-reference.sh"
 CREF="$(darc_c_reference "$ROOT")" || exit 1
+# The reference is built the way DArc builds GRZip: see darc_codec_cflags
+# in c-reference.sh for why the makefile's flags, not an -O level, are the
+# oracle.
+CFLAGS_C="$(darc_codec_cflags GRZip)" || exit 1
 W="${TMPDIR:-/tmp}/grzip-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -25,7 +29,7 @@ LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 # Trailing arguments land after the sources: GNU ld resolves an archive against
 # only the objects already seen, so a library placed first is silently dropped.
 cc() { local out="$1"; shift
-  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+  clang++ -std=c++17 $CFLAGS_C -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
     -I"$CREF" -I"$CREF/Compression" \
     "$CREF/rust/difftest/grzip_ref.cpp" "$CREF/rust/difftest/grzip_ccodec.cpp" \
     "$CREF/Compression/Common.cpp" "$@" -o "$out"; }

--- a/rust/difftest/grzip-stage-check.sh
+++ b/rust/difftest/grzip-stage-check.sh
@@ -17,12 +17,16 @@ set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 . "$ROOT/rust/difftest/c-reference.sh"
 CREF="$(darc_c_reference "$ROOT")" || exit 1
+# The reference is built the way DArc builds GRZip: see darc_codec_cflags
+# in c-reference.sh for why the makefile's flags, not an -O level, are the
+# oracle.
+CFLAGS_C="$(darc_codec_cflags GRZip)" || exit 1
 W="${TMPDIR:-/tmp}/grzip-lzp.$$"; mkdir -p "$W/in"
 trap 'rm -rf "$W"' EXIT
 ( cd "$ROOT/rust" && cargo build --release -p darc-codecs ) >/dev/null 2>&1 || { echo "cargo build failed"; exit 1; }
 LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 cc() { local out="$1"; shift
-  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+  clang++ -std=c++17 $CFLAGS_C -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
     -I"$CREF" -I"$CREF/Compression" \
     "$CREF/rust/difftest/grzip_ref.cpp" "$CREF/rust/difftest/grzip_ccodec.cpp" \
     "$CREF/Compression/Common.cpp" "$@" -o "$out"; }

--- a/rust/difftest/lz4hc-check.sh
+++ b/rust/difftest/lz4hc-check.sh
@@ -17,6 +17,10 @@ set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 . "$ROOT/rust/difftest/c-reference.sh"
 CREF="$(darc_c_reference "$ROOT")" || exit 1
+# The reference is built the way DArc builds LZ4: see darc_codec_cflags
+# in c-reference.sh for why the makefile's flags, not an -O level, are the
+# oracle.
+CFLAGS_C="$(darc_codec_cflags LZ4)" || exit 1
 W="${TMPDIR:-/tmp}/lz4hc-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -26,7 +30,7 @@ LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 
 # The staticlib goes AFTER the sources that reference it: GNU ld resolves an
 # archive only against the undefined symbols it has already seen.
-clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+clang++ -std=c++17 $CFLAGS_C -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
   -I"$CREF" -I"$CREF/Compression" \
   "$CREF/rust/difftest/lz4hc_ref.cpp" "$LIB" -o "$W/t" || exit 1
 

--- a/rust/difftest/lzp-check.sh
+++ b/rust/difftest/lzp-check.sh
@@ -22,6 +22,10 @@ set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 . "$ROOT/rust/difftest/c-reference.sh"
 CREF="$(darc_c_reference "$ROOT")" || exit 1
+# The reference is built the way DArc builds LZP: see darc_codec_cflags
+# in c-reference.sh for why the makefile's flags, not an -O level, are the
+# oracle.
+CFLAGS_C="$(darc_codec_cflags LZP)" || exit 1
 W="${TMPDIR:-/tmp}/lzp-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -41,7 +45,7 @@ LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 # "undefined reference". Passing it through "$@" did exactly that and only CI
 # caught it.
 cc() { local out="$1" lib="$2"; shift 2
-  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+  clang++ -std=c++17 $CFLAGS_C -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
     -I"$CREF" -I"$CREF/Compression" "$@" \
     "$CREF/rust/difftest/lzp_ref.cpp" \
     "$CREF/Compression/LZP/C_LZP.cpp" \

--- a/rust/difftest/mm-check.sh
+++ b/rust/difftest/mm-check.sh
@@ -18,6 +18,10 @@ ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 # c-reference.sh for why.
 . "$ROOT/rust/difftest/c-reference.sh"
 CREF="$(darc_c_reference "$ROOT")" || exit 1
+# The reference is built the way DArc builds MM: see darc_codec_cflags
+# in c-reference.sh for why the makefile's flags, not an -O level, are the
+# oracle.
+CFLAGS_C="$(darc_codec_cflags MM)" || exit 1
 W="${TMPDIR:-/tmp}/mm-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -31,7 +35,7 @@ LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 # comes back undefined. macOS ld does not care.
 cc() { # cc <output> [args appended after the sources]
   local out="$1"; shift
-  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+  clang++ -std=c++17 $CFLAGS_C -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
     -I"$CREF" -I"$CREF/Compression" \
     "$CREF/rust/difftest/mm_ref.cpp" "$CREF/rust/difftest/mm_ccodec.cpp" \
     "$CREF/Compression/Common.cpp" "$@" -o "$out"

--- a/rust/difftest/ppmd-alloc-check.sh
+++ b/rust/difftest/ppmd-alloc-check.sh
@@ -50,14 +50,13 @@ trap 'rm -rf "$W"' EXIT
 LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 [ -f "$LIB" ] || { echo "the Rust staticlib is missing" >&2; exit 1; }
 
-# The same flag list as ppmd-check.sh, copied from Compression/PPMD/makefile.
-# See the long note there: for this codec the optimisation flags are part of the
-# format, so the reference is built the way the shipped codec is built rather
-# than at whatever -O level seemed reasonable.
-PPMD_MAKEFILE_FLAGS="-fno-exceptions -fno-rtti -O1 -fomit-frame-pointer -fno-strict-aliasing -funroll-loops -g0"
+# The flags come from Compression/PPMD/makefile via darc_codec_cflags, not from
+# an -O level chosen here. For this codec the optimisation flags are part of the
+# format -- see the note on that function in c-reference.sh.
+CFLAGS_C="$(darc_codec_cflags PPMD)" || exit 1
 cc() { local out="$1"; shift
   # shellcheck disable=SC2086  # the flag list is a word list on purpose
-  clang++ -std=c++17 $PPMD_MAKEFILE_FLAGS -w \
+  clang++ -std=c++17 $CFLAGS_C -w \
     -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
     -I"$CREF" -I"$CREF/Compression" \
     "$CREF/rust/difftest/ppmd_alloc_ref.cpp" "$CREF/rust/difftest/ppmd_ccodec.cpp" "$@" -o "$out"; }

--- a/rust/difftest/ppmd-check.sh
+++ b/rust/difftest/ppmd-check.sh
@@ -65,10 +65,10 @@ LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 # There is a second reason to prefer this oracle: with -fno-strict-aliasing the
 # answer no longer depends on how clever the compiler's alias analysis is, so it
 # is stable across compilers and versions. The bare -O1 reading was not.
-PPMD_MAKEFILE_FLAGS="-fno-exceptions -fno-rtti -O1 -fomit-frame-pointer -fno-strict-aliasing -funroll-loops -g0"
+CFLAGS_C="$(darc_codec_cflags PPMD)" || exit 1
 cc() { local out="$1"; shift
   # shellcheck disable=SC2086  # the flag list is a word list on purpose
-  clang++ -std=c++17 $PPMD_MAKEFILE_FLAGS -w \
+  clang++ -std=c++17 $CFLAGS_C -w \
     -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
     -I"$CREF" -I"$CREF/Compression" \
     "$CREF/rust/difftest/ppmd_ref.cpp" "$CREF/rust/difftest/ppmd_ccodec.cpp" "$@" -o "$out"; }

--- a/rust/difftest/rep-check.sh
+++ b/rust/difftest/rep-check.sh
@@ -11,6 +11,10 @@ ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 # c-reference.sh for why.
 . "$ROOT/rust/difftest/c-reference.sh"
 CREF="$(darc_c_reference "$ROOT")" || exit 1
+# The reference is built the way DArc builds REP: see darc_codec_cflags
+# in c-reference.sh for why the makefile's flags, not an -O level, are the
+# oracle.
+CFLAGS_C="$(darc_codec_cflags REP)" || exit 1
 W="${TMPDIR:-/tmp}/rep-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -25,7 +29,7 @@ LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 # locally while never having linked on Linux.
 cc() { # cc <output> [args appended after the sources]
   local out="$1"; shift
-  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+  clang++ -std=c++17 $CFLAGS_C -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
     -DREP_LIBRARY -I"$CREF" -I"$CREF/Compression" \
     "$CREF/rust/difftest/rep_ref.cpp" "$CREF/Compression/REP/rep.cpp" \
     "$CREF/Compression/Common.cpp" "$@" -o "$out"

--- a/rust/difftest/run.sh
+++ b/rust/difftest/run.sh
@@ -22,6 +22,10 @@ ROOT="$(cd "$HERE/../.." && pwd)"
 # c-reference.sh. Delta.cpp no longer exists in the checkout.
 . "$HERE/c-reference.sh"
 CREF="$(darc_c_reference "$ROOT")" || exit 1
+# The reference is built the way DArc builds Delta: see darc_codec_cflags
+# in c-reference.sh for why the makefile's flags, not an -O level, are the
+# oracle.
+CFLAGS_C="$(darc_codec_cflags Delta)" || exit 1
 
 # rust/ is a cargo workspace, so build output lands in the WORKSPACE target
 # directory. It was rust/darc-codecs/target/ before the workspace existed, and
@@ -46,7 +50,7 @@ build_ref () {
   # DELTA_LIBRARY suppresses Delta.cpp's own main(); Common.cpp supplies
   # MyAlloc/MyFree. Both are easy to omit and produce link errors that look
   # unrelated to the driver.
-  clang++ -std=c++17 -O2 -w \
+  clang++ -std=c++17 $CFLAGS_C -w \
     -DDELTA_LIBRARY -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
     -I "$CREF/Compression" -I "$CREF" \
     -o "$REF" "$CREF/rust/difftest/delta_ref.cpp" "$CREF/Compression/Delta/Delta.cpp" "$CREF/Compression/Common.cpp" \
@@ -98,7 +102,7 @@ build_rs () {
   ( cd "$ROOT/rust" && cargo build --release -p darc-codecs ) >/dev/null 2>&1 \
     || { echo "error: cargo build failed" >&2; return 1; }
   require_rust_lib || return 1
-  clang++ -std=c++17 -O2 -w \
+  clang++ -std=c++17 $CFLAGS_C -w \
     -DUSE_RUST -DDELTA_LIBRARY -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
     -I "$CREF/Compression" -I "$CREF" \
     -o "$RS" "$CREF/rust/difftest/delta_ref.cpp" "$CREF/Compression/Delta/Delta.cpp" "$CREF/Compression/Common.cpp" \
@@ -217,7 +221,7 @@ sabotage () {
     cp "$bak" "$MUT_SRC"
     if ! apply_mutation "$pat" "$rep"; then status=1; continue; fi
     ( cd "$ROOT/rust" && cargo build --release -p darc-codecs ) >/dev/null 2>&1
-    clang++ -std=c++17 -O2 -w -DUSE_RUST -DDELTA_LIBRARY -DFREEARC_UNIX \
+    clang++ -std=c++17 $CFLAGS_C -w -DUSE_RUST -DDELTA_LIBRARY -DFREEARC_UNIX \
       -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT -I "$CREF/Compression" -I "$CREF" \
       -o "$broken" "$CREF/rust/difftest/delta_ref.cpp" "$CREF/Compression/Delta/Delta.cpp" "$CREF/Compression/Common.cpp" \
       "$RUST_LIB" 2>/dev/null

--- a/rust/difftest/tornado-check.sh
+++ b/rust/difftest/tornado-check.sh
@@ -16,6 +16,10 @@ ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 # c-reference.sh for why.
 . "$ROOT/rust/difftest/c-reference.sh"
 CREF="$(darc_c_reference "$ROOT")" || exit 1
+# The reference is built the way DArc builds Tornado: see darc_codec_cflags
+# in c-reference.sh for why the makefile's flags, not an -O level, are the
+# oracle.
+CFLAGS_C="$(darc_codec_cflags Tornado)" || exit 1
 W="${TMPDIR:-/tmp}/tornado-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -26,7 +30,7 @@ LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 # Trailing arguments land after the sources: GNU ld resolves an archive against
 # only the objects already seen, so a library placed first is silently dropped.
 cc() { local out="$1"; shift
-  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+  clang++ -std=c++17 $CFLAGS_C -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
     -I"$CREF" -I"$CREF/Compression" \
     "$CREF/rust/difftest/tornado_ref.cpp" "$CREF/rust/difftest/tornado_ccodec.cpp" \
     "$CREF/Compression/Common.cpp" "$@" -o "$out"; }

--- a/rust/difftest/tornado-encode-check.sh
+++ b/rust/difftest/tornado-encode-check.sh
@@ -18,6 +18,10 @@ ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 # The C reference comes from a pinned revision, not the working tree.
 . "$ROOT/rust/difftest/c-reference.sh"
 CREF="$(darc_c_reference "$ROOT")" || exit 1
+# The reference is built the way DArc builds Tornado: see darc_codec_cflags
+# in c-reference.sh for why the makefile's flags, not an -O level, are the
+# oracle.
+CFLAGS_C="$(darc_codec_cflags Tornado)" || exit 1
 W="${TMPDIR:-/tmp}/tornado-encode-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -28,7 +32,7 @@ LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 # Trailing arguments land after the sources: GNU ld resolves an archive against
 # only the objects already seen, so a library placed first is silently dropped.
 cc() { local out="$1"; shift
-  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+  clang++ -std=c++17 $CFLAGS_C -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
     -I"$CREF" -I"$CREF/Compression" \
     "$CREF/rust/difftest/tornado_ref.cpp" "$CREF/rust/difftest/tornado_ccodec.cpp" \
     "$CREF/Compression/Common.cpp" "$@" -o "$out"; }

--- a/rust/difftest/tta-check.sh
+++ b/rust/difftest/tta-check.sh
@@ -13,6 +13,10 @@ ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 # c-reference.sh for why.
 . "$ROOT/rust/difftest/c-reference.sh"
 CREF="$(darc_c_reference "$ROOT")" || exit 1
+# The reference is built the way DArc builds MM: see darc_codec_cflags
+# in c-reference.sh for why the makefile's flags, not an -O level, are the
+# oracle.
+CFLAGS_C="$(darc_codec_cflags MM)" || exit 1
 W="${TMPDIR:-/tmp}/tta-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
@@ -27,7 +31,7 @@ LIB="$ROOT/rust/target/release/libdarc_codecs.a"
 # locally while never having linked on Linux.
 cc() { # cc <output> [args appended after the sources]
   local out="$1"; shift
-  clang++ -std=c++17 -O2 -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+  clang++ -std=c++17 $CFLAGS_C -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
     -I"$CREF" -I"$CREF/Compression" \
     "$CREF/rust/difftest/tta_ref.cpp" "$CREF/rust/difftest/tta_ccodec.cpp" \
     "$CREF/rust/difftest/mmdet_ccodec.cpp" \


### PR DESCRIPTION
Closes the gap #94 exposed. PPMd proved that a codec's optimisation flags can be
part of the archive format; every other harness had the same mismatch, just
unchecked.

## The mismatch

`rescale()`'s `if (p->Freq == 0)` re-reads the heap under `-fno-strict-aliasing`
and reuses a cached value without it, because `StateCpy`/`SWAP` type-pun through
`(WORD&)`. `Compression/PPMD/makefile` passes `-fno-strict-aliasing`, so the
re-reading build is the one real `-mppmd` archives came from — and #94 had to
rewrite the port after its oracle turned out to be a build DArc does not ship.

Every `Compression/*/makefile` passes that flag. Every `rust/difftest/*.sh`
built its reference **without** it, at an `-O` level picked by hand.

## Checked before changing anything

One variable at a time, all 23 harnesses each time:

| oracle build | result |
|---|---|
| `-O2` + `-fno-strict-aliasing` (isolates the flag) | **23/23 pass** |
| each codec makefile's own `OPT_FLAGS` | **23/23 pass** |

So PPMd was the only codec sensitive to the difference, and nothing else was
verified against the wrong C by accident. Worth establishing rather than
assuming — that is the point of the change, not a side note.

## What changes

The flags come from one place: `darc_codec_cflags` in `c-reference.sh`, keyed by
`Compression` subdirectory, with the reasoning and the per-codec values in a
single comment. Each harness sets `CFLAGS_C="$(darc_codec_cflags <Codec>)"` and
uses it. The two PPMd harnesses move onto the same helper, so there is no second
copy of the flag list to drift.

Deliberate omissions, stated in the comment:

- `-fforce-addr` (DisPack, LZ4) and `--param inline-unit-growth=999` (Tornado) —
  GCC-only or long removed, so a clang oracle cannot carry them either way.
- `CODE_FLAGS` (`-fno-exceptions`, `-fno-rtti`, the `-W`s) — they change codegen
  and diagnostics but not the value semantics a byte-comparison can see, and
  forcing them on the drivers would only constrain how the drivers may be
  written. Confirmed empirically: PPMd still gives 456/456 after dropping
  `-fno-exceptions -fno-rtti -g0` from its oracle.

An unknown codec name is an error rather than a silent default, so adding a
harness means reading the makefile instead of inheriting whatever the last one
happened to use.

Locally: the six fastest harnesses plus delta re-run clean, PPMd 456/456 streams
and 16/16 allocator traces. CI runs the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)