### PR TITLE
Type-safety items 1-3: make the silent-no-op bug class fail loudly

### DIFF
--- a/RUST_PORT_PROGRESS.md
+++ b/RUST_PORT_PROGRESS.md
@@ -470,6 +470,43 @@ reaches Rust through the C dispatcher rather than calling `darc_rs_*` directly.
 `lzma` is deliberately excluded as an inner method: it has no Rust port, so that
 comparison would compare a build against itself.
 
+### 10b. Make the silent-no-op bug class a COMPILER error -- AGREED, item 4 PENDING
+
+Prompted by the Tornado presets 7-11 divergence, whose cause was a trait default
+that did nothing in release: `MatchFinder::update_hash1` defaulted to
+`debug_assert!(false, ...)`, `Hash3` implemented it only inherently, and
+`CombineMF`'s `Box<dyn MatchFinder>` call landed on the default. Every difftest
+builds `--release`, so the guard never ran.
+
+**Done.** No defaulted trait methods remain anywhere in the crate. Removing the
+two on `MatchFinder` turned the omission into a compile error and immediately
+surfaced two more instances of the same shape -- `MatchFinderN` (inherent-only)
+and `CachingMatchFinder` (absent, though the C has one at MatchFinder.cpp:462).
+`debug-assert-check.sh` now runs the codecs in a debug profile, which nothing did
+before.
+
+**Small, low risk, worth doing next:**
+
+1. Crate-level lint gates in `rust/darc-codecs/src/lib.rs` -- there are none.
+2. The 11 `_ => {}` catch-all arms: consult the C per site, `unreachable!()` where
+   the C would not compile, a documented no-op where it genuinely falls through.
+   `mm.rs:445` already does the latter correctly and is the model to copy.
+3. Audit the 23 `debug_assert!`s: promote cheap invariant checks to `assert!` so
+   they are live in release; leave per-call hot-path ones as debug. For scale,
+   342 assertions in the crate ARE live -- the bug hid in one of the 23 that
+   were not.
+
+**Item 4, agreed and deliberately deferred: model mode bytes as enums and
+offsets as newtypes.** This is the only item that yields a compile error rather
+than a runtime panic, because bare integers cannot be matched exhaustively.
+
+It is a project, not a patch: roughly 1968 `as` casts in the crate, each a
+possible silent truncation, in codecs whose output must stay byte-exact. Do it
+PER CODEC, with that codec's difftest green at every step, and expect it to
+surface further latent holes the way removing the trait defaults did. Candidates:
+GRZip's mode bits, MM's filter selector, TTA's `byte_size`, DisPack's mode,
+Tornado's `encoding_method`/`caching_finder`.
+
 ### 11. Port the Haskell application layer (17,843 lines, 41 files)
 
 The largest remaining piece. Suggested order (from `CLAUDE.md`):

--- a/rust/darc-codecs/src/dispack/encode.rs
+++ b/rust/darc-codecs/src/dispack/encode.rs
@@ -329,7 +329,11 @@ impl Encoder {
         for b in &self.buf {
             out.extend_from_slice(b);
         }
-        debug_assert_eq!(out.len(), total);
+        // assert_eq!, not debug_assert_eq!: this runs once per block, so it is
+        // affordable in release, and a wrong output length means a malformed
+        // stream. The difftests build --release, where a debug_assert would not
+        // have been checked at all.
+        assert_eq!(out.len(), total, "DisPack encode produced the wrong length");
         out
     }
 }

--- a/rust/darc-codecs/src/lib.rs
+++ b/rust/darc-codecs/src/lib.rs
@@ -7,6 +7,31 @@
 //! "correctly" but differently produces archives older builds cannot read,
 //! which is the highest-risk failure mode in this repository.
 
