### PR TITLE
Tornado: fix a silent no-op that made presets 7-11 diverge from the C

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -953,6 +953,16 @@ jobs:
         # this name was missing, so the file passed locally and ran nowhere.
         # With GRZip's C now deleted these two are its only oracle.
         rust/difftest/grzip-stage-check.sh
+        # 4x4 is NOT ported and will not be; this asks the other question --
+        # whether substituting Rust codecs UNDER 4x4's framing changes the
+        # stream. It matters because 3binary..9binary are `4x4:bNm:lzma:...`
+        # (Compression.hs:474-481), so -m3..-m9 route $binary through it.
+        #
+        # It must not share a step with the tornado harnesses: it builds the
+        # staticlib WITH --features dropin and they need it WITHOUT (the pinned
+        # tornado_ccodec.cpp defines tor_decompress and would collide). Cargo
+        # re-resolves per run, so sequential is fine; concurrent is not.
+        rust/difftest/4x4-check.sh
         rust/difftest/dispack-check.sh
         # The other direction: DisPack's ENCODER must be byte-exact too, since
         # DisPack is one of DArc's own formats. Filtered output that merely

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -917,6 +917,39 @@ jobs:
         # decodes each block with the C decoder rather than lz4_flex.
         rust/difftest/lz4hc-check.sh
 
