### PR TITLE
Fix Dict and LZP reporting good archives as corrupt to Unarc and every SFX

### DIFF
--- a/Tests/sfx-roundtrip.sh
+++ b/Tests/sfx-roundtrip.sh
@@ -44,7 +44,15 @@ fail=0; tested=0
 # several codecs together, and a module missing any ONE of them fails the whole
 # chain. That is how 4x4, BSC, DisPack, LZ4 and Zstd turned out to be absent
 # from the module's link list.
-for m in 0 1 2 3 4 5 9 x tor lzma ppmd grzip bsc dispack lz4 zstd; do
+#
+# `dict` and `lzp` are named individually even though -m9 already chains Dict,
+# because -m9 only reaches it when the *corpus* is classified $text by
+# detect_datatype -- and the four files above are too small and too artificial
+# to be. So -m9 passed this test for as long as Dict was completely unreadable
+# here: unarc reported "archive data corrupted" for every real -m9 archive
+# containing a text file, and nothing in CI noticed. Name the codec, do not
+# trust a preset to reach it.
+for m in 0 1 2 3 4 5 9 x tor lzma ppmd grzip bsc dispack lz4 zstd dict lzp; do
   rm -f "$W/t.arc"; rm -rf "$W/out"; mkdir -p "$W/out"
   if ! ( cd "$W" && "$ARC" a --nodates -r -y -m$m t.arc in ) >"$W/c.log" 2>&1; then
     echo "  -m$m: the ARCHIVER failed to create it"; tail -2 "$W/c.log" | sed 's/^/     /'