+//! ## Lint gates
+//!
+//! These are `deny`, not `warn`, and each one guards a way this crate has
+//! actually been bitten or could be silently bitten:
+//!
+//! * `clippy::wildcard_enum_match_arm` -- a `_ =>` over an enum silently
+//!   absorbs variants added later. This is the compile-time half of the lesson
+//!   from the Tornado presets 7-11 bug, where a silent fallback (a trait default
+//!   whose body was `debug_assert!`, dead in release) changed the encoder's
+//!   output with nothing failing. As the codecs' bare mode integers become enums
+//!   (RUST_PORT_PROGRESS.md section 10b, item 4), this lint is what converts each
+//!   one into enforced exhaustiveness.
+//! * `clippy::todo`, `clippy::unimplemented` -- placeholders that panic at run
+//!   time in a library whose failures corrupt archives.
+//! * `clippy::mem_forget` -- leaking a codec buffer is never intended here.
+//! * `unused_must_use` -- these codecs return `c_int` status codes constantly;
+//!   an ignored one is a swallowed error.
+//!
+//! Deliberately NOT denied: `unreachable_pub` (84 pre-existing hits) and the
+//! ~169 style warnings the port carries. Those are noise to fix, not hazards,
+//! and denying them would mean touching byte-exact code for cosmetics.
+#![deny(clippy::wildcard_enum_match_arm)]
+#![deny(clippy::todo, clippy::unimplemented, clippy::mem_forget)]
+#![deny(unused_must_use)]
+
 pub mod bsc;
 pub mod delta;
 pub mod dict;

--- a/rust/darc-codecs/src/lz4hc.rs
+++ b/rust/darc-codecs/src/lz4hc.rs
@@ -1051,9 +1051,15 @@ pub fn compress_hc(src: &[u8], dst: &mut [u8], level: i32) -> usize {
     let mut out = Out { buf: dst, pos: 0 };
     let input_size = src.len() as i32;
     let strategy = level_params(level);
+    // Exhaustive on purpose: a wildcard here would silently give a new strategy
+    // `max_nb_attempts = 0`, and `pattern_analysis` below is derived from it, so
+    // the parse would change without any error. clippy::wildcard_enum_match_arm
+    // is denied at the crate root to keep it that way.
     let max_nb_attempts = match strategy {
         Strategy::HashChain(n) => n,
-        _ => 0,
+        // The mid and optimal parsers do not use a hash-chain attempt budget;
+        // lz4hc.c reaches their loops without consulting nbSearches this way.
+        Strategy::Mid | Strategy::Optimal(..) => 0,
     };
     // `patternAnalysis` (lz4hc.c:1133) is tied to the search depth, not the
     // level number: "levels 9+". (The optimal parser hardcodes it on instead.)

--- a/rust/darc-codecs/src/mm.rs
+++ b/rust/darc-codecs/src/mm.rs
@@ -627,6 +627,11 @@ fn encode(
                 2 => diff2(data, chan, &mut base),
                 3 => diff3(data, chan, &mut base),
                 4 => diff4(data, chan, &mut base),
+                // Verified against the pinned C: `switch (byte_size)` has cases
+                // 1-4 and NO default (MM/tta.cpp:133, :183), so a value outside
+                // 1..=4 passes through unchanged there too. Documented rather than
+                // turned into `unreachable!()` because the fall-through is the C's
+                // behaviour, not an impossibility.
                 _ => {}
             }
             // reorder_words (:r2) is not resurrected: the C is `return buf;`.

--- a/rust/darc-codecs/src/srep/hashes.rs
+++ b/rust/darc-codecs/src/srep/hashes.rs
@@ -115,7 +115,11 @@ mod tests {
                 Hash::Md5 => Md5::digest(data).to_vec(),
                 Hash::Sha1 => Sha1::digest(data).to_vec(),
                 Hash::Sha512 => Sha512::digest(data).to_vec(),
-                _ => unreachable!(),
+                // Exhaustive rather than `_`: the loop above lists the three
+                // seedless hashes, and the crate root denies
+                // clippy::wildcard_enum_match_arm so a new variant has to be
+                // classified here instead of silently landing in this arm.
+                Hash::None | Hash::Unverified(_) => unreachable!(),
             };
             assert_eq!(good.len(), h.stored_bytes());
             assert!(h.verify(data, &good).is_ok());

--- a/rust/darc-codecs/src/tornado/lz77_enc.rs
+++ b/rust/darc-codecs/src/tornado/lz77_enc.rs
@@ -134,7 +134,16 @@ impl Lz77Encoder for ByteCoder<'_> {
     }
 
     fn encode_table(&mut self, _kind: i32, _len: i32) {
-        debug_assert!(false, "encode_table on a coder without table support");
+        // `unreachable!`, not `debug_assert!`. The whole body used to be a
+        // debug_assert, which compiles out in release -- so a mis-dispatch here
+        // silently skipped table encoding and produced a different stream with
+        // nothing failing. That is exactly how the Tornado presets 7-11
+        // divergence happened one module over (MatchFinder::update_hash1).
+        //
+        // The encode loop only calls this when `support_tables` is set, and the
+        // preset sweep covers `notables` both ways, so this is unreachable in
+        // practice -- and now says so in release too.
+        unreachable!("encode_table on a coder without table support");
     }
 
     fn shift_occurs(&mut self) {}
