### PR TITLE
Item 4, codec 1: model DisPack's flag nibble as types

### DIFF
--- a/rust/darc-codecs/src/dispack/encode.rs
+++ b/rust/darc-codecs/src/dispack/encode.rs
@@ -223,7 +223,7 @@ impl Encoder {
             self.put16(ST_IMM16, v);
         }
 
-        if flags & F_MODE == F_MR {
+        if mode_of(flags) == Mode::ModRm {
             let modrm = instr[p];
             p += 1;
             self.put8(ST_MODRM, modrm);
@@ -252,30 +252,29 @@ impl Encoder {
             }
         }
 
-        if flags & F_MODE == F_AM {
-            match flags & F_TYPE {
-                F_AD => {
+        if mode_of(flags) == Mode::Address {
+            match addr_of(flags) {
+                AddrType::Absolute => {
                     let w = &instr[p..p + 4];
                     let v = u32::from_le_bytes([w[0], w[1], w[2], w[3]]);
                     p += 4;
                     self.put32(ST_ADDR32, v);
                 }
-                F_DA => {
+                AddrType::DwordAbsJump => {
                     let w = &instr[p..p + 4];
                     let v = u32::from_le_bytes([w[0], w[1], w[2], w[3]]);
                     p += 4;
                     self.put32(ST_AJUMP32, v);
                 }
-                F_BR => {
+                AddrType::ByteRel => {
                     let v = instr[p];
                     p += 1;
                     self.put8(ST_JUMP8, v);
                 }
-                // Named, not `_`: this arm carries F_DR's real logic, and as a
-                // catch-all it would have silently applied that logic to any
-                // unexpected value. It is correct only because F_DR is the
-                // fourth of four; say which case it is.
-                F_DR => {
+                // This arm carries real logic. Before #104 it was spelled `_`,
+                // so any unexpected value silently received the relative-dword
+                // treatment; now the type makes that impossible to write.
+                AddrType::DwordRel => {
                     // Relative dword target -> absolute.
                     let w = &instr[p..p + 4];
                     let disp = u32::from_le_bytes([w[0], w[1], w[2], w[3]]);
@@ -289,24 +288,23 @@ impl Encoder {
                         self.put_call_target(target);
                     }
                 }
-                // F_TYPE is 0xc -- two bits, four values -- and the four arms
-                // above are 0x0/0x4/0x8/0xc. The C's switch (DisPack.cpp:516)
-                // has no `default` for the same reason.
-                _ => unreachable!("flags & F_TYPE outside the four-value mask"),
+                // No catch-all: all four variants are named, so the match is
+                // total by construction. The C's switch (DisPack.cpp:516) has no
+                // `default` for the same reason.
             }
         } else {
-            match flags & F_TYPE {
-                F_BI => {
+            match imm_of(flags) {
+                ImmSize::Byte => {
                     let v = instr[p];
                     p += 1;
                     self.put8(ST_IMM8, v);
                 }
-                F_WI => {
+                ImmSize::Word => {
                     let v = u16::from_le_bytes([instr[p], instr[p + 1]]);
                     p += 2;
                     self.put16(ST_IMM16, v);
                 }
-                F_DI => {
+                ImmSize::Dword => {
                     if !o16 {
                         let w = &instr[p..p + 4];
                         let v = u32::from_le_bytes([w[0], w[1], w[2], w[3]]);
@@ -318,12 +316,9 @@ impl Encoder {
                         self.put16(ST_IMM16, v);
                     }
                 }
-                // F_NI, "no immediate". The C's switch (DisPack.cpp:541) lists
-                // only fBI/fWI/fDI and lets fNI fall through, so a no-op is the
-                // correct port -- named so it is distinguishable from the
-                // impossible fourth value.
-                F_NI => {}
-                _ => unreachable!("flags & F_TYPE outside the four-value mask"),
+                // The C's switch (DisPack.cpp:541) lists only fBI/fWI/fDI and
+                // lets fNI fall through, so a no-op is the correct port.
+                ImmSize::None => {}
             }
         }
 

--- a/rust/darc-codecs/src/dispack/filter.rs
+++ b/rust/darc-codecs/src/dispack/filter.rs
@@ -256,10 +256,13 @@ pub fn dis_unfilter(source: &[u8], dest_size: usize, mem_start: u32) -> Option<V
             copy16_chk!(ST_IMM16);
         }
 
-        // "Has a ModR/M byte" is `flags & fMR` (0x2): true for fMR (0x2) and
-        // fMEXTRA (0x3), false for fNM (0x0) and fAM (0x1).
+        // "Has a ModR/M byte" is the C's `flags & fMR` (DisPack.cpp:782): true
+        // for fMR and fMEXTRA, false for fNM and fAM. Note the encoder tests
+        // `(flags & fMODE) == fMR` instead (:496) -- the asymmetry is the C's
+        // own, and spelling both as `Mode` makes it legible rather than two
+        // similar-looking bit tests.
         let mut flags = flags;
-        if flags & F_MR != 0 {
+        if matches!(mode_of(flags), Mode::ModRm | Mode::ModRmExtra) {
             if !st.src_avail(ST_MODRM, 1) || !st.dst_ok(cap, 1) {
                 return None;
             }
@@ -298,14 +301,14 @@ pub fn dis_unfilter(source: &[u8], dest_size: usize, mem_start: u32) -> Option<V
             }
         }
 
-        if (flags & F_MODE) == F_AM {
-            match flags & F_TYPE {
-                F_AD => copy32_chk!(ST_ADDR32),
-                F_DA => copy32_chk!(ST_AJUMP32),
-                F_BR => {
+        if mode_of(flags) == Mode::Address {
+            match addr_of(flags) {
+                AddrType::Absolute => copy32_chk!(ST_ADDR32),
+                AddrType::DwordAbsJump => copy32_chk!(ST_AJUMP32),
+                AddrType::ByteRel => {
                     copy8_chk!(ST_JUMP8);
                 }
-                F_DR => {
+                AddrType::DwordRel => {
                     // Relative dword target: recover it from the absolute value.
                     let target = if code as u8 == OP_CALLN {
                         check_src!(ST_CALL_IDX, 1);
@@ -333,34 +336,26 @@ pub fn dis_unfilter(source: &[u8], dest_size: usize, mem_start: u32) -> Option<V
                     }
                     st.out.extend_from_slice(&rel.to_le_bytes());
                 }
-                // Dead by arithmetic, not by assumption: F_TYPE is 0xc, two
-                // bits, so `flags & F_TYPE` has exactly four possible values,
-                // and F_AD/F_DA/F_BR/F_DR are 0x0/0x4/0x8/0xc -- all four. The
-                // C's switch (DisPack.cpp:812) has no `default` for the same
-                // reason. Only a bare-integer mask forces an arm here at all;
-                // modelling F_TYPE as an enum would remove it.
-                _ => unreachable!("flags & F_TYPE outside the four-value mask"),
+                // No catch-all: all four variants are named, so the compiler
+                // knows the match is total. #104 had to establish that by hand
+                // from the C header; now it is a property of the type.
             }
         } else {
-            match flags & F_TYPE {
-                F_BI => {
+            match imm_of(flags) {
+                ImmSize::Byte => {
                     copy8_chk!(ST_IMM8);
                 }
-                F_WI => copy16_chk!(ST_IMM16),
-                F_DI => {
+                ImmSize::Word => copy16_chk!(ST_IMM16),
+                ImmSize::Dword => {
                     if !o16 {
                         copy32_chk!(ST_IMM32);
                     } else {
                         copy16_chk!(ST_IMM16);
                     }
                 }
-                // F_NI, "no immediate" -- the common case for most opcodes.
-                // Named rather than left as `_`: the C's switch
-                // (DisPack.cpp:849) lists only fBI/fWI/fDI and lets fNI fall
-                // through, so doing nothing is the correct port, and saying so
-                // separates it from the impossible fourth value below.
-                F_NI => {}
-                _ => unreachable!("flags & F_TYPE outside the four-value mask"),
+                // The C's switch (DisPack.cpp:849) lists only fBI/fWI/fDI and
+                // lets fNI fall through, so doing nothing is the correct port.
+                ImmSize::None => {}
             }
         }
     }

--- a/rust/darc-codecs/src/dispack/tables.rs
+++ b/rust/darc-codecs/src/dispack/tables.rs
@@ -81,6 +81,85 @@ pub const F_DR: u8 = 0xc; // dword relative jump target
 
 pub const F_ERR: u8 = 0xf; // invalid opcode
 
+// The nibble's two fields, as types. The opcode tables below stay `u8` on
+// purpose -- they must reproduce the C's byte-for-byte -- so the conversion
+// happens once, here, at the point of use.
+//
+// Why bother: `flags & F_TYPE` is a two-bit field, so it has exactly four
+// values, but the compiler cannot know that about a `u8`. Every match on it
+// therefore needs an arm for values that cannot occur, and #104 had to prove by
+// hand -- from a 40-year-old C header -- that three such arms were dead. As
+// enums the matches are exhaustive, the impossible arms disappear, and a new
+// variant becomes a compile error instead of something a catch-all absorbs.
+
+/// The low two bits: how the instruction's operands are encoded.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum Mode {
+    /// `fNM` — no ModR/M byte.
+    NoModRm,
+    /// `fAM` — no ModR/M, and the operand is an address (jump or direct).
+    Address,
+    /// `fMR` — ModR/M present.
+    ModRm,
+    /// `fMEXTRA` — ModR/M present, opcode extension in the reg field.
+    ModRmExtra,
+}
+
+/// The high two bits when [`Mode`] is not [`Mode::Address`]: immediate size.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum ImmSize {
+    /// `fNI` — no immediate operand. The common case.
+    None,
+    /// `fBI`
+    Byte,
+    /// `fWI`
+    Word,
+    /// `fDI` — dword, or word under a 0x66 operand-size prefix.
+    Dword,
+}
+
+/// The high two bits when [`Mode`] is [`Mode::Address`]: kind of address operand.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum AddrType {
+    /// `fAD` — absolute address.
+    Absolute,
+    /// `fDA` — dword absolute jump target.
+    DwordAbsJump,
+    /// `fBR` — byte relative jump target.
+    ByteRel,
+    /// `fDR` — dword relative jump target.
+    DwordRel,
+}
+
+// Indexed lookups rather than `match`: the index is masked to 0..=3, so there is
+// no arm and no panic path to justify. A `match` on the `u8` would reintroduce
+// exactly the catch-all this exists to remove.
+const MODES: [Mode; 4] = [Mode::NoModRm, Mode::Address, Mode::ModRm, Mode::ModRmExtra];
+const IMM_SIZES: [ImmSize; 4] = [ImmSize::None, ImmSize::Byte, ImmSize::Word, ImmSize::Dword];
+const ADDR_TYPES: [AddrType; 4] = [
+    AddrType::Absolute,
+    AddrType::DwordAbsJump,
+    AddrType::ByteRel,
+    AddrType::DwordRel,
+];
+
+/// The encoding mode of a table nibble.
+pub fn mode_of(flags: u8) -> Mode {
+    MODES[(flags & F_MODE) as usize]
+}
+
+/// The immediate size of a table nibble. Meaningful only when [`mode_of`] is not
+/// [`Mode::Address`]; the same two bits mean [`AddrType`] there.
+pub fn imm_of(flags: u8) -> ImmSize {
+    IMM_SIZES[((flags & F_TYPE) >> 2) as usize]
+}
+
+/// The address-operand type of a table nibble. Meaningful only when [`mode_of`]
+/// is [`Mode::Address`].
+pub fn addr_of(flags: u8) -> AddrType {
+    ADDR_TYPES[((flags & F_TYPE) >> 2) as usize]
+}
+
 // The nibble combinations, so the tables below read like the C source.
 const MR_NI: u8 = F_MR | F_NI;
 const MR_BI: u8 = F_MR | F_BI;


### PR DESCRIPTION
**Stacked on #104** — base is `catchall-arms-dispack-grzip`, so review that first.
I'll retarget to `main` once #104 merges.

The first codec of `RUST_PORT_PROGRESS.md` §10b item 4. #104 established that
three DisPack catch-alls were dead by proving, by hand from a 40-year-old C
header, that `flags & F_TYPE` is a two-bit field. That proof should be the
compiler's job.

## What changed

Three enums in `tables.rs` — `Mode` (the low two bits), `ImmSize` and `AddrType`
(the high two, one meaning per mode) — plus `mode_of` / `imm_of` / `addr_of`.

Two deliberate boundaries:

* **The opcode tables stay `u8`.** They must reproduce the C's bytes exactly, and
  converting them would be a large diff over the part of this codec that *is*
  literally the archive format. The nibble is decoded once, at the point of use.
* **The conversions are 4-element array lookups** indexed by a value masked to
  `0..=3`, not a `match` on the `u8`. A match would reintroduce the very
  catch-all this removes, just relocated.

Net: all four dispatch sites become exhaustive matches, and the three
`unreachable!()`s #104 added are **deleted**. No arm anywhere in DisPack now
exists for a value that cannot occur.

## It does what the item promised

Adding a hypothetical fifth `ImmSize` variant fails the build at the decision
sites, in both directions:

```
encode.rs:296 error[E0004]: non-exhaustive patterns: `ImmSize::Qword` not covered
filter.rs:344 error[E0004]: non-exhaustive patterns: `ImmSize::Qword` not covered
```

That is the "one compiler error instead of several diagnostic runs" this line of
work exists for. Note it points at the *decision* sites, not the lookup array —
a 5-variant enum for a 2-bit field is nonsense, and the error lands where the
judgement has to be made.

## An asymmetry the types made legible

The C tests the ModR/M mode **differently in each direction**: `(flags & fMODE)
== fMR` when encoding (`DisPack.cpp:496`) but `flags & fMR` when decoding
(`:782`) — the latter true for `fMEXTRA` as well. Two similar-looking bit tests
that are not the same test, which is easy to misread as a port bug in either
direction (I did, briefly, and checked the C rather than "fixing" it). They are
now `mode_of(flags) == Mode::ModRm` and `matches!(mode_of(flags), Mode::ModRm |
Mode::ModRmExtra)`, which says what it means.

## Verified

Byte-identical against the pinned C (`5c2c6ce`), both directions:

| harness | result |
|---|---|
| `dispack-check.sh` | **0 differing**, 3 block sizes × 13 inputs |
| `dispack-filter-check.sh` | **0 differing over 108** comparisons |

`cargo clippy --all-targets` clean; `cargo nextest -p darc-codecs` 182 passed.

**The conversion arrays are the whole risk** — a swapped entry silently remaps a
mode, and only byte-identity would ever notice. So each was sabotaged, and each
was caught by `dispack-filter-check`:

* `MODES` swap Address/ModRm → caught
* `IMM_SIZES` swap Byte/Word → caught
* `ADDR_TYPES` swap Absolute/DwordAbsJump → caught

## Next codecs

Same shape, one PR each, each gated by its own difftest: GRZip's mode bits, MM's
filter selector, TTA's `byte_size`, Tornado's `encoding_method` /
`caching_finder`. GRZip needs care — its rec mode arrives **from the compressed
stream**, so its fall-through must survive as a no-op (see #104); the enum there
wants an explicit `Unknown` variant rather than an exhaustive four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
