### PR TITLE
CI: actually run grzip-stage-check.sh, which was never invoked

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -946,6 +946,13 @@ jobs:
         rust/difftest/tornado-check.sh
         rust/difftest/tornado-encode-check.sh
         rust/difftest/grzip-check.sh
+        # grzip-check.sh covers the DECODER and the multi-block stream. This one
+        # covers the six ENCODER stages individually -- ST4, MTF-Ari, BWT (fast
+        # and strong), WFC-Ari and Rec -- which nothing else reaches, and it had
+        # never been invoked here at all: every difftest is listed by name and
+        # this name was missing, so the file passed locally and ran nowhere.
+        # With GRZip's C now deleted these two are its only oracle.
+        rust/difftest/grzip-stage-check.sh
         rust/difftest/dispack-check.sh
         # The other direction: DisPack's ENCODER must be byte-exact too, since
         # DisPack is one of DArc's own formats. Filtered output that merely


### PR DESCRIPTION
The harness existed, passed, and **ran nowhere**. Every difftest in `build.yml` is listed by name and this name was simply missing — so `grzip-stage-check.sh` was green on any machine that happened to run it and had no effect on any pull request.

It is **not** redundant with `grzip-check.sh`:

| harness | covers |
|---|---|
| `grzip-check.sh` | the **decoder** and the multi-block stream |
| `grzip-stage-check.sh` | the six **encoder** stages individually — ST4, MTF-Ari, BWT (fast + strong), WFC-Ari, Rec — plus LZP |

GRZip's C was deleted in #97, so between them these two are its only oracle, and half of it was switched off.

## How it was found

By auditing for the shape that hid Dict's missing harness in #100:

```bash
# reference drivers that no harness compiles (comment mentions excluded)
for ref in rust/difftest/*_ref.cpp; do
  rg -n "$(basename $ref)" rust/difftest/*.sh | rg -v ':[0-9]+:\s*#'
done
# harnesses the workflow never names
for h in rust/difftest/*-check.sh; do rg -q "$(basename $h)" .github/workflows/build.yml; done
```

The first check now reports only `dict_phase1_ref.cpp`, which is a phase-level diagnostic tool rather than a test — left alone deliberately. The second reported this file, and now reports nothing.

*(The first version of that audit counted every mention and so reported "1 harness" for `dict_phase1_ref.cpp` purely because a comment names it — hence the `rg -v` for comment lines.)*

## Verified it can fail, not just pass

Adding a `wrapping_add(1)` to the delta in the Rust Rec encoder:

```
[rec] rec16_flat: OUTPUT differs
[rec] rec16_high: OUTPUT differs
grzip Rec encode: 44/46 agree
exit 1
```

Removing it returns 46/46 across every stage.

Costs **28 seconds**; added to `rust-codecs-b` next to `grzip-check.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)