@@ -204,7 +213,16 @@ impl Lz77Encoder for BitCoder<'_> {
     }
 
     fn encode_table(&mut self, _kind: i32, _len: i32) {
-        debug_assert!(false, "encode_table on a coder without table support");
+        // `unreachable!`, not `debug_assert!`. The whole body used to be a
+        // debug_assert, which compiles out in release -- so a mis-dispatch here
+        // silently skipped table encoding and produced a different stream with
+        // nothing failing. That is exactly how the Tornado presets 7-11
+        // divergence happened one module over (MatchFinder::update_hash1).
+        //
+        // The encode loop only calls this when `support_tables` is set, and the
+        // preset sweep covers `notables` both ways, so this is unreachable in
+        // practice -- and now says so in release too.
+        unreachable!("encode_table on a coder without table support");
     }
 
     fn shift_occurs(&mut self) {}

--- a/rust/darc-codecs/src/tta.rs
+++ b/rust/darc-codecs/src/tta.rs
@@ -433,6 +433,11 @@ fn filters_decompress(data: &mut [i64], level: usize, byte_size: usize) {
             2 => *p += predictor1(last, 5),
             3 => *p += predictor1(last, 5),
             4 => *p += last,
+            // Verified against the pinned C: `switch (byte_size)` has cases
+            // 1-4 and NO default (MM/tta.cpp:133, :183), so a value outside
+            // 1..=4 passes through unchanged there too. Documented rather than
+            // turned into `unreachable!()` because the fall-through is the C's
+            // behaviour, not an impossibility.
             _ => {}
         }
         last = *p;
@@ -501,6 +506,11 @@ fn write_wave(
                     out[base + 2] = (u >> 16) as u8;
                 }
                 4 => out[base..base + 4].copy_from_slice(&(v as i32).to_le_bytes()),
+                // Verified against the pinned C: `switch (byte_size)` has cases
+                // 1-4 and NO default (MM/tta.cpp:133, :183), so a value outside
+                // 1..=4 passes through unchanged there too. Documented rather than
+                // turned into `unreachable!()` because the fall-through is the C's
+                // behaviour, not an impossibility.
                 _ => {}
             }
         }
@@ -904,6 +914,11 @@ fn filters_compress(data: &mut [i64], level: usize, byte_size: usize) {
             1 => *v = v.wrapping_sub(predictor1(last, 4)),
             2 | 3 => *v = v.wrapping_sub(predictor1(last, 5)),
             4 => *v = v.wrapping_sub(last),
+            // Verified against the pinned C: `switch (byte_size)` has cases
+            // 1-4 and NO default (MM/tta.cpp:133, :183), so a value outside
+            // 1..=4 passes through unchanged there too. Documented rather than
+            // turned into `unreachable!()` because the fall-through is the C's
+            // behaviour, not an impossibility.
             _ => {}
         }
         last = tmp;
@@ -1029,6 +1044,11 @@ fn read_wave(
                 ]) as i64;
             }
         }
+        // Verified against the pinned C: `switch (byte_size)` has cases
+        // 1-4 and NO default (MM/tta.cpp:133, :183), so a value outside
+        // 1..=4 passes through unchanged there too. Documented rather than
+        // turned into `unreachable!()` because the fall-through is the C's
+        // behaviour, not an impossibility.
         _ => {}
     }
     Ok((bytes_read, buffer))


### PR DESCRIPTION
Follow-up to #102, whose bug was a trait default that compiled to nothing in
release: the encoder diverged from the C for thousands of positions with nothing
failing anywhere. Items 1-3 of the plan in `RUST_PORT_PROGRESS.md` §10b. Item 4
(enum-model the mode bytes) stays deferred — it is per-codec and difftest-gated,
one PR each.

## 1. Crate-level lint gates (there were none)