--- a/rust/darc-codecs/src/dict.rs
+++ b/rust/darc-codecs/src/dict.rs
@@ -194,8 +194,11 @@ pub fn decompress(io: &Io, block_size: u32) -> c_int {
             if io.read(&mut raw) as usize != n {
                 return FREEARC_ERRCODE_IO;
             }
-            if io.write(&raw) < 0 {
-                return FREEARC_ERRCODE_IO;
+            // Propagate, do not substitute: a negative write is not
+            // necessarily an error. See the note on Io::write.
+            let w = io.write(&raw);
+            if w < 0 {
+                return w;
             }
             continue;
         }
@@ -213,8 +216,11 @@ pub fn decompress(io: &Io, block_size: u32) -> c_int {
         }
         match decode(&packed, block_size) {
             Ok(out) => {
-                if !out.is_empty() && io.write(&out) < 0 {
-                    return FREEARC_ERRCODE_IO;
+                if !out.is_empty() {
+                    let w = io.write(&out);
+                    if w < 0 {
+                        return w;
+                    }
                 }
             }
             Err(e) => return e,

--- a/rust/darc-codecs/src/ffi.rs
+++ b/rust/darc-codecs/src/ffi.rs
@@ -65,7 +65,26 @@ impl Io {
         self.call(b"read\0", buf.as_mut_ptr() as *mut c_void, clamp_len(buf.len()))
     }
 
-    /// Write `buf`. Returns the count written, or a negative error.
+    /// Write `buf`. Returns the count written, or a negative status.
+    ///
+    /// **A negative return is not necessarily an error, and callers must
+    /// propagate it rather than substitute one of their own.** Unarc's write
+    /// callback answers `FREEARC_ERRCODE_NO_MORE_DATA_REQUIRED` (-9,
+    /// Compression.h:28) as soon as every file it wanted out of the solid block
+    /// has been written -- it means "that was a success, now stop", and
+    /// `Unarc/unarc.cpp:449` accepts exactly that code alongside `>= 0`:
+    ///
+    /// ```text
+    /// CHECK (result>=0 || result==FREEARC_ERRCODE_NO_MORE_DATA_REQUIRED,
+    ///        "ERROR: archive data corrupted (decompression fails)");
+    /// ```
+    ///
+    /// A decoder that turned this into `FREEARC_ERRCODE_IO` reported perfectly
+    /// good archives as corrupt: `dict` and `lzp` did, which made every archive
+    /// whose `$text` group used Dict -- i.e. anything written with `-m9` --
+    /// unreadable by the standalone extractor and every SFX module, while the
+    /// archiver read it back fine. Substituting also loses genuine codes, so
+    /// `-5` (out of memory) would have been reported as an I/O failure too.
     pub fn write(&self, buf: &[u8]) -> c_int {
         if buf.is_empty() {
             return 0;

--- a/rust/darc-codecs/src/lzp.rs
+++ b/rust/darc-codecs/src/lzp.rs
@@ -274,8 +274,11 @@ pub fn decompress(io: &Io, block_size: u32, min_len: c_int, hash_size_log: c_int
             if io.read(&mut raw) as usize != n {
                 return FREEARC_ERRCODE_IO;
             }
-            if io.write(&raw) < 0 {
-                return FREEARC_ERRCODE_IO;
+            // Propagate, do not substitute: a negative write is not
+            // necessarily an error. See the note on Io::write.
+            let w = io.write(&raw);
+            if w < 0 {
+                return w;
             }
             continue;
         }
@@ -287,8 +290,11 @@ pub fn decompress(io: &Io, block_size: u32, min_len: c_int, hash_size_log: c_int
         let _ = block_size;
         match decode(&packed, &mut out, min_len, hash_size, barrier, smallest_len) {
             Ok(_) => {
-                if !out.is_empty() && io.write(&out) < 0 {
-                    return FREEARC_ERRCODE_IO;
+                if !out.is_empty() {
+                    let w = io.write(&out);
+                    if w < 0 {
+                        return w;
+                    }
                 }
             }
             Err(e) => return e,


### PR DESCRIPTION
`arc a -mdict a.arc file.txt` produces an archive the archiver reads back perfectly and `unarc` refuses:

```
arc   t : All OK, extracts correctly
unarc t : ERROR: archive data corrupted (decompression fails)
```

Same for `-mlzp`, and for any chain containing either. **Dict is what the `$text` group uses**, so every `-m9`/`-m9t`/`-m9x` archive containing a text file was unreadable by the standalone extractor and by all three SFX modules.

## The data was never corrupt

It is an error-code translation bug:

1. Unarc's write callback finishes the last file it wanted out of the solid block and answers `FREEARC_ERRCODE_NO_MORE_DATA_REQUIRED` (-9) — *"that write succeeded, now stop decompressing"*. `Unarc/unarc.cpp:449` accepts exactly that code alongside `>= 0`:
   ```cpp
   CHECK (result>=0 || result==FREEARC_ERRCODE_NO_MORE_DATA_REQUIRED,
          "ERROR: archive data corrupted (decompression fails)");
   ```
2. `dict::decompress` and `lzp::decompress` did `if io.write(..) < 0 { return FREEARC_ERRCODE_IO }`, turning **-9 into -6**.
3. Unarc saw -6 — not -9, not `>= 0` — and reported corruption.

Traced with a temporary diagnostic, which showed both reads returning in full and the write returning the stop signal:

```
[DIAG] read asked=4     got=4      bytes_left=25420
[DIAG] read asked=25420 got=25420  bytes_left=0
[DIAG] write size=25420 -> NO_MORE_DATA_REQUIRED (file complete)
[DIAG] dict_decompress -> rc=-6
```

Block size was ruled out first: forcing 64 MB instead of the 26624 Unarc derives changed nothing.

## The fix

Both decoders now propagate the callback's own code instead of substituting one. The whole crate had no mention of `NO_MORE_DATA_REQUIRED`, so the explanation goes on `Io::write` where the next codec author will meet it. Substituting also swallowed genuine codes — a `-5` (out of memory) was reported as an I/O failure too.

**Only `dict` and `lzp` were affected**: they are the only two *decoders* that substituted. The same pattern survives on encode paths in `delta.rs`, `dict_encode.rs` and `dispack/encode.rs`, where the archiver's write callback does not raise -9 — left alone rather than changed untested.

## Verification

| check | result |
|---|---|
| all 18 methods, one file through `arc` then `unarc` | before: `dict` ERROR, `lzp` ERROR, 16 OK → after: **18/18 OK** |
| MM/TTA corpus (52 archives) extracted via unarc, contents diffed | **52/52** (was 46/50) |
| GRZip corpus (17 archives) same | **17/17** (was 13/13 of a 13-archive subset) |
| archives written by the fixed binary vs the pre-fix one | **17/17 byte-identical** — decode-only change |
| `lzp-check.sh` | 0 differing over 84 comparisons |

## Why CI missed it, and the coverage that closes it

`Tests/sfx-roundtrip.sh` **already ran `-m9`**, which chains Dict, and passed throughout. `-m9` only reaches Dict when `detect_datatype` classifies the corpus as `$text`, and the script's four small synthetic files are not. So a codec that was *completely unreadable* here stayed green.

`-mdict` and `-mlzp` are now named explicitly. Checked the only way worth trusting — revert the two Rust hunks and re-run:

```
-mdict: unarc failed: ERROR: archive data corrupted
-mlzp:  unarc failed: ERROR: archive data corrupted
-m9:    OK          <-- still passes, which is the point
2 FAILED  (exit 1)
```

## Follow-up, not in this PR

**Dict has no differential test at all.** `rust/difftest/dict_ref.cpp` and `dict_phase1_ref.cpp` exist but no harness builds them, and the workflow never names `dict`. That is the same gap LZP was found in before `lzp-check.sh` was written — worth closing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)