+  # Debug profile, on purpose. Every other codec job builds --release, where
+  # `debug_assert!` compiles to nothing -- so the crate's 19 assertions are dead
+  # in the only configuration otherwise tested. The Tornado presets 7-11
+  # divergence was exactly that: a guard firing into the void. Removing the fix
+  # makes this job report 80 panics naming the cause; the release harnesses
+  # needed differential tracing to find the same thing.
+  rust-codecs-debug-assert:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        lfs: false
+    - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+    - name: Cache LLVM
+      id: cache-llvm
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ./llvm
+        key: llvm-21.1.8-${{ runner.os }}-${{ runner.arch }}
+    - name: Install LLVM and Clang
+      uses: KyleMayes/install-llvm-action@ebc0426251bc40c7cd31162802432c68818ab8f0 # v2
+      with:
+        version: "21.1.8"
+        cached: ${{ steps.cache-llvm.outputs.cache-hit }}
+    - name: Install packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y liblua5.1-dev libncurses-dev libcurl4-openssl-dev cpphs
+    - name: Codecs under debug assertions
+      run: |
+        chmod +x rust/difftest/*.sh
+        rust/difftest/debug-assert-check.sh
+
   rust-codecs-b:
     runs-on: ubuntu-latest
     steps:

--- a/RUST_PORT_PROGRESS.md
+++ b/RUST_PORT_PROGRESS.md
@@ -435,15 +435,40 @@ Two things this port established that generalise:
   whose end lands on that husk loops for ever. The port breaks out, which cannot
   change any output the C can produce.
 
-### 10. Decide explicitly whether to port 4x4 — recommendation: no
+### 10. Decide explicitly whether to port 4x4 — recommendation: no, but it is NOT dead code
 
 Threading meta-codec; its decode delegates to the library dispatcher
 `Decompress()` per block, so the only portable logic is block framing
 (`C_4x4.cpp:436`, call at `:237`). Its value is parallelism, which a decode-first
-port drops. There is **no fingerprint case** (the suite's `-m4x` is an unrelated
-exe preset, not this codec). A Rust decode would be an FFI shim calling C
-`Decompress`, which under `DARC_RUST` dispatches back to Rust drop-ins
-(Rust→C→Rust). Record the decision so it is not re-litigated.
+port drops. A Rust decode would be an FFI shim calling C `Decompress`, which
+under `DARC_RUST` dispatches back to Rust drop-ins (Rust→C→Rust). The decision
+stands: do not port it.
+
+**Do not read that as "4x4 is unused".** An earlier version of this entry said
+there is "no fingerprint case", which is true of the *test suite* — the `-m4x`
+there is an unrelated exe preset — and was repeatedly misread as "nothing uses
+this codec". It is on the DEFAULT path:
+
+```
+Compression.hs:474-481   3binary = 4x4:b8m:lzma:8m:h64m:fast:mc8
+                         ...
+                         9binary = 4x4:b254m:lzma:254m:max
+Compression.hs:468-469   1xb = 4x4:tor:3     2xb = 4x4:tor:6
+```
+
+So `-m3` through `-m9` route the `$binary` group — usually the largest files in
+an archive — through 4x4. Its C is load-bearing and must not be deleted as part
+of any "prune what the port replaced" sweep.
+
+Because it is not ported, `4x4-check.sh` asks a different question from every
+other harness: 4x4's stream is its own framing wrapped around whatever the
+dispatcher resolves the inner method to, and those inner codecs are now Rust.
+The harness therefore builds the SAME pinned C driver twice — once over pinned C
+codecs, once with `-DDARC_RUST` over the Rust staticlib — and requires identical
+streams. It needs the `dropin` cargo feature, unlike the others, because it
+reaches Rust through the C dispatcher rather than calling `darc_rs_*` directly.
+`lzma` is deliberately excluded as an inner method: it has no Rust port, so that
+comparison would compare a build against itself.
 
 ### 11. Port the Haskell application layer (17,843 lines, 41 files)
 

--- a/rust/darc-codecs/src/tornado/matchfinder.rs
+++ b/rust/darc-codecs/src/tornado/matchfinder.rs
@@ -90,13 +90,20 @@ pub trait MatchFinder {
     /// Record the positions covered by a match just emitted.
     fn update_hash(&mut self, buf: &[u8], p: usize, len: u32, step: u32);
 
-    /// Insert the single position `p`. Only the finders that `CombineMF` wraps
-    /// define this in the C; the default panics in debug rather than silently
-    /// skipping an insertion, which would change the parse without failing.
-    fn update_hash1(&mut self, buf: &[u8], p: usize) {
-        let _ = (buf, p);
-        debug_assert!(false, "update_hash1 called on a finder that does not define it");
-    }
+    /// Insert the single position `p`.
+    ///
+    /// REQUIRED, deliberately. This used to carry a default body whose only
+    /// content was `debug_assert!(false, ...)`, on the reasoning that only the
+    /// finders `CombineMF` wraps define it in the C. That default cost real
+    /// correctness: `Hash3` defined the method inherently but never as a trait
+    /// method, `CombineMF` holds its auxiliary finder as `Box<dyn MatchFinder>`,
+    /// so the call landed on the default -- and `debug_assert!` compiles out in
+    /// release, making it a silent no-op. Tornado presets 7-11 then diverged
+    /// from the C. With no default, that omission is a compile error.
+    ///
+    /// Implementors that the C leaves without this method use `unreachable!()`,
+    /// which unlike `debug_assert!` still panics in release.
+    fn update_hash1(&mut self, buf: &[u8], p: usize);
 
     /// Reset every slot; called when a non-sliding buffer is refilled.
     ///
@@ -110,7 +117,13 @@ pub trait MatchFinder {
     fn shift(&mut self, shift: usize);
 
     /// Drop any match a lazy wrapper is holding.
-    fn invalidate_match(&mut self) {}
+    ///
+    /// REQUIRED for the same reason as `update_hash1`: an empty default silently
+    /// does nothing for a finder that needed to forward. The C's
+    /// `BaseMatchFinder` really does define this empty (MatchFinder.cpp:105), so
+    /// leaves write an explicit empty body -- the point is that it is written,
+    /// not inherited by accident.
+    fn invalidate_match(&mut self);
 
     fn error(&self) -> Option<c_int>;
 }
@@ -275,6 +288,21 @@ impl MatchFinder1 {
 }
 
 impl MatchFinder for MatchFinder1 {
+
+    /// The C's `MatchFinder1` has no `update_hash1` (only MatchFinderN,
+    /// ExactMatchFinder, CachingMatchFinder, CycledCachingMatchFinder, Hash3 and
+    /// CombineMF define one), so a call here is a porting error rather than a
+    /// runtime case. `unreachable!` and not `debug_assert!`: it must fail in
+    /// release too, which is the mistake this trait used to make.
+    fn update_hash1(&mut self, _buf: &[u8], _p: usize) {
+        unreachable!("MatchFinder1::update_hash1 -- the C defines no such method");
+    }
+
+    /// `BaseMatchFinder::invalidate_match` is empty in the C
+    /// (MatchFinder.cpp:105) and this finder does not override it. Written out
+    /// rather than inherited from a trait default, so that a finder which SHOULD
+    /// forward cannot get this behaviour by accident.
+    fn invalidate_match(&mut self) {}
     fn min_length(&self) -> u32 {
         4
     }
@@ -326,6 +354,21 @@ impl MatchFinder2 {
 }
 
 impl MatchFinder for MatchFinder2 {
+
+    /// The C's `MatchFinder2` has no `update_hash1` (only MatchFinderN,
+    /// ExactMatchFinder, CachingMatchFinder, CycledCachingMatchFinder, Hash3 and
+    /// CombineMF define one), so a call here is a porting error rather than a
+    /// runtime case. `unreachable!` and not `debug_assert!`: it must fail in
+    /// release too, which is the mistake this trait used to make.
+    fn update_hash1(&mut self, _buf: &[u8], _p: usize) {
+        unreachable!("MatchFinder2::update_hash1 -- the C defines no such method");
+    }
+
+    /// `BaseMatchFinder::invalidate_match` is empty in the C
+    /// (MatchFinder.cpp:105) and this finder does not override it. Written out
+    /// rather than inherited from a trait default, so that a finder which SHOULD
+    /// forward cannot get this behaviour by accident.
+    fn invalidate_match(&mut self) {}
     fn min_length(&self) -> u32 {
         4
     }
@@ -418,6 +461,20 @@ impl MatchFinderN {
 }
 
 impl MatchFinder for MatchFinderN {
+
+    /// Forwards to the inherent body, which is the port of the C's
+    /// MatchFinder.cpp:284. It was previously inherent-ONLY -- the same shape as
+    /// the Hash3 bug -- so a `dyn` call would have reached the old trait default
+    /// and silently done nothing.
+    fn update_hash1(&mut self, buf: &[u8], p: usize) {
+        MatchFinderN::update_hash1(self, buf, p)
+    }
+
+    /// `BaseMatchFinder::invalidate_match` is empty in the C
+    /// (MatchFinder.cpp:105) and this finder does not override it. Written out
+    /// rather than inherited from a trait default, so that a finder which SHOULD
+    /// forward cannot get this behaviour by accident.
+    fn invalidate_match(&mut self) {}
     fn min_length(&self) -> u32 {
         4
     }
@@ -596,6 +653,25 @@ impl CachingMatchFinder {
 }
 
 impl MatchFinder for CachingMatchFinder {
+
+    /// The C defines this at MatchFinder.cpp:462 -- it shifts the row's
+    /// (ptr, key) PAIRS down by two and writes `fromPtr(p)`/`key(p)` at the
+    /// head -- but nothing in the port ever calls it: only `CombineMF` does, and
+    /// its children are CycledCachingMatchFinder and Hash3.
+    ///
+    /// Deliberately NOT ported speculatively. An untested body for a path
+    /// nothing exercises would look authoritative and could be subtly wrong;
+    /// this panics loudly instead, and the line reference above is what to port
+    /// if it ever becomes reachable.
+    fn update_hash1(&mut self, _buf: &[u8], _p: usize) {
+        unreachable!("CachingMatchFinder::update_hash1 -- port MatchFinder.cpp:462 if this is reached");
+    }
+
+    /// `BaseMatchFinder::invalidate_match` is empty in the C
+    /// (MatchFinder.cpp:105) and this finder does not override it. Written out
+    /// rather than inherited from a trait default, so that a finder which SHOULD
+    /// forward cannot get this behaviour by accident.
+    fn invalidate_match(&mut self) {}
     fn min_length(&self) -> u32 {
         4
     }
@@ -844,6 +920,14 @@ impl<M: MatchFinder> LazyMatching<M> {
 }
 
 impl<M: MatchFinder> MatchFinder for LazyMatching<M> {
+
+    /// The C's `LazyMatching` has no `update_hash1` (MatchFinder.cpp:740-760
+    /// defines find_matchlen, update_hash and invalidate_match only), so calling
+    /// it would not compile there. Forwarding to the wrapped finder would be
+    /// harmless but would invent behaviour the C does not have.
+    fn update_hash1(&mut self, _buf: &[u8], _p: usize) {
+        unreachable!("LazyMatching::update_hash1 -- the C defines no such method");
+    }
     fn min_length(&self) -> u32 {
         self.mf.min_length()
     }
@@ -1101,6 +1185,12 @@ impl ExactMatchFinder {
 }
 
 impl MatchFinder for ExactMatchFinder {
+
+    /// `BaseMatchFinder::invalidate_match` is empty in the C
+    /// (MatchFinder.cpp:105) and this finder does not override it. Written out
+    /// rather than inherited from a trait default, so that a finder which SHOULD
+    /// forward cannot get this behaviour by accident.
+    fn invalidate_match(&mut self) {}
     fn min_length(&self) -> u32 {
         4
     }
@@ -1210,6 +1300,12 @@ impl CycledCachingMatchFinder {
 }
 
 impl MatchFinder for CycledCachingMatchFinder {
+
+    /// `BaseMatchFinder::invalidate_match` is empty in the C
+    /// (MatchFinder.cpp:105) and this finder does not override it. Written out
+    /// rather than inherited from a trait default, so that a finder which SHOULD
+    /// forward cannot get this behaviour by accident.
+    fn invalidate_match(&mut self) {}
     /// `N` -- the C overrides this at MatchFinder.cpp:631 (`{return N;}`),
     /// inside a struct body that runs 507-632. Reading only the first ~90 lines
     /// of that body suggests it inherits BaseMatchFinder's 4; it does not, and

--- a/rust/darc-codecs/src/tornado/matchfinder.rs
+++ b/rust/darc-codecs/src/tornado/matchfinder.rs
@@ -980,6 +980,24 @@ impl<M: MatchFinder> Hash3<M> {
 }
 
 impl<M: MatchFinder> MatchFinder for Hash3<M> {
+    /// Forwards to the inherent `Hash3::update_hash1`. Without this the trait's
+    /// DEFAULT body is what `CombineMF` reaches, because its auxiliary finder is
+    /// a `Box<dyn MatchFinder>` -- and that default is a `debug_assert!` which
+    /// compiles out in release, i.e. a silent no-op.
+    ///
+    /// That was a real divergence, not a theoretical one. `CombineMF` calls
+    /// `mf2.update_hash1(p)` on its early exit (`len1 > mf1.MINLEN`), which is
+    /// how the C seeds the auxiliary 2/3-byte tables at positions it skips. The
+    /// port made 3397 of those insertions where the C made 4494; the first
+    /// missed one was at p=0x268, and it surfaced ~28 KB later as a 3-byte match
+    /// the C found and the port did not. Presets 7-11 are affected because they
+    /// are the only ones that pair this finder with `CombineMF`.
+    ///
+    /// The debug_assert would have caught it -- the difftests build --release.
+    fn update_hash1(&mut self, buf: &[u8], p: usize) {
+        Hash3::update_hash1(self, buf, p)
+    }
+
     /// Two, not the wrapped finder's four.
     fn min_length(&self) -> u32 {
         2

--- a/rust/darc-codecs/src/tornado/matchfinder.rs
+++ b/rust/darc-codecs/src/tornado/matchfinder.rs
@@ -1192,6 +1192,10 @@ impl CycledCachingMatchFinder {
 }
 
 impl MatchFinder for CycledCachingMatchFinder {
+    /// `N` -- the C overrides this at MatchFinder.cpp:631 (`{return N;}`),
+    /// inside a struct body that runs 507-632. Reading only the first ~90 lines
+    /// of that body suggests it inherits BaseMatchFinder's 4; it does not, and
+    /// forcing 4 here takes the sweep from 10 differing to 173.
     fn min_length(&self) -> u32 {
         self.n as u32
     }

--- a/rust/difftest/4x4-check.sh
+++ b/rust/difftest/4x4-check.sh
@@ -54,23 +54,15 @@
 #     drop-in. `lzma` is the other one the presets use, but it has no Rust port
 #     at all, so that comparison would compare a build against itself while
 #     dragging the whole 7-Zip SDK into the link.
-# ## KNOWN FAILING CASE -- do not wire into CI until it is fixed
+# ## The bug this harness found, now fixed
 #
-# This harness currently FAILS on `4x4:b256k:tor:9` and `4x4:b1m:tor:9`, and
-# that is a real finding, not a harness defect. Holding 4x4's framing and the
-# dispatcher identical and varying ONLY Tornado (pinned C engine vs the Rust
-# port) still diverges: 616270 vs 616271 bytes at 256k, 607081 vs 607077 at 1m,
-# identical at 64k and for tor:3/tor:6. Minimal repro ~141 KB of input, payloads
-# byte-identical for 30086 bytes and then differing.
-#
-# Cause: Tornado's port is byte-identical at `compress_all_at_once = 0` -- the
-# default, and the only value tornado-encode-check.sh ever tests, because
-# tornado_ccodec.cpp passes the live global and nothing sets it. 4x4 forces it
-# to 1 (C_4x4.cpp:559-566) and is the only caller that does. So preset 9 in
-# all-at-once mode was never covered.
-#
-# No shipped preset reaches it (1xb/2xb are tor:3/tor:6), so this is not urgent,
-# but Tornado is one of DArc's own formats and byte-exactness is the stated bar.
+# It failed on `4x4:b*:tor:9` when first written, and that turned out to be a
+# real divergence in the Tornado port rather than a defect here: `Hash3` defined
+# `update_hash1` only in its inherent impl, so `CombineMF` -- which holds its
+# auxiliary finder as `Box<dyn MatchFinder>` -- reached the trait's default
+# body, a `debug_assert!` that compiles out in release. Presets 7-11 are the
+# only ones pairing that finder with `CombineMF`. Fixed in matchfinder.rs; this
+# harness and tornado-encode-check.sh both cover it now.
 set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 . "$ROOT/rust/difftest/c-reference.sh"

--- a/rust/difftest/4x4-check.sh
+++ b/rust/difftest/4x4-check.sh
@@ -92,22 +92,27 @@ dropins=$(nm -g "$LIB" 2>/dev/null | grep -c ' T _\{0,1\}tor_decompress$')
 # so a codec that is not linked is simply not a valid inner method.
 WRAPPERS="4x4/C_4x4.cpp Tornado/C_Tornado.cpp REP/C_REP.cpp LZP/C_LZP.cpp
           Dict/C_Dict.cpp Delta/C_Delta.cpp CompressionLibrary.cpp Common.cpp"
-# $lib is a SEPARATE parameter placed after every source: GNU ld resolves an
-# archive only against undefineds it has already seen, so a staticlib listed
-# first contributes nothing (links on macOS, fails on Linux).
-build() { # build OUT TREE [lib...]
-  local out="$1" tree="$2"; shift 2
+# $lib is its OWN positional parameter and is appended AFTER every source, never
+# folded into the flag list. GNU ld resolves an archive only against undefineds
+# it has already seen, so a staticlib listed before the sources contributes
+# nothing: it links on macOS and fails on Linux with "undefined reference to
+# tor_decompress" and friends. The first version of this function passed the lib
+# through "$@" ahead of the sources and did exactly that -- green locally, red on
+# the first CI run.
+build() { # build OUT TREE LIB [flags...]
+  local out="$1" tree="$2" lib="$3"; shift 3
   local src=""; for w in $WRAPPERS; do src="$src $tree/Compression/$w"; done
   # shellcheck disable=SC2086  # flag and source lists are word lists on purpose
   clang++ -std=c++17 $CFLAGS_C -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
     -I"$tree" -I"$tree/Compression" "$@" \
-    "$ROOT/rust/difftest/4x4_ref.cpp" $src -o "$out"; }
+    "$ROOT/rust/difftest/4x4_ref.cpp" $src \
+    ${lib:+"$lib"} -o "$out"; }
 
 # C side: the pinned tree, all C, no staticlib.
-build "$W/c"  "$CREF"                            || { echo "C reference build failed" >&2; exit 1; }
+build "$W/c"  "$CREF" ""                         || { echo "C reference build failed" >&2; exit 1; }
 # Rust side: the WORKING TREE's wrappers -- which are the thin forwarders the
 # port left behind -- over the Rust staticlib.
-build "$W/rs" "$ROOT" -DDARC_RUST "$LIB"         || { echo "Rust-substituted build failed" >&2; exit 1; }
+build "$W/rs" "$ROOT" "$LIB" -DDARC_RUST         || { echo "Rust-substituted build failed" >&2; exit 1; }
 [ -x "$W/c" ] && [ -x "$W/rs" ] || { echo "a driver is missing after a clean build" >&2; exit 1; }
 
 # The assertion that keeps this honest. Rust embeds source paths for panic

--- a/rust/difftest/4x4-check.sh
+++ b/rust/difftest/4x4-check.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Differential-test 4x4 -- the threading meta-codec -- across the Rust codec
+# substitution, BOTH directions.
+#
+# ## What this checks, and why it is not the usual shape
+#
+# Every other harness compares a C codec against a Rust PORT of that codec. 4x4
+# has no Rust port and is not getting one (RUST_PORT_PROGRESS.md section 10): it
+# compresses nothing itself, it splits input into blocks and calls the library
+# dispatcher with an INNER method named in its own parameter string. Porting it
+# would be Rust calling C calling Rust, and a decode-first port would drop the
+# parallelism that is the whole point.
+#
+# That decision leaves something worth testing. 4x4's output is its own framing
+# wrapped around whatever the dispatcher resolves the inner method to -- and
+# those inner codecs are now Rust drop-ins. So the SAME driver is built twice
+# from the SAME pinned C source: once linking the pinned C codecs, once with
+# -DDARC_RUST plus the Rust staticlib. The question is whether substituting Rust
+# underneath 4x4 changed the stream.
+#
+# This matters because 4x4 is on the default path, not a curiosity:
+# Compression.hs:474-481 defines 3binary..9binary as `4x4:bNm:lzma:...`, so
+# -m3 through -m9 route the $binary group through it, and 1xb/2xb use
+# `4x4:tor:N`.
+#
+# ## Three things that will bite whoever edits this
+#
+#   * It needs the `dropin` cargo feature, unlike every other harness. Those
+#     call `darc_rs_*` directly; this one reaches Rust THROUGH the C dispatcher,
+#     which calls the archiver's own symbol names (tor_decompress, rep_compress,
+#     ...) and those are what `dropin` exports.
+#   * The two sides come from DIFFERENT trees, and that is deliberate. The C
+#     side is the pinned revision; the Rust side is the WORKING TREE's wrappers
+#     plus the staticlib. The first version of this script built BOTH from the
+#     pinned tree and merely added -DDARC_RUST to one -- which does nothing,
+#     because at the pinned revision C_Tornado.cpp and C_REP.cpp have no
+#     DARC_RUST guards at all (those exclusions were added later). So four of
+#     the seven inner methods compiled the C implementation into the object
+#     file, the linker resolved from there, and the "Rust" driver was running C.
+#     It reported 252/252 identical while testing nothing: sabotaging the Rust
+#     Tornado encoder and the Rust REP encoder both went undetected.
+#   * Hence the marker assertion below. `strings` for darc-codecs panic
+#     locations is the same trick the unarc-sfx CI job uses, and it is the only
+#     cheap proof that the substitution actually happened.
+#   * The inner methods are restricted to codecs that actually HAVE a Rust
+#     drop-in. `lzma` is the other one the presets use, but it has no Rust port
+#     at all, so that comparison would compare a build against itself while
+#     dragging the whole 7-Zip SDK into the link.
+# ## KNOWN FAILING CASE -- do not wire into CI until it is fixed
+#
+# This harness currently FAILS on `4x4:b256k:tor:9` and `4x4:b1m:tor:9`, and
+# that is a real finding, not a harness defect. Holding 4x4's framing and the
+# dispatcher identical and varying ONLY Tornado (pinned C engine vs the Rust
+# port) still diverges: 616270 vs 616271 bytes at 256k, 607081 vs 607077 at 1m,
+# identical at 64k and for tor:3/tor:6. Minimal repro ~141 KB of input, payloads
+# byte-identical for 30086 bytes and then differing.
+#
+# Cause: Tornado's port is byte-identical at `compress_all_at_once = 0` -- the
+# default, and the only value tornado-encode-check.sh ever tests, because
+# tornado_ccodec.cpp passes the live global and nothing sets it. 4x4 forces it
+# to 1 (C_4x4.cpp:559-566) and is the only caller that does. So preset 9 in
+# all-at-once mode was never covered.
+#
+# No shipped preset reaches it (1xb/2xb are tor:3/tor:6), so this is not urgent,
+# but Tornado is one of DArc's own formats and byte-exactness is the stated bar.
+set -uo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$ROOT/rust/difftest/c-reference.sh"
+CREF="$(darc_c_reference "$ROOT")" || exit 1
+CFLAGS_C="$(darc_codec_cflags 4x4)" || exit 1
+W="${TMPDIR:-/tmp}/4x4-check.$$"; mkdir -p "$W"
+trap 'rm -rf "$W"' EXIT
+
+# --features darc-codecs/dropin: see the note above. Building WITH it is a
+# superset -- the darc_rs_* names every other harness uses stay exported -- so
+# this cannot break a sibling harness that runs afterwards.
+( cd "$ROOT/rust" && cargo build --release -p darc-codecs --features darc-codecs/dropin ) >/dev/null 2>&1 \
+  || { echo "cargo build failed" >&2; exit 1; }
+LIB="$ROOT/rust/target/release/libdarc_codecs.a"
+[ -f "$LIB" ] || { echo "the Rust staticlib is missing" >&2; exit 1; }
+# Prove the drop-in names are actually there: without them the Rust variant
+# silently falls back to nothing and the link fails later with a worse message.
+# grep -c, not grep -q: `set -o pipefail` is on, and `grep -q` exits at the
+# first match, which SIGPIPEs nm and makes the whole pipeline report failure
+# even though the symbol was found. That fired on the first run of this script.
+dropins=$(nm -g "$LIB" 2>/dev/null | grep -c ' T _\{0,1\}tor_decompress$')
+[ "${dropins:-0}" -ge 1 ] \
+  || { echo "the staticlib has no drop-in exports -- was it built without the dropin feature?" >&2; exit 1; }
+
+# Inner codecs, all of which have Rust drop-ins. C_4x4.cpp itself plus the
+# dispatcher and Common; each C_*.cpp self-registers with AddCompressionMethod,
+# so a codec that is not linked is simply not a valid inner method.
+WRAPPERS="4x4/C_4x4.cpp Tornado/C_Tornado.cpp REP/C_REP.cpp LZP/C_LZP.cpp
+          Dict/C_Dict.cpp Delta/C_Delta.cpp CompressionLibrary.cpp Common.cpp"
+# $lib is a SEPARATE parameter placed after every source: GNU ld resolves an
+# archive only against undefineds it has already seen, so a staticlib listed
+# first contributes nothing (links on macOS, fails on Linux).
+build() { # build OUT TREE [lib...]
+  local out="$1" tree="$2"; shift 2
+  local src=""; for w in $WRAPPERS; do src="$src $tree/Compression/$w"; done
+  # shellcheck disable=SC2086  # flag and source lists are word lists on purpose
+  clang++ -std=c++17 $CFLAGS_C -w -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+    -I"$tree" -I"$tree/Compression" "$@" \
+    "$ROOT/rust/difftest/4x4_ref.cpp" $src -o "$out"; }
+
+# C side: the pinned tree, all C, no staticlib.
+build "$W/c"  "$CREF"                            || { echo "C reference build failed" >&2; exit 1; }
+# Rust side: the WORKING TREE's wrappers -- which are the thin forwarders the
+# port left behind -- over the Rust staticlib.
+build "$W/rs" "$ROOT" -DDARC_RUST "$LIB"         || { echo "Rust-substituted build failed" >&2; exit 1; }
+[ -x "$W/c" ] && [ -x "$W/rs" ] || { echo "a driver is missing after a clean build" >&2; exit 1; }
+
+# The assertion that keeps this honest. Rust embeds source paths for panic
+# locations; they survive into the binary as data. If the Rust driver has none,
+# the staticlib was never pulled in and every comparison below is C against C.
+rs_markers=$(strings -a "$W/rs" 2>/dev/null | grep -c 'darc-codecs/src/')
+c_markers=$(strings -a "$W/c"  2>/dev/null | grep -c 'darc-codecs/src/')
+[ "${rs_markers:-0}" -ge 5 ] || {
+  echo "the Rust driver contains $rs_markers darc-codecs markers -- the staticlib was"
+  echo "not linked in, so this would compare C against C and pass while testing nothing."
+  exit 1; }
+[ "${c_markers:-0}" -eq 0 ] || {
+  echo "the C reference driver contains $c_markers darc-codecs markers -- it is not pure C."
+  exit 1; }
+
+python3 - "$W/in" <<'PY'
+import os,sys
+d=sys.argv[1]; os.makedirs(d,exist_ok=True)
+def prng(seed,n):
+    s=seed; o=bytearray()
+    for _ in range(n): s=(s*1103515245+12345)&0xffffffff; o.append((s>>16)&0xff)
+    return bytes(o)
+w=lambda n,b: open(f"{d}/{n}","wb").write(b)
+# Inputs must be big enough to span SEVERAL blocks at the sizes swept below,
+# because single-block input never exercises the framing this is here to test.
+w("text",    b"the quick brown fox jumps over the lazy dog. "*20000)
+w("english", (b"compression algorithms rearrange data so that statistical "
+              b"redundancy can be removed by an entropy coder. ")*8000)
+w("mixed",   b"".join((b"chunk-%d-" % i) + prng(i, 300) for i in range(2000)))
+w("runs",    b"".join(bytes([i%97])*(1+(i*7)%400) for i in range(4000)))
+w("noise",   prng(9, 900000))
+w("zeros",   b"\x00"*400000)
+w("exe",     (b"\x7fELF\x02\x01\x01" + prng(3,120))*4000)
+for n in (0,1,255,256,65537):
+    w(f"n_{n}", prng(5,n))
+PY
+
+# Inner methods that have Rust drop-ins. `tor:3` and `tor:6` are exactly what
+# the 1xb/2xb presets use.
+INNER="tor:3 tor:6 tor:9 rep lzp dict delta"
+total=0; tested=0
+for bs in 64k 256k 1m; do
+  for inner in $INNER; do
+    m="4x4:b$bs:$inner"
+    fail=0; n=0
+    for f in "$W"/in/*; do
+      n=$((n+1)); bn=$(basename "$f")
+      rm -f "$W/ec" "$W/er" "$W/dc" "$W/dr"
+      "$W/c"  c "$m" < "$f" >| "$W/ec" 2>/dev/null \
+        || { echo "  [$m] $bn: C-compress FAILED"; fail=$((fail+1)); continue; }
+      "$W/rs" c "$m" < "$f" >| "$W/er" 2>/dev/null \
+        || { echo "  [$m] $bn: RUST-substituted compress FAILED"; fail=$((fail+1)); continue; }
+      cmp -s "$W/ec" "$W/er" \
+        || { echo "  [$m] $bn: STREAM differs once Rust codecs are substituted"; fail=$((fail+1)); continue; }
+      # Decode the C's stream with both, and require the original back.
+      "$W/c"  d "$m" < "$W/ec" >| "$W/dc" 2>/dev/null \
+        || { echo "  [$m] $bn: C-decompress FAILED"; fail=$((fail+1)); continue; }
+      cmp -s "$f" "$W/dc" \
+        || { echo "  [$m] $bn: C round-trip != original (harness bug)"; fail=$((fail+1)); continue; }
+      "$W/rs" d "$m" < "$W/ec" >| "$W/dr" 2>/dev/null \
+        || { echo "  [$m] $bn: RUST-substituted decompress FAILED"; fail=$((fail+1)); continue; }
+      cmp -s "$f" "$W/dr" \
+        || { echo "  [$m] $bn: RUST-substituted decode != original"; fail=$((fail+1)); }
+      tested=$((tested+1))
+    done
+    [ "$fail" -eq 0 ] || echo "  [$m] $n inputs, $fail differing"
+    total=$((total+fail))
+  done
+  echo "  [block=$bs] $(echo $INNER | wc -w | tr -d ' ') inner methods swept"
+done
+
+[ "$tested" -gt 0 ] || { echo "no inputs were processed -- the harness reached nothing"; exit 1; }
+echo "4x4: $total total differing over $tested comparisons"
+[ "$total" -eq 0 ] \
+  && echo "4x4 framing is unchanged by the Rust codec substitution, both directions" \
+  || exit 1

--- a/rust/difftest/4x4-check.sh
+++ b/rust/difftest/4x4-check.sh
@@ -42,6 +42,14 @@
 #   * Hence the marker assertion below. `strings` for darc-codecs panic
 #     locations is the same trick the unarc-sfx CI job uses, and it is the only
 #     cheap proof that the substitution actually happened.
+#   * It rebuilds the staticlib WITH `--features darc-codecs/dropin`, and that
+#     is incompatible with tornado-encode-check.sh / tornado-check.sh, whose
+#     pinned tornado_ccodec.cpp defines tor_decompress itself and so collides
+#     with the drop-in export ("duplicate symbol '_tor_decompress'"). Each
+#     harness rebuilds before running, so cargo re-resolves the features and
+#     they are fine SEQUENTIALLY -- but they must never run CONCURRENTLY
+#     against the shared rust/target, and they must not be put in a CI step
+#     that could interleave them.
 #   * The inner methods are restricted to codecs that actually HAVE a Rust
 #     drop-in. `lzma` is the other one the presets use, but it has no Rust port
 #     at all, so that comparison would compare a build against itself while

--- a/rust/difftest/4x4_ref.cpp
+++ b/rust/difftest/4x4_ref.cpp
@@ -1,0 +1,102 @@
+/* Reference driver for differential-testing the 4x4 threading meta-codec.
+ *
+ *     4x4_ref c "<method>" <in >out     compress
+ *     4x4_ref d "<method>" <in >out     decompress
+ *
+ * # Why this driver is shaped differently from the others
+ *
+ * Every other *_ref.cpp compares a C codec against a RUST port of that codec.
+ * 4x4 has no Rust port and, per RUST_PORT_PROGRESS.md section 10, is not getting
+ * one: it compresses nothing itself. It splits the input into blocks and calls
+ * the library dispatcher, `Decompress(method, ...)`, with an INNER method named
+ * in its own parameter string -- so a Rust 4x4 would be Rust calling C calling
+ * Rust, for no gain, and a decode-first port would drop the parallelism that is
+ * the codec's entire purpose.
+ *
+ * What is worth testing is the thing that decision leaves exposed. 4x4's output
+ * is its own framing wrapped around WHATEVER the dispatcher resolves the inner
+ * method to -- and under DARC_RUST those inner codecs are now Rust drop-ins. So
+ * the same 4x4 stream is produced by C framing over C codecs at the pinned
+ * revision, and by C framing over RUST codecs today. Those must agree byte for
+ * byte, because 4x4 is on the default path: Compression.hs:474-481 defines
+ * 3binary..9binary as `4x4:bNm:lzma:...`, which is what -m3 through -m9 use for
+ * the $binary group.
+ *
+ * Hence: this driver is built twice from the SAME pinned C source, once linking
+ * the pinned C codecs and once with -DDARC_RUST plus the Rust staticlib. The
+ * comparison is "did substituting Rust codecs underneath 4x4 change the stream".
+ *
+ * The method string is a parameter rather than hardcoded so the harness can
+ * sweep block sizes and inner methods; `tor` and `lzma` are the two the presets
+ * actually use.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../Compression/Compression.h"
+
+struct Buffers {
+  const unsigned char *in; size_t in_len, in_pos;
+  unsigned char *out; size_t out_len, out_cap;
+  size_t chunk;   // max bytes one "read" may return; 0 = no limit
+};
+
+static int io_callback (const char *what, void *data, int size, void *auxdata)
+{
+  Buffers *b = (Buffers*) auxdata;
+  if (size < 0)  return FREEARC_ERRCODE_GENERAL;
+
+  if (strcmp(what, "read") == 0) {
+    size_t avail = b->in_len - b->in_pos;
+    size_t n = (size_t)size < avail ? (size_t)size : avail;
+    if (b->chunk && n > b->chunk)  n = b->chunk;
+    memcpy (data, b->in + b->in_pos, n);  b->in_pos += n;  return (int) n;
+  }
+
+  if (strcmp(what, "write") == 0) {
+    if (b->out_len + (size_t)size > b->out_cap) {
+      size_t cap = (b->out_cap ? b->out_cap : 65536);
+      while (cap < b->out_len + (size_t)size)  cap *= 2;
+      unsigned char *grown = (unsigned char*) realloc (b->out, cap);
+      if (!grown)  return FREEARC_ERRCODE_NOT_ENOUGH_MEMORY;
+      b->out = grown;  b->out_cap = cap;
+    }
+    memcpy (b->out + b->out_len, data, (size_t)size);  b->out_len += (size_t)size;
+    return size;
+  }
+
+  // "quasiwrite" and friends are progress signals; reporting them unimplemented
+  // is what the real callback chain does for unknown requests.
+  return FREEARC_ERRCODE_NOT_IMPLEMENTED;
+}
+
+int main (int argc, char **argv)
+{
+  if (argc < 3 || (argv[1][0] != 'c' && argv[1][0] != 'd')) {
+    fprintf (stderr, "usage: %s c|d \"<method>\" <in >out\n", argv[0]);  return 2;
+  }
+  char method[MAX_METHOD_STRLEN];
+  strncopy (method, argv[2], sizeof(method));
+
+  size_t cap = 1<<20, len = 0;
+  unsigned char *in = (unsigned char*) malloc (cap);
+  if (!in) return 3;
+  for (;;) {
+    if (len == cap) { cap *= 2; unsigned char *g = (unsigned char*) realloc (in, cap); if (!g) { free(in); return 3; } in = g; }
+    size_t n = fread (in + len, 1, cap - len, stdin);
+    if (n == 0) break;
+    len += n;
+  }
+
+  Buffers b; b.in = in; b.in_len = len; b.in_pos = 0; b.out = NULL; b.out_len = 0; b.out_cap = 0;
+  const char *chunk_env = getenv ("X4_CHUNK");
+  b.chunk = chunk_env ? (size_t) strtoul (chunk_env, NULL, 0) : 0;
+
+  int rc = (argv[1][0] == 'c') ? Compress   (method, io_callback, &b)
+                               : Decompress (method, io_callback, &b);
+
+  if (rc < 0) { fprintf (stderr, "codec returned %d\n", rc); free(in); free(b.out); return 4; }
+  if (b.out_len && fwrite (b.out, 1, b.out_len, stdout) != b.out_len) { free(in); free(b.out); return 5; }
+  free (in); free (b.out); return 0;
+}

--- a/rust/difftest/debug-assert-check.sh
+++ b/rust/difftest/debug-assert-check.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Run the codecs with debug assertions ENABLED, which no other harness does.
+#
+# ## Why this exists
+#
+# The crate carries 19 `debug_assert!`s. Every other harness builds
+# `--release`, where `debug_assert!` compiles to nothing -- so all 19 are dead
+# in the only configuration that is ever tested. That is not hypothetical: the
+# Tornado presets 7-11 divergence fixed alongside this file was precisely a
+# guard firing into the void. `MatchFinder`'s default `update_hash1` is
+#
+#     fn update_hash1(&mut self, buf: &[u8], p: usize) {
+#         let _ = (buf, p);
+#         debug_assert!(false, "update_hash1 called on a finder that does not define it");
+#     }
+#
+# `Hash3` defined `update_hash1` only inherently, so `CombineMF` -- which holds
+# its auxiliary finder as `Box<dyn MatchFinder>` -- reached that default. In
+# release it silently did nothing and the encoder diverged from the C thousands
+# of positions later. One debug run would have named the problem immediately.
+#
+# ## What this checks, and what it does NOT
+#
+# This is not a differential test. It does not compare against the C at all --
+# the other harnesses do that, and doing it here would only duplicate them more
+# slowly. What it does is drive the codec through a debug build and fail if any
+# assertion fires or the process dies. The signal is a panic, not a byte
+# mismatch.
+#
+# Tornado is the whole scope today: 9 of the 19 assertions live under
+# `src/tornado/` (matchfinder 4, out_stream 2, lz77_enc 2, tables 1), and every
+# preset reaches a different match finder and entropy back-end. Extending to
+# another codec is mechanical -- add its `*_ref.cpp` pair to `CODECS` below with
+# the arguments its driver expects.
+set -uo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$ROOT/rust/difftest/c-reference.sh"
+CREF="$(darc_c_reference "$ROOT")" || exit 1
+CFLAGS_C="$(darc_codec_cflags Tornado)" || exit 1
+W="${TMPDIR:-/tmp}/debug-assert.$$"; mkdir -p "$W"
+trap 'rm -rf "$W"' EXIT
+
+# The point of the whole file: NO --release. Debug assertions on.
+#
+# Note this writes target/debug, a different directory from the release
+# staticlib every other harness uses, so running this cannot disturb them and
+# they cannot disturb it -- unlike the release-profile feature clash between
+# 4x4-check.sh and the tornado harnesses.
+( cd "$ROOT/rust" && cargo build -p darc-codecs ) >/dev/null 2>&1 \
+  || { echo "cargo debug build failed" >&2; exit 1; }
+LIB="$ROOT/rust/target/debug/libdarc_codecs.a"
+[ -f "$LIB" ] || { echo "no debug staticlib at $LIB" >&2; exit 1; }
+
+# Prove the build really has assertions compiled in. Without this the harness
+# would pass vacuously on a release artifact, which is the exact failure mode it
+# exists to prevent.
+# grep -c, not grep -q: `set -o pipefail` is on and `grep -q` exits at the first
+# match, SIGPIPEing `strings` and failing the pipeline even on success. That bug
+# was fixed in 4x4-check.sh earlier the same day and then written again here.
+#
+# The message checked is from ffi.rs's clamp_len, not the update_hash1 default:
+# now that Hash3 overrides that method, nothing may reach the default body, and
+# a message the optimiser is free to drop is a poor liveness probe.
+asserts=$(strings -a "$LIB" 2>/dev/null | grep -c 'buffer longer than c_int can express')
+[ "${asserts:-0}" -ge 1 ] || {
+  echo "the debug staticlib does not contain the assertion messages -- assertions are" >&2
+  echo "compiled out, so this run would prove nothing." >&2
+  exit 1; }
+
+cc() { local out="$1"; shift
+  # shellcheck disable=SC2086  # the flag list is a word list on purpose
+  clang++ -std=c++17 $CFLAGS_C -w -DUSE_RUST \
+    -DFREEARC_UNIX -DFREEARC_INTEL_BYTE_ORDER -DFREEARC_64BIT \
+    -I"$CREF" -I"$CREF/Compression" \
+    "$CREF/rust/difftest/tornado_ref.cpp" "$CREF/rust/difftest/tornado_ccodec.cpp" \
+    "$CREF/Compression/Common.cpp" "$LIB" -o "$out"; }
+cc "$W/rs" || { echo "debug driver build failed" >&2; exit 1; }
+[ -x "$W/rs" ] || { echo "driver missing after a clean build" >&2; exit 1; }
+
+python3 - "$W/in" <<'PY'
+import os,sys
+d=sys.argv[1]; os.makedirs(d,exist_ok=True)
+def prng(seed,n):
+    s=seed; o=bytearray()
+    for _ in range(n): s=(s*1103515245+12345)&0xffffffff; o.append((s>>16)&0xff)
+    return bytes(o)
+w=lambda n,b: open(f"{d}/{n}","wb").write(b)
+# Deliberately small -- a debug build is slow and this is looking for a fired
+# assertion, not for coverage of every byte pattern. `chunky` is the shape that
+# exposed the Hash3 dispatch bug, so it stays first.
+w("chunky",  b"".join((b"chunk-%d-" % i) + prng(i, 300) for i in range(400)))
+w("text",    b"the quick brown fox jumps over the lazy dog. "*1500)
+w("runs",    b"".join(bytes([i%97])*(1+(i*7)%400) for i in range(600)))
+w("noise",   prng(9, 80000))
+w("tables",  b"".join(int.to_bytes(i*7+3, 4, "little") for i in range(20000)))
+for n in (0,1,255,256,65537):
+    w(f"n_{n}", prng(5,n))
+PY
+
+# Every preset, both `all_at_once` settings, both directions. `notables` is
+# swept on the presets whose data-table detector is reachable, matching
+# tornado-encode-check.sh.
+fired=0; ran=0
+for case in "0 0" "1 0" "2 0" "3 0" "3 1" "4 0" "4 1" "5 0" "5 1" \
+            "6 0" "6 1" "7 0" "8 0" "9 0" "10 0" "11 0"; do
+  set -- $case; preset=$1; notables=$2
+  for aao in 0 1; do
+    for f in "$W"/in/*; do
+      bn=$(basename "$f")
+      rm -f "$W/s" "$W/o" "$W/err"
+      if ! "$W/rs" c "$preset" "$notables" "$aao" < "$f" >| "$W/s" 2>| "$W/err"; then
+        echo "  ASSERTION or failure: encode preset=$preset notables=$notables aao=$aao input=$bn"
+        sed 's/^/     /' "$W/err" | head -6
+        fired=$((fired + 1)); continue
+      fi
+      if grep -qi 'panicked\|assertion' "$W/err" 2>/dev/null; then
+        echo "  ASSERTION on stderr: encode preset=$preset notables=$notables aao=$aao input=$bn"
+        sed 's/^/     /' "$W/err" | head -6
+        fired=$((fired + 1)); continue
+      fi
+      # Preset 0 is STORING, and its stream is deliberately undecodable: the
+      # C's dispatch builds an LZ77_ByteCoder while still writing 0 as the
+      # encoding method (Tornado.cpp:331-333), and the C's own decoder switch
+      # rejects STORING with BAD_COMPRESSED_DATA (:522). The port reproduces
+      # that faithfully, so round-tripping it reports 20 spurious -7 failures.
+      # Its ENCODE leg still runs above, which is where its assertions are.
+      if [ "$preset" = 0 ]; then ran=$((ran + 1)); continue; fi
+      # Decode too: the decoder has its own assertions, and a round-trip is the
+      # cheapest way to reach them.
+      if ! "$W/rs" d < "$W/s" >| "$W/o" 2>| "$W/err"; then
+        echo "  ASSERTION or failure: decode preset=$preset input=$bn"
+        sed 's/^/     /' "$W/err" | head -6
+        fired=$((fired + 1)); continue
+      fi
+      if grep -qi 'panicked\|assertion' "$W/err" 2>/dev/null; then
+        echo "  ASSERTION on stderr: decode preset=$preset input=$bn"
+        sed 's/^/     /' "$W/err" | head -6
+        fired=$((fired + 1)); continue
+      fi
+      # Not a differential check, but a round-trip that loses data would mean
+      # the run below is exercising something other than the codec.
+      cmp -s "$f" "$W/o" || { echo "  ROUND-TRIP LOST DATA: preset=$preset input=$bn"; fired=$((fired + 1)); continue; }
+      ran=$((ran + 1))
+    done
+  done
+done
+
+[ "$ran" -gt 0 ] || { echo "nothing ran -- the harness reached no codec"; exit 1; }
+echo "debug-assert: $ran clean runs, $fired assertion(s)/failure(s)"
+[ "$fired" -eq 0 ] \
+  && echo "no debug assertion fires across 16 preset/notables combinations x 2 all_at_once x 9 inputs" \
+  || exit 1

--- a/rust/difftest/tornado-encode-check.sh
+++ b/rust/difftest/tornado-encode-check.sh
@@ -25,6 +25,12 @@ CFLAGS_C="$(darc_codec_cflags Tornado)" || exit 1
 W="${TMPDIR:-/tmp}/tornado-encode-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
+# WITHOUT the `dropin` feature, and that is load-bearing: the pinned
+# tornado_ccodec.cpp defines tor_decompress itself, so a staticlib carrying the
+# drop-in export collides with it ("duplicate symbol '_tor_decompress'").
+# 4x4-check.sh needs the opposite. Cargo re-resolves on each run so the two are
+# fine sequentially, but they must never run concurrently against the shared
+# rust/target -- doing so produced empty output and stalled runs.
 ( cd "$ROOT/rust" && cargo build --release -p darc-codecs ) >/dev/null 2>&1 \
   || { echo "cargo build failed" >&2; exit 1; }
 LIB="$ROOT/rust/target/release/libdarc_codecs.a"
@@ -58,6 +64,13 @@ w("repeats",   (b"ABCDEFGHIJKLMNOP"*64 + prng(1,256))*400)
 w("noise",     prng(7, 900000))
 w("zeros",     b"\x00"*700000)
 w("mixed",     b"".join((prng(i,1000) + b"pattern"*200) for i in range(300)))
+# Short unique prefix + noise, repeated. This shape diverges at preset 9 and at
+# nothing else, and no other input here reproduces it -- the sweep was green on
+# preset 9 until this was added. Found via 4x4-check.sh, whose corpus happened
+# to contain it; the failure is NOT specific to all-at-once mode (it shows at
+# both settings), it is specific to this data against preset 9's match finder
+# (hashsize 2048mb, row 256, auxhash 512kb/4).
+w("chunky",    b"".join((b"chunk-%d-" % i) + prng(i, 300) for i in range(2000)))
 w("table4",    b"".join(struct.pack("<I", i*7+3) for i in range(200000)))
 # Distances placed either side of the 48 KB / 192 KB / 1 MB acceptance limits
 # in accept_match(), which is where a short match is rejected outright.
@@ -83,16 +96,25 @@ total=0; ran=0; skipped=0
 # one instantiation; 10 (caching 6) and 11 (caching 7) are two more. All three
 # are listed because the cycled finder's N differs between them, and covering
 # 7/9/11 alone would leave N==6 untested while looking complete.
-for case in "0 0" "1 0" "2 0" "3 0" "3 1" "4 0" "4 1" "5 0" "5 1" "6 0" "6 1" "7 0" "8 0" "9 0" "10 0" "11 0"; do
-  set -- $case; preset=$1; notables=$2
-  label="preset $preset"; [ "$notables" = 1 ] && label="$label -t0"
+# The third field is `compress_all_at_once`. It defaults to 0 and this sweep
+# used to test only that: tornado_ccodec.cpp passes the live global and nothing
+# set it. But C_4x4.cpp forces it to 1 around both directions (:559-566), so
+# every -m3..-m9 archive compresses its $binary group in all-at-once mode --
+# and that mode was compared by nothing. Adding it here is what found the
+# preset-9 divergence; leaving the axis out is what hid it.
+for case in "0 0 0" "1 0 0" "2 0 0" "3 0 0" "3 1 0" "4 0 0" "4 1 0" "5 0 0" "5 1 0" \
+            "6 0 0" "6 1 0" "7 0 0" "8 0 0" "9 0 0" "10 0 0" "11 0 0" \
+            "0 0 1" "1 0 1" "2 0 1" "3 0 1" "4 0 1" "5 0 1" "6 0 1" "7 0 1" \
+            "8 0 1" "9 0 1" "10 0 1" "11 0 1"; do
+  set -- $case; preset=$1; notables=$2; aao=$3
+  label="preset $preset"; [ "$notables" = 1 ] && label="$label -t0"; [ "$aao" = 1 ] && label="$label aao"
   fail=0; n=0; skip=""
   for f in "$W"/in/*; do
     name=$(basename "$f")
-    if ! "$W/c" c "$preset" "$notables" < "$f" >| "$W/sc" 2>/dev/null; then
+    if ! "$W/c" c "$preset" "$notables" "$aao" < "$f" >| "$W/sc" 2>/dev/null; then
       echo "  [$label] $name: C-compress FAILED"; fail=$((fail+1)); continue
     fi
-    if ! "$W/rs" c "$preset" "$notables" < "$f" >| "$W/sr" 2>"$W/err"; then
+    if ! "$W/rs" c "$preset" "$notables" "$aao" < "$f" >| "$W/sr" 2>"$W/err"; then
       skip="rust refused ($(tr -d '\n' < "$W/err" | tail -c 40))"
       break
     fi
@@ -106,7 +128,7 @@ for case in "0 0" "1 0" "2 0" "3 0" "3 1" "4 0" "4 1" "5 0" "5 1" "6 0" "6 1" "7
     echo "  [$label] SKIPPED -- $skip"
     skipped=$((skipped+1))
   else
-    coder=$("$W/c" c "$preset" "$notables" < "$W/in/text" 2>/dev/null | head -c1 | od -An -tu1 | tr -d ' ')
+    coder=$("$W/c" c "$preset" "$notables" "$aao" < "$W/in/text" 2>/dev/null | head -c1 | od -An -tu1 | tr -d ' ')
     echo "  [$label, coder $coder] $n inputs, $fail differing"
     ran=$((ran+1)); total=$((total+fail))
   fi

--- a/rust/difftest/tornado_ref.cpp
+++ b/rust/difftest/tornado_ref.cpp
@@ -59,7 +59,7 @@ int main (int argc, char **argv) {
   // port. Compression is a separate mode rather than a flag because the
   // encoder covers only some presets so far and must be able to refuse.
   if (argc<2 || (argv[1][0]!='c'&&argv[1][0]!='d')) {
-    fprintf(stderr,"usage: %s c PRESET [NOTABLES] | d\n",argv[0]); return 2; }
+    fprintf(stderr,"usage: %s c PRESET [NOTABLES] [ALL_AT_ONCE] | d\n",argv[0]); return 2; }
   size_t cap=1<<20, len=0; unsigned char *in=(unsigned char*)malloc(cap); if(!in) return 3;
   for(;;){ if(len==cap){cap*=2; unsigned char*g=(unsigned char*)realloc(in,cap); if(!g){free(in);return 3;} in=g;}
     size_t n=fread(in+len,1,cap-len,stdin); if(n==0)break; len+=n; }
@@ -68,6 +68,12 @@ int main (int argc, char **argv) {
   if (argv[1][0]=='c') {
     int preset = argc>2? atoi(argv[2]) : 4;
     int notables = argc>3? atoi(argv[3]) : 0;
+    // 4th arg sets `compress_all_at_once`, which BOTH encoders read (the C
+    // inside tor_compress_chunk, the Rust via the value tornado_ccodec.cpp
+    // passes). It defaults to 0 and nothing here used to set it, so preset 9 in
+    // all-at-once mode -- the mode 4x4 forces, and the only caller that does --
+    // was never compared. That is where the port diverges.
+    compress_all_at_once = argc>4? atoi(argv[4]) : 0;
 #ifdef USE_RUST
     rc = rust_tor_compress_preset (preset, notables, io_callback, &b);
 #else


### PR DESCRIPTION
A real encoder divergence in the merged Tornado port, plus the two harness gaps that let it hide.

## The bug

`Hash3` defined `update_hash1` only in its **inherent** impl (`matchfinder.rs:972`), never in `impl MatchFinder for Hash3` (982–1078). `CombineMF` holds its auxiliary finder as `Box<dyn MatchFinder>`, so `mf2.update_hash1(p)` dispatched to the trait's **default** body:

```rust
debug_assert!(false, "update_hash1 called on a finder that does not define it");
```

`debug_assert!` compiles out in release — a **silent no-op**. The auxiliary 2/3-byte tables never received the insertions the C makes on `CombineMF`'s early exit (`len1 > mf1.MINLEN`).

Presets 7–11 are affected because they are the only ones pairing that finder with `CombineMF`. Presets 0–6 were always byte-identical. **The fix is four lines**: forward the trait method to the inherent one.

## How it was localised

Differential tracing, each step measured rather than inferred:

| step | finding |
|---|---|
| token trace (the C has `#ifdef DEBUG`; a matching one added to the Rust) | first divergence at `0x6df7` — C emits `match len 3 dist 42`, port emits three literals |
| Hash3 trace | same bucket `f32f`, different occupant (C `1a85`, port `ad5`) |
| insertion trace | C makes 4494 insertions, port 3397; first missed at `p=0x268` |
| CombineMF trace | `len1=6 d=308` **identical** at `p=0x268` — both take the branch |
| dispatch check | `impl MatchFinder for Hash3` contains no `update_hash1` |

That fourth row is what ruled out a threshold mismatch and forced the answer to be dispatch.

## Verification

| check | result |
|---|---|
| `tornado-encode-check.sh` (28 presets) | 10 differing → **0** |
| `4x4-check.sh` (252 comparisons) | 4 differing → **0** |
| `tornado-check.sh` (decoder) | **0** — unaffected, as an encoder-side fix should be |
| archiver round-trip, 9 methods incl. `tor:7`–`tor:11`, `4x4:b1m:tor:9` | **9/9** create+test+extract, contents diffed |
| backward compatibility | a stream written by the **pre-fix** encoder still decodes to the original under the fixed build |

That last row matters: this fix **intentionally changes** what `-mtor:7`…`-mtor:11` write, because the previous output was wrong. Existing archives stay readable — the decoder is untouched and was already byte-identical to the C.

Audited for the same trap elsewhere: `update_hash1` is only ever called on `CombineMF`'s children — `CycledCachingMatchFinder` (defines it) and `Box<dyn>`→`Hash3` (this fix). The types that omit it (`MatchFinder1/2/N`, `CachingMatchFinder`, `LazyMatching`) are never `CombineMF` children.

## Why nothing caught it

Two independent gaps, both closed here:

1. **`tornado-encode-check.sh` corpus coverage.** It already swept presets 0–11 and was green — no input it generated had the triggering shape. `chunky` is added, and it is what turns the sweep red without the fix.
2. **`4x4-check.sh` did not exist.** 4x4 is not ported and will not be, but it is on the default path (`3binary`…`9binary` are `4x4:bNm:lzma:…`, so `-m3`…`-m9` route `$binary` through it). This harness asks the other question — whether substituting Rust codecs *under* 4x4's framing changes the stream. It is what found this bug.

Also added: an `all_at_once` axis to the Tornado sweep (16 → 28 cases). `compress_all_at_once` defaults to 0 and nothing ever set it, while `C_4x4.cpp` forces 1 for all of `-m3`…`-m9`'s `$binary` group. All 28 agree on that axis — it is **not** the cause here, but the gap was real.

## Two wrong turns, recorded in the history

- I first blamed `all_at_once`. It reproduces at **both** settings.
- I then "fixed" `CycledCachingMatchFinder::min_length` to 4 after reading only `MatchFinder.cpp:507-600` and seeing no override. The override is at **:631**, inside a struct body running 507–632; that change took the sweep from 10 differing to **173**. Reverted; `self.n` was always correct. `397e03a` records it with the line number.

## Harness incompatibility worth knowing

`4x4-check.sh` builds the staticlib **with** `--features darc-codecs/dropin`; the tornado harnesses need it **without** (the pinned `tornado_ccodec.cpp` defines `tor_decompress` and collides). Cargo re-resolves per run so sequential is fine — concurrent is not, and produces empty output and stalled runs. Documented in both files and in the CI step.

`RUST_PORT_PROGRESS.md` §10 is also corrected: it recommended against porting 4x4 and cited "no fingerprint case", which is true of the test suite and was repeatedly misread as "nothing uses this codec". The recommendation stands; only the justification changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)