```rust
#![deny(clippy::wildcard_enum_match_arm)]
#![deny(clippy::todo, clippy::unimplemented, clippy::mem_forget)]
#![deny(unused_must_use)]
```

Chosen by measuring which lints are *already* clean, not by taste —
`unreachable_pub` (84 hits) and the ~169 style warnings are deliberately left as
warnings, being cosmetics in byte-exact code.

`wildcard_enum_match_arm` is the one that matters: a `_ =>` over an enum
silently absorbs variants added later, which is the compile-time half of this
bug class. Verified the gate *bites* by reintroducing a wildcard — the build
fails with "wildcard match will also match any future added variants".

It has **two** hits, both now exhaustive:

* `lz4hc.rs`'s `_ => 0` over `Strategy` → `Strategy::Mid | Strategy::Optimal(..)`.
  `Strategy` has exactly three variants (`lz4hc.rs:1009`), so the new arm set is
  provably identical to the wildcard: a no-op today, enforcement tomorrow.
* `srep/hashes.rs:118`, a test's `_ => unreachable!()` over the three seedless
  hashes → `Hash::None | Hash::Unverified(_)`. Found only after the first commit,
  because my survey ran over the **lib** and this arm is inside `#[cfg(test)]` —
  a target a lib-only clippy run never compiles. Same shape as the bug this
  branch is about: I checked a proxy for a claim about the whole crate.

`cargo clippy --all-targets` is clean as of `a64f1ae`; `cargo nextest -p
darc-codecs` is 182 passed.

## 2. The 11 `_ => {}` arms — six done, five deliberately untouched

They collapse to three matched expressions, not eleven:

* `byte_size` (mm.rs ×2, tta.rs ×4) — verified against the pinned C, whose
  `switch (byte_size)` has cases 1-4 and **no** default (`MM/tta.cpp:133`,
  `:183`). The fall-through *is* the C's behaviour, so these are documented, not
  converted to `unreachable!()`.
* `flags & F_TYPE` (dispack ×3) and GRZip's rec mode (×2) — **not touched.**
  Verifying them needs the C DisPack filter and `Rec_Flt.c` read properly, and
  both are deleted from the working tree. An unverified `unreachable!()` there
  could panic on a valid archive, which is worse than the status quo.

## 3. Release-dead guards

* `lz77_enc.rs` ×2 (`encode_table` on a coder without table support): the whole
  body was `debug_assert!(false, …)`, so a mis-dispatch silently skipped table
  encoding in release and changed the stream — the exact shape of #102. Now
  `unreachable!()`.
* `out_stream.rs:93` **left alone**, deliberately: it also sets
  `err = FREEARC_ERRCODE_GENERAL` and returns false, so it does not silently
  continue, and panicking across the FFI boundary would be worse.
* DisPack's once-per-block output-length invariant promoted from
  `debug_assert_eq!` to `assert_eq!` — affordable at that frequency, and the
  difftests build `--release`, where the debug form was never checked at all.

## Validation

All six relevant difftests re-run **sequentially** against the pinned C
reference (`5c2c6ce`) — they share `rust/target`, and two want different cargo
feature sets, so parallel runs produce garbage. Every one **0 differing**:

| harness | result |
|---|---|
| `tornado-encode-check.sh` | 28 presets × 29 inputs, 0 differing (1570s) |
| `dispack-check.sh` | 3 block sizes × 13 inputs, 0 differing |
| `dispack-filter-check.sh` | 0 differing |
| `tta-check.sh` | 14 configs × 17 inputs, 0 differing |
| `mm-check.sh` | 640 filtered streams + 125 stored, 0 differing |
| `lz4hc-check.sh` | 312/312 byte-identical |

The two that carry the risk: **Tornado is green on presets 7-11 at both
`all_at_once` settings** — the exact set that diverged before #102 — so neither
`encode_table` stub is reachable on any preset, and the `unreachable!()`
conversion costs nothing. And DisPack passes with the promoted `assert_eq!`, so
that invariant does not fire.

## Known gap, not fixed here

CI runs `cargo clippy --all-targets || true` (`build.yml:763`), so **these deny
gates cannot fail CI as things stand.** They bite locally and in any editor, but
the `|| true` makes the enforcement half of item 1 advisory. Dropping it is a
one-line change with a real blast radius — every `deny` in the workspace becomes
a merge blocker — so it belongs in its own PR rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
