### PR TITLE
Enforce totality: no `if let` anywhere in the Rust workspace

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -761,6 +761,44 @@ jobs:
     - name: cargo clippy
       working-directory: rust
       run: cargo clippy --all-targets || true
+    # Totality gate, across the WHOLE Rust workspace -- darc-codecs and
+    # darc-crypto both. An exhaustive `match` with every arm named is preferred
+    # over `if let`, so a branch carrying archive or crypto behaviour has to be
+    # written down and cannot be silently absent -- that is the shape of the
+    # Tornado presets 7-11 bug (#102) and of the lz4hc `Strategy` fall-through
+    # this gate's own PR fixed.
+    #
+    # darc-crypto had zero `if let` when the gate was widened, so this costs
+    # nothing today and is purely about keeping it that way.
+    #
+    # This is a grep because clippy cannot express it. There is no lint that bans
+    # `if let`; the whole related family (`single_match`, `single_match_else`,
+    # `manual_let_else`, `option_if_let_else`) points from `match` TOWARDS
+    # `if let`, and `single_match` is warn-by-default, which is why the crate root
+    # allows it. Totality is `deny(clippy::wildcard_enum_match_arm)` -- no `_ =>`,
+    # so every arm is named -- plus this gate.
+    #
+    # `while let` and `let ... else` are deliberately NOT covered: the first is a
+    # loop's termination condition, and the second must diverge in its `else`, so
+    # both already write down what happens in the other case.
+    - name: no `if let` in the Rust workspace
+      run: |
+        set -uo pipefail
+        # -F for a literal match; the pattern must not be read as a regex.
+        # --exclude-dir=target keeps build artefacts and vendored crate sources
+        # out: `rust/target` contains third-party code this rule does not govern.
+        # The two -v filters drop comment lines: `//` after the file:line prefix,
+        # and `//!` module docs (the rule is documented in prose in lib.rs).
+        # Single quotes throughout -- backticks inside double quotes would be
+        # command substitution, and "if let" is not a command.
+        hits=$(grep -rnF 'if let ' rust --include='*.rs' --exclude-dir=target \
+                 | grep -Ev ':[0-9]+: *//' | grep -v '//!' || true)
+        if [ -n "$hits" ]; then
+          echo '::error::this workspace uses an exhaustive match, not if let. Offenders:'
+          echo "$hits"
+          exit 1
+        fi
+        echo 'no if let anywhere under rust/ (excluding target)'
 
   # ── Rust codec ports ────────────────────────────────────────────────────────
   # Two things are checked, and they are not the same thing:

--- a/rust/darc-codecs/src/bsc/lzp_enc.rs
+++ b/rust/darc-codecs/src/bsc/lzp_enc.rs
@@ -416,14 +416,17 @@ fn encode_unrolled(input: &[u8], output: &mut [u8], hash_size: u32, min_len: u32
             }
         }
 
-        if let Some(k) = bad {
-            // BAD_MATCH_FOUND: step past the literal, which is already in the
-            // output, and append the escape byte.
-            ip += k + 1;
-            op += k + 1;
-            output[op] = 255;
-            op += 1;
-            continue;
+        match bad {
+            Some(k) => {
+                // BAD_MATCH_FOUND: step past the literal, which is already in the
+                // output, and append the escape byte.
+                ip += k + 1;
+                op += k + 1;
+                output[op] = 255;
+                op += 1;
+                continue;
+            }
+            None => {}
         }
 
         let (k, reference) = match good {

--- a/rust/darc-codecs/src/delta.rs
+++ b/rust/darc-codecs/src/delta.rs
@@ -532,22 +532,33 @@ pub fn compress(io: &Io, block_size: u32, _extended_tables: c_int) -> c_int {
                             if !fast_check(&buf, n, p) {
                                 continue;
                             }
-                            if let Some((ts, te, ty)) = slow_check_for_data_table(
+                            match slow_check_for_data_table(
                                 &mut buf, n, p, last_table_end as isize, bufend, &mut scratch,
                             ) {
-                                tskip.extend_from_slice(&((ts - last_table_end) as u32).to_le_bytes());
-                                ttype.extend_from_slice(&ty.to_le_bytes());
-                                trows.extend_from_slice(&(((te - ts) / n) as u32).to_le_bytes());
-                                last_table_end = te;
-                                found_end = Some(te);
-                                break 'candidates;
+                                Some((ts, te, ty)) => {
+                                    tskip.extend_from_slice(
+                                        &((ts - last_table_end) as u32).to_le_bytes(),
+                                    );
+                                    ttype.extend_from_slice(&ty.to_le_bytes());
+                                    trows.extend_from_slice(
+                                        &(((te - ts) / n) as u32).to_le_bytes(),
+                                    );
+                                    last_table_end = te;
+                                    found_end = Some(te);
+                                    break 'candidates;
+                                }
+                                // No table at this candidate; try the next `p`.
+                                None => {}
                             }
                         }
                     }
                 }
-                if let Some(te) = found_end {
-                    ptr = core::cmp::max(ptr + LINE, te);
-                    continue;
+                match found_end {
+                    Some(te) => {
+                        ptr = core::cmp::max(ptr + LINE, te);
+                        continue;
+                    }
+                    None => {}
                 }
             }
             ptr += LINE;

--- a/rust/darc-codecs/src/dict_encode.rs
+++ b/rust/darc-codecs/src/dict_encode.rs
@@ -666,9 +666,12 @@ impl Encoder {
             if dict_is_two[i] {
                 continue;
             }
-            if let Some(k) = dict[i] {
-                let w = self.words[k];
-                out.extend_from_slice(&self.text[w.at..w.at + w.len as usize]);
+            match dict[i] {
+                Some(k) => {
+                    let w = self.words[k];
+                    out.extend_from_slice(&self.text[w.at..w.at + w.len as usize]);
+                }
+                None => {}
             }
         }
         // 4. separator, then the two-byte words minus their shared prefix
@@ -682,9 +685,12 @@ impl Encoder {
                         (Some(a), Some(b)) => self.common_prefix_length(a, b),
                         _ => 0,
                     };
-                    if let Some(k) = cur {
-                        let w = self.words[k];
-                        out.extend_from_slice(&self.text[w.at + n..w.at + w.len as usize]);
+                    match cur {
+                        Some(k) => {
+                            let w = self.words[k];
+                            out.extend_from_slice(&self.text[w.at + n..w.at + w.len as usize]);
+                        }
+                        None => {}
                     }
                     out.push(word_sep);
                     prev = cur;
@@ -767,8 +773,13 @@ impl Encoder {
                 let idx = (hash & self.hashmask) as usize;
                 if self.codewords[idx].len != 0 {
                     longest = Some(self.codewords[idx].clone());
-                } else if let Some(l) = &longest {
-                    self.codewords[idx] = l.clone();
+                } else {
+                    match &longest {
+                        Some(l) => {
+                            self.codewords[idx] = l.clone();
+                        }
+                        None => {}
+                    }
                 }
             }
             if abandoned {
@@ -837,20 +848,23 @@ impl Encoder {
         let mut out: Vec<u8> = Vec::new();
         let mut p = 0usize;
         while p < endbuf {
-            if let Some(w) = self.find_word(p, endbuf) {
-                out.push(w.chr);
-                if w.chr2 != RESERVED_CHAR {
-                    out.push(w.chr2);
+            match self.find_word(p, endbuf) {
+                Some(w) => {
+                    out.push(w.chr);
+                    if w.chr2 != RESERVED_CHAR {
+                        out.push(w.chr2);
+                    }
+                    p += w.len as usize;
                 }
-                p += w.len as usize;
-            } else {
-                let c = self.text[p];
-                p += 1;
-                // A character whose code was given away must be escaped.
-                if self.char_counts[c as usize] == 0 || c == self.prefix_for_weak_chars {
-                    out.push(self.prefix_for_weak_chars);
+                None => {
+                    let c = self.text[p];
+                    p += 1;
+                    // A character whose code was given away must be escaped.
+                    if self.char_counts[c as usize] == 0 || c == self.prefix_for_weak_chars {
+                        out.push(self.prefix_for_weak_chars);
+                    }
+                    out.push(c);
                 }
-                out.push(c);
             }
         }
         out

--- a/rust/darc-codecs/src/grzip/block.rs
+++ b/rust/darc-codecs/src/grzip/block.rs
@@ -287,50 +287,53 @@ pub fn compress_block(input: &[u8], size: usize, out: &mut [u8], mode: i32) -> R
     if size > 1024 && (mode & DISABLE_DELTA_FLT) == 0 {
         // `test` hands back a classified mode or nothing at all, so the encoder
         // never holds a raw mode integer.
-        if let Some(rec_mode) = super::rec::test(input, size) {
-            let mut buffer = vec![0u8; size + 1024];
-            super::rec::encode(input, size, &mut buffer, rec_mode);
-            let sub_mode = mode + DISABLE_DELTA_FLT;
-            // Modes 1 and 3 split in two, 2 and 4 in four, matching the record
-            // width the filter chose.
-            let parts: Vec<(usize, usize)> = if rec_mode.parts() == 2 {
-                let half = size >> 1;
-                vec![(0, half), (half, size - half)]
-            } else {
-                let q = size >> 2;
-                vec![(0, q), (q, q), (2 * q, q), (3 * q, size - 3 * q)]
-            };
-            let mut new_size = 0usize;
-            let mut ok = true;
-            for (off, len) in parts {
-                let mut sub = vec![0u8; len + BLOCK_HEADER + 1024];
-                match compress_block(&buffer[off..off + len], len, &mut sub, sub_mode) {
-                    Ok(n) => {
-                        if BLOCK_HEADER + new_size + n > out.len() {
+        match super::rec::test(input, size) {
+            Some(rec_mode) => {
+                let mut buffer = vec![0u8; size + 1024];
+                super::rec::encode(input, size, &mut buffer, rec_mode);
+                let sub_mode = mode + DISABLE_DELTA_FLT;
+                // Modes 1 and 3 split in two, 2 and 4 in four, matching the record
+                // width the filter chose.
+                let parts: Vec<(usize, usize)> = if rec_mode.parts() == 2 {
+                    let half = size >> 1;
+                    vec![(0, half), (half, size - half)]
+                } else {
+                    let q = size >> 2;
+                    vec![(0, q), (q, q), (2 * q, q), (3 * q, size - 3 * q)]
+                };
+                let mut new_size = 0usize;
+                let mut ok = true;
+                for (off, len) in parts {
+                    let mut sub = vec![0u8; len + BLOCK_HEADER + 1024];
+                    match compress_block(&buffer[off..off + len], len, &mut sub, sub_mode) {
+                        Ok(n) => {
+                            if BLOCK_HEADER + new_size + n > out.len() {
+                                ok = false;
+                                break;
+                            }
+                            out[BLOCK_HEADER + new_size..BLOCK_HEADER + new_size + n]
+                                .copy_from_slice(&sub[..n]);
+                            new_size += n;
+                        }
+                        Err(_) => {
                             ok = false;
                             break;
                         }
-                        out[BLOCK_HEADER + new_size..BLOCK_HEADER + new_size + n]
-                            .copy_from_slice(&sub[..n]);
-                        new_size += n;
-                    }
-                    Err(_) => {
-                        ok = false;
-                        break;
                     }
                 }
+                if ok && new_size < size {
+                    put_word(out, 4, -2);
+                    // The mode NUMBER: this byte is the archive format, and the
+                    // decoder re-classifies it on the way back in.
+                    put_word(out, 8, rec_mode.to_i32());
+                    put_word(out, 16, new_size as i32);
+                    put_word(out, 20, 0);
+                    put_word(out, 24, 0);
+                    return Ok(new_size + BLOCK_HEADER);
+                }
+                return Ok(store_block(input, size, out, 0));
             }
-            if ok && new_size < size {
-                put_word(out, 4, -2);
-                // The mode NUMBER: this byte is the archive format, and the
-                // decoder re-classifies it on the way back in.
-                put_word(out, 8, rec_mode.to_i32());
-                put_word(out, 16, new_size as i32);
-                put_word(out, 20, 0);
-                put_word(out, 24, 0);
-                return Ok(new_size + BLOCK_HEADER);
-            }
-            return Ok(store_block(input, size, out, 0));
+            None => {}
         }
     }
 
@@ -374,8 +377,11 @@ pub fn compress_block(input: &[u8], size: usize, out: &mut [u8], mode: i32) -> R
             let mut lz = vec![0u8; size + 1024];
             let mml = ((mode / 65536) % 32767) as u32;
             let ht = (1u32 << ((mode / 256) % 256)) - 1;
-            if let Ok(n) = super::lzp::encode(&input[..size], &mut lz, mml, ht) {
-                return store_block(&lz, n, out, mode);
+            match super::lzp::encode(&input[..size], &mut lz, mml, ht) {
+                Ok(n) => {
+                    return store_block(&lz, n, out, mode);
+                }
+                Err(_) => {}
             }
         }
         store_block(input, size, out, 0)

--- a/rust/darc-codecs/src/grzip/stream.rs
+++ b/rust/darc-codecs/src/grzip/stream.rs
@@ -236,8 +236,11 @@ pub fn compress(
             Ok(n) => n,
             Err(e) => return e,
         };
-        if let Err(e) = io.write_all(&outbuf[..n]) {
-            return e;
+        match io.write_all(&outbuf[..n]) {
+            Err(e) => {
+                return e;
+            }
+            Ok(_) => {}
         }
         if remainder > 0 {
             inbuf.copy_within(rem_pos..rem_pos + remainder, 0);

--- a/rust/darc-codecs/src/lz4hc.rs
+++ b/rust/darc-codecs/src/lz4hc.rs
@@ -640,15 +640,21 @@ fn compress_mid(src: &[u8], out: &mut Out) -> Option<usize> {
 
     macro_rules! addpos8 {
         ($p:expr, $idx:expr) => {
-            if let Some(v) = read64(src, $p) {
-                hash8[mid_hash8(v)] = $idx;
+            match read64(src, $p) {
+                Some(v) => {
+                    hash8[mid_hash8(v)] = $idx;
+                }
+                None => {}
             }
         };
     }
     macro_rules! addpos4 {
         ($p:expr, $idx:expr) => {
-            if let Some(v) = read32(src, $p) {
-                hash4[mid_hash4(v)] = $idx;
+            match read32(src, $p) {
+                Some(v) => {
+                    hash4[mid_hash4(v)] = $idx;
+                }
+                None => {}
             }
         };
     }
@@ -663,47 +669,56 @@ fn compress_mid(src: &[u8], out: &mut Out) -> Option<usize> {
         // never-written slots, so no separate emptiness test is needed.
         'found: {
             // Long match first.
-            if let Some(v) = read64(src, ip) {
-                let h8 = mid_hash8(v);
-                let pos8 = hash8[h8];
-                hash8[h8] = ip_index;
-                if ip_index - pos8 <= DISTANCE_MAX {
-                    let m = (pos8 - BASE) as i32;
-                    match_length = count_forward(src, ip, m, matchlimit);
-                    if match_length >= MINMATCH {
-                        match_distance = (ip_index - pos8) as i32;
-                        break 'found;
+            match read64(src, ip) {
+                Some(v) => {
+                    let h8 = mid_hash8(v);
+                    let pos8 = hash8[h8];
+                    hash8[h8] = ip_index;
+                    if ip_index - pos8 <= DISTANCE_MAX {
+                        let m = (pos8 - BASE) as i32;
+                        match_length = count_forward(src, ip, m, matchlimit);
+                        if match_length >= MINMATCH {
+                            match_distance = (ip_index - pos8) as i32;
+                            break 'found;
+                        }
                     }
                 }
+                None => {}
             }
             // Then a short match, with a one-byte lookahead for a longer one.
-            if let Some(v) = read32(src, ip) {
-                let h4 = mid_hash4(v);
-                let pos4 = hash4[h4];
-                hash4[h4] = ip_index;
-                if ip_index - pos4 <= DISTANCE_MAX {
-                    let m = (pos4 - BASE) as i32;
-                    match_length = count_forward(src, ip, m, matchlimit);
-                    if match_length >= MINMATCH {
-                        match_distance = (ip_index - pos4) as i32;
-                        if let Some(v2) = read64(src, ip + 1) {
-                            let h8 = mid_hash8(v2);
-                            let pos8 = hash8[h8];
-                            let m2_distance = ip_index + 1 - pos8;
-                            if m2_distance <= DISTANCE_MAX && ip < mflimit {
-                                let m2 = (pos8 - BASE) as i32;
-                                let ml2 = count_forward(src, ip + 1, m2, matchlimit);
-                                if ml2 > match_length {
-                                    hash8[h8] = ip_index + 1;
-                                    ip += 1;
-                                    match_length = ml2;
-                                    match_distance = m2_distance as i32;
+            match read32(src, ip) {
+                Some(v) => {
+                    let h4 = mid_hash4(v);
+                    let pos4 = hash4[h4];
+                    hash4[h4] = ip_index;
+                    if ip_index - pos4 <= DISTANCE_MAX {
+                        let m = (pos4 - BASE) as i32;
+                        match_length = count_forward(src, ip, m, matchlimit);
+                        if match_length >= MINMATCH {
+                            match_distance = (ip_index - pos4) as i32;
+                            match read64(src, ip + 1) {
+                                Some(v2) => {
+                                    let h8 = mid_hash8(v2);
+                                    let pos8 = hash8[h8];
+                                    let m2_distance = ip_index + 1 - pos8;
+                                    if m2_distance <= DISTANCE_MAX && ip < mflimit {
+                                        let m2 = (pos8 - BASE) as i32;
+                                        let ml2 = count_forward(src, ip + 1, m2, matchlimit);
+                                        if ml2 > match_length {
+                                            hash8[h8] = ip_index + 1;
+                                            ip += 1;
+                                            match_length = ml2;
+                                            match_distance = m2_distance as i32;
+                                        }
+                                    }
                                 }
+                                None => {}
                             }
+                            break 'found;
                         }
-                        break 'found;
                     }
                 }
+                None => {}
             }
             // No match: step forward, accelerating over incompressible data.
             ip += 1 + ((ip - anchor) >> 9);
@@ -1072,170 +1087,182 @@ pub fn compress_hc(src: &[u8], dst: &mut [u8], level: i32) -> usize {
     let mut ip = 0i32;
     let mut anchor = 0i32;
 
-    if input_size >= LZ4_MIN_LENGTH && strategy == Strategy::Mid {
-        match compress_mid(src, &mut out) {
-            Some(a) => anchor = a as i32,
-            None => return 0,
-        }
-    } else if let (true, Strategy::Optimal(nb, target, full)) =
-        (input_size >= LZ4_MIN_LENGTH, strategy)
-    {
-        let mut ctx = HashChain::new();
-        match compress_optimal(src, &mut out, &mut ctx, nb, target, full) {
-            Some(a) => anchor = a,
-            None => return 0,
-        }
-    } else if input_size >= LZ4_MIN_LENGTH {
-        let mut ctx = HashChain::new();
-
-        'main: while ip <= mflimit {
-            let mut m1 = ctx.get_wider_match(src, ip, ip, matchlimit, MINMATCH - 1, max_nb_attempts, pattern_analysis, false);
-            if m1.len < MINMATCH {
-                ip += 1;
-                continue;
+    // Exhaustive on (long enough, which parser). This was an `if let` on a
+    // tuple plus two `else if`s, which meant a NEW `Strategy` variant fell
+    // silently into the hash-chain branch -- the same silent-fallback class as
+    // the Tornado presets 7-11 bug. Now it is a compile error.
+    match (input_size >= LZ4_MIN_LENGTH, strategy) {
+        (true, Strategy::Mid) => {
+            match compress_mid(src, &mut out) {
+                Some(a) => anchor = a as i32,
+                None => return 0,
             }
+        }
+        (true, Strategy::Optimal(nb, target, full)) => {
+            let mut ctx = HashChain::new();
+            match compress_optimal(src, &mut out, &mut ctx, nb, target, full) {
+                Some(a) => anchor = a,
+                None => return 0,
+            }
+        }
+        (true, Strategy::HashChain(_)) => {
+            let mut ctx = HashChain::new();
 
-            // Saved, in case the parser later decides it skipped too far.
-            let mut start0 = ip;
-            let mut m0 = m1;
-            let mut start2 = ip;
-            let mut m2 = NO_MATCH;
-            let mut start3;
-            let mut m3;
+            'main: while ip <= mflimit {
+                let mut m1 = ctx.get_wider_match(src, ip, ip, matchlimit, MINMATCH - 1, max_nb_attempts, pattern_analysis, false);
+                if m1.len < MINMATCH {
+                    ip += 1;
+                    continue;
+                }
 
-            // The C threads this section with `goto _Search2` / `goto _Search3`;
-            // `state` reproduces those jumps exactly.
-            let mut state = 2u8;
-            loop {
-                if state == 2 {
-                    // ---- _Search2 (lz4hc.c:1165) ----
-                    if ip + m1.len <= mflimit {
-                        start2 = ip + m1.len - 2;
-                        m2 = ctx.get_wider_match(src, start2, ip, matchlimit, m1.len, max_nb_attempts, pattern_analysis, false);
-                        start2 += m2.back;
-                    } else {
-                        m2 = NO_MATCH; // do not search further
+                // Saved, in case the parser later decides it skipped too far.
+                let mut start0 = ip;
+                let mut m0 = m1;
+                let mut start2 = ip;
+                let mut m2 = NO_MATCH;
+                let mut start3;
+                let mut m3;
+
+                // The C threads this section with `goto _Search2` / `goto _Search3`;
+                // `state` reproduces those jumps exactly.
+                let mut state = 2u8;
+                loop {
+                    if state == 2 {
+                        // ---- _Search2 (lz4hc.c:1165) ----
+                        if ip + m1.len <= mflimit {
+                            start2 = ip + m1.len - 2;
+                            m2 = ctx.get_wider_match(src, start2, ip, matchlimit, m1.len, max_nb_attempts, pattern_analysis, false);
+                            start2 += m2.back;
+                        } else {
+                            m2 = NO_MATCH; // do not search further
+                        }
+
+                        if m2.len <= m1.len {
+                            // No better match => encode ML1 immediately.
+                            if encode_sequence(src, &mut out, &mut ip, &mut anchor, m1.len, m1.off) {
+                                return 0;
+                            }
+                            continue 'main;
+                        }
+
+                        if start0 < ip && start2 < ip + m0.len {
+                            // Squeezing ML1 between ML0 and ML2: restore Match1.
+                            ip = start0;
+                            m1 = m0;
+                        }
+
+                        if start2 - ip < 3 {
+                            // First match too small: drop it.
+                            ip = start2;
+                            m1 = m2;
+                            continue;
+                        }
+                        state = 3;
+                        continue;
                     }
 
-                    if m2.len <= m1.len {
-                        // No better match => encode ML1 immediately.
+                    // ---- _Search3 (lz4hc.c:1198) ----
+                    if start2 - ip < OPTIMAL_ML {
+                        let mut new_ml = m1.len.min(OPTIMAL_ML);
+                        if ip + new_ml > start2 + m2.len - MINMATCH {
+                            new_ml = (start2 - ip) + m2.len - MINMATCH;
+                        }
+                        let correction = new_ml - (start2 - ip);
+                        if correction > 0 {
+                            start2 += correction;
+                            m2.len -= correction;
+                        }
+                    }
+
+                    if start2 + m2.len <= mflimit {
+                        start3 = start2 + m2.len - 3;
+                        m3 = ctx.get_wider_match(src, start3, start2, matchlimit, m2.len, max_nb_attempts, pattern_analysis, false);
+                        start3 += m3.back;
+                    } else {
+                        start3 = start2;
+                        m3 = NO_MATCH;
+                    }
+
+                    if m3.len <= m2.len {
+                        // No better match => encode ML1 and ML2.
+                        if start2 < ip + m1.len {
+                            m1.len = start2 - ip;
+                        }
                         if encode_sequence(src, &mut out, &mut ip, &mut anchor, m1.len, m1.off) {
+                            return 0;
+                        }
+                        ip = start2;
+                        if encode_sequence(src, &mut out, &mut ip, &mut anchor, m2.len, m2.off) {
                             return 0;
                         }
                         continue 'main;
                     }
 
-                    if start0 < ip && start2 < ip + m0.len {
-                        // Squeezing ML1 between ML0 and ML2: restore Match1.
-                        ip = start0;
-                        m1 = m0;
+                    if start3 < ip + m1.len + 3 {
+                        if start3 >= ip + m1.len {
+                            // Seq1 can be written now; Seq2 goes away and Seq3
+                            // becomes the new Seq1.
+                            if start2 < ip + m1.len {
+                                let correction = ip + m1.len - start2;
+                                start2 += correction;
+                                m2.len -= correction;
+                                if m2.len < MINMATCH {
+                                    start2 = start3;
+                                    m2 = m3;
+                                }
+                            }
+                            if encode_sequence(src, &mut out, &mut ip, &mut anchor, m1.len, m1.off) {
+                                return 0;
+                            }
+                            ip = start3;
+                            m1 = m3;
+                            start0 = start2;
+                            m0 = m2;
+                            state = 2;
+                            continue;
+                        }
+                        start2 = start3;
+                        m2 = m3;
+                        continue; // state stays 3
                     }
 
-                    if start2 - ip < 3 {
-                        // First match too small: drop it.
-                        ip = start2;
-                        m1 = m2;
-                        continue;
-                    }
-                    state = 3;
-                    continue;
-                }
-
-                // ---- _Search3 (lz4hc.c:1198) ----
-                if start2 - ip < OPTIMAL_ML {
-                    let mut new_ml = m1.len.min(OPTIMAL_ML);
-                    if ip + new_ml > start2 + m2.len - MINMATCH {
-                        new_ml = (start2 - ip) + m2.len - MINMATCH;
-                    }
-                    let correction = new_ml - (start2 - ip);
-                    if correction > 0 {
-                        start2 += correction;
-                        m2.len -= correction;
-                    }
-                }
-
-                if start2 + m2.len <= mflimit {
-                    start3 = start2 + m2.len - 3;
-                    m3 = ctx.get_wider_match(src, start3, start2, matchlimit, m2.len, max_nb_attempts, pattern_analysis, false);
-                    start3 += m3.back;
-                } else {
-                    start3 = start2;
-                    m3 = NO_MATCH;
-                }
-
-                if m3.len <= m2.len {
-                    // No better match => encode ML1 and ML2.
+                    // Three ascending matches; write the first.
                     if start2 < ip + m1.len {
-                        m1.len = start2 - ip;
+                        if start2 - ip < OPTIMAL_ML {
+                            if m1.len > OPTIMAL_ML {
+                                m1.len = OPTIMAL_ML;
+                            }
+                            if ip + m1.len > start2 + m2.len - MINMATCH {
+                                m1.len = (start2 - ip) + m2.len - MINMATCH;
+                            }
+                            let correction = m1.len - (start2 - ip);
+                            if correction > 0 {
+                                start2 += correction;
+                                m2.len -= correction;
+                            }
+                        } else {
+                            m1.len = start2 - ip;
+                        }
                     }
                     if encode_sequence(src, &mut out, &mut ip, &mut anchor, m1.len, m1.off) {
                         return 0;
                     }
-                    ip = start2;
-                    if encode_sequence(src, &mut out, &mut ip, &mut anchor, m2.len, m2.off) {
-                        return 0;
-                    }
-                    continue 'main;
-                }
 
-                if start3 < ip + m1.len + 3 {
-                    if start3 >= ip + m1.len {
-                        // Seq1 can be written now; Seq2 goes away and Seq3
-                        // becomes the new Seq1.
-                        if start2 < ip + m1.len {
-                            let correction = ip + m1.len - start2;
-                            start2 += correction;
-                            m2.len -= correction;
-                            if m2.len < MINMATCH {
-                                start2 = start3;
-                                m2 = m3;
-                            }
-                        }
-                        if encode_sequence(src, &mut out, &mut ip, &mut anchor, m1.len, m1.off) {
-                            return 0;
-                        }
-                        ip = start3;
-                        m1 = m3;
-                        start0 = start2;
-                        m0 = m2;
-                        state = 2;
-                        continue;
-                    }
+                    // ML2 becomes ML1, ML3 becomes ML2; look for a new ML3.
+                    ip = start2;
+                    m1 = m2;
                     start2 = start3;
                     m2 = m3;
-                    continue; // state stays 3
+                    // state stays 3
                 }
-
-                // Three ascending matches; write the first.
-                if start2 < ip + m1.len {
-                    if start2 - ip < OPTIMAL_ML {
-                        if m1.len > OPTIMAL_ML {
-                            m1.len = OPTIMAL_ML;
-                        }
-                        if ip + m1.len > start2 + m2.len - MINMATCH {
-                            m1.len = (start2 - ip) + m2.len - MINMATCH;
-                        }
-                        let correction = m1.len - (start2 - ip);
-                        if correction > 0 {
-                            start2 += correction;
-                            m2.len -= correction;
-                        }
-                    } else {
-                        m1.len = start2 - ip;
-                    }
-                }
-                if encode_sequence(src, &mut out, &mut ip, &mut anchor, m1.len, m1.off) {
-                    return 0;
-                }
-
-                // ML2 becomes ML1, ML3 becomes ML2; look for a new ML3.
-                ip = start2;
-                m1 = m2;
-                start2 = start3;
-                m2 = m3;
-                // state stays 3
             }
         }
+        // Shorter than LZ4_MIN_LENGTH: no matches are emitted at all, and the
+        // tail below stores the whole input as literals. Spelled out per
+        // variant rather than `(false, _)` so a new strategy lands here too.
+        (false, Strategy::Mid)
+        | (false, Strategy::HashChain(_))
+        | (false, Strategy::Optimal(..)) => {}
     }
 
     // ---- Encode last literals (lz4hc.c:1308) ----

--- a/rust/darc-codecs/src/tornado/decode.rs
+++ b/rust/darc-codecs/src/tornado/decode.rs
@@ -100,8 +100,11 @@ impl<'a> Window<'a> {
 macro_rules! flush_if {
     ($w:expr, $d:expr, $cond:expr) => {
         if $cond {
-            if let Some(e) = $d.error() {
-                return Err(e);
+            match $d.error() {
+                Some(e) => {
+                    return Err(e);
+                }
+                None => {}
             }
             $w.flush()?;
         }
@@ -114,8 +117,11 @@ fn decompress0<D: Lz77Decoder>(
     header_bufsize: u32,
     minlen: u32,
 ) -> Result<(), c_int> {
-    if let Some(e) = d.error() {
-        return Err(e);
+    match d.error() {
+        Some(e) => {
+            return Err(e);
+        }
+        None => {}
     }
     // compress_all_at_once is false on the archiver's streaming path, so the
     // window is grown to at least HUGE_BUFFER_SIZE exactly as the C does.
@@ -202,8 +208,11 @@ fn decompress0<D: Lz77Decoder>(
         }
     }
 
-    if let Some(e) = d.error() {
-        return Err(e);
+    match d.error() {
+        Some(e) => {
+            return Err(e);
+        }
+        None => {}
     }
     Ok(())
 }
@@ -221,8 +230,11 @@ fn run(io: &Io) -> Result<(), c_int> {
     let method = hdr.get8();
     let minlen = hdr.get8();
     let bufsize = hdr.get32();
-    if let Some(e) = hdr.error() {
-        return Err(e);
+    match hdr.error() {
+        Some(e) => {
+            return Err(e);
+        }
+        None => {}
     }
     if bufsize == 0 || bufsize > MAX_BUFSIZE {
         return Err(BAD);

--- a/rust/darc-codecs/src/tornado/encode.rs
+++ b/rust/darc-codecs/src/tornado/encode.rs
@@ -194,13 +194,16 @@ fn compress_chunk(
                     Ok(true) => {}
                 }
                 // A slide moves every recorded position (:113-116).
-                if let Some(sh) = w.last_shift.take() {
-                    let _ = before;
-                    if find_tables {
-                        table_end = if table_end > sh { table_end - sh } else { 0 };
-                        last_found = if last_found > sh { last_found - sh } else { 0 };
+                match w.last_shift.take() {
+                    Some(sh) => {
+                        let _ = before;
+                        if find_tables {
+                            table_end = if table_end > sh { table_end - sh } else { 0 };
+                            last_found = if last_found > sh { last_found - sh } else { 0 };
+                        }
+                        last_checked.reset();
                     }
-                    last_checked.reset();
+                    None => {}
                 }
                 matchend = w.bufend - MAX_HASHED_BYTES.min(w.bufend);
             }
@@ -246,11 +249,17 @@ fn compress_chunk(
         }
     }
 
-    if let Some(e) = mf.error() {
-        return Err(e);
+    match mf.error() {
+        Some(e) => {
+            return Err(e);
+        }
+        None => {}
     }
-    if let Some(e) = coder.error() {
-        return Err(e);
+    match coder.error() {
+        Some(e) => {
+            return Err(e);
+        }
+        None => {}
     }
     // End of data (:209).
     coder.encode(IMPOSSIBLE_LEN, &w.buf, 0, i32::MAX / 2, minlen);
@@ -450,8 +459,11 @@ fn run<M: MatchFinder + 'static>(
     coder_kind: u32,
     all_at_once: bool,
 ) -> Result<(), c_int> {
-    if let Some(e) = mf.error() {
-        return Err(e);
+    match mf.error() {
+        Some(e) => {
+            return Err(e);
+        }
+        None => {}
     }
     compress_chunk(io, m, &mut mf, coder_kind, all_at_once)
 }

--- a/rust/darc-codecs/src/tornado/out_stream.rs
+++ b/rust/darc-codecs/src/tornado/out_stream.rs
@@ -177,8 +177,11 @@ impl<'a> OutputByteStream<'a> {
         if self.err.is_some() {
             return;
         }
-        if let Err(e) = self.io.write_all(&self.buf[..n]) {
-            self.err = Some(e);
+        match self.io.write_all(&self.buf[..n]) {
+            Err(e) => {
+                self.err = Some(e);
+            }
+            Ok(_) => {}
         }
     }
 }

--- a/rust/darc-codecs/src/tornado/stream.rs
+++ b/rust/darc-codecs/src/tornado/stream.rs
@@ -125,8 +125,11 @@ impl<'a> InputByteStream<'a> {
     /// Any hard error seen so far: a negative callback return, or reading so far
     /// past the end of the data that the stream must be truncated.
     pub fn error(&self) -> Option<c_int> {
-        if let Some(e) = self.err {
-            return Some(e);
+        match self.err {
+            Some(e) => {
+                return Some(e);
+            }
+            None => {}
         }
         if self.overrun > EXHAUSTED_SLACK {
             return Some(BAD);

--- a/rust/darc-codecs/src/tornado/tables.rs
+++ b/rust/darc-codecs/src/tornado/tables.rs
@@ -169,16 +169,19 @@ impl DataTables {
     /// Undiff everything up to `write_end`, ready for the bytes to be written.
     pub fn undiff_tables(&mut self, buf: &mut [u8], write_start: usize, write_end: usize) {
         self.original_bytes = 0;
-        if let Some(first) = self.tables.first().copied() {
-            if first.start < write_start {
-                // This table began in the previous chunk. Its first row on disk
-                // is a difference, so swap in the base row saved back then, and
-                // remember what was there to put back afterwards.
-                let n = first.row.min(write_start - first.start).min(MAX_ROW);
-                self.original[..n].copy_from_slice(&buf[first.start..first.start + n]);
-                buf[first.start..first.start + n].copy_from_slice(&self.base_data[..n]);
-                self.original_bytes = n;
+        match self.tables.first().copied() {
+            Some(first) => {
+                if first.start < write_start {
+                    // This table began in the previous chunk. Its first row on disk
+                    // is a difference, so swap in the base row saved back then, and
+                    // remember what was there to put back afterwards.
+                    let n = first.row.min(write_start - first.start).min(MAX_ROW);
+                    self.original[..n].copy_from_slice(&buf[first.start..first.start + n]);
+                    buf[first.start..first.start + n].copy_from_slice(&self.base_data[..n]);
+                    self.original_bytes = n;
+                }
             }
+            None => {}
         }
         self.process(buf, write_end, true);
     }
@@ -187,36 +190,45 @@ impl DataTables {
     /// clear the list -- keeping the tail of a table that runs past `write_end`.
     pub fn diff_tables(&mut self, buf: &mut [u8], write_start: usize, write_end: usize) {
         let mut carry_over: Option<TableEntry> = None;
-        if let Some(&last) = self.tables.last() {
-            if last.row != 0 && write_end >= last.start {
-                let processed = (write_end - last.start) / last.row;
-                if processed < last.len {
-                    // Keep two extra rows: one as the undiff base for the next
-                    // chunk, and one because a row can straddle the boundary.
-                    let processed = processed.saturating_sub(2);
-                    let mut tail = last;
-                    tail.start += processed * last.row;
-                    tail.len -= processed;
-                    let n = tail.row.min(MAX_ROW);
-                    self.base_data[..n].copy_from_slice(&buf[tail.start..tail.start + n]);
-                    carry_over = Some(tail);
+        match self.tables.last() {
+            Some(&last) => {
+                if last.row != 0 && write_end >= last.start {
+                    let processed = (write_end - last.start) / last.row;
+                    if processed < last.len {
+                        // Keep two extra rows: one as the undiff base for the next
+                        // chunk, and one because a row can straddle the boundary.
+                        let processed = processed.saturating_sub(2);
+                        let mut tail = last;
+                        tail.start += processed * last.row;
+                        tail.len -= processed;
+                        let n = tail.row.min(MAX_ROW);
+                        self.base_data[..n].copy_from_slice(&buf[tail.start..tail.start + n]);
+                        carry_over = Some(tail);
+                    }
                 }
             }
+            None => {}
         }
         self.process(buf, write_end, false);
         // Put back the bytes undiff_tables borrowed for the base row.
         if self.original_bytes > 0 {
-            if let Some(first) = self.tables.first().copied() {
-                if first.start < write_start {
-                    let n = self.original_bytes;
-                    buf[first.start..first.start + n].copy_from_slice(&self.original[..n]);
+            match self.tables.first().copied() {
+                Some(first) => {
+                    if first.start < write_start {
+                        let n = self.original_bytes;
+                        buf[first.start..first.start + n].copy_from_slice(&self.original[..n]);
+                    }
                 }
+                None => {}
             }
         }
         self.original_bytes = 0;
         self.tables.clear();
-        if let Some(t) = carry_over {
-            self.tables.push(t);
+        match carry_over {
+            Some(t) => {
+                self.tables.push(t);
+            }
+            None => {}
         }
     }
 

--- a/rust/darc-codecs/src/zstd.rs
+++ b/rust/darc-codecs/src/zstd.rs
@@ -99,8 +99,11 @@ pub fn compress_stream(io: &Io, params: Params) -> c_int {
                 (output.pos(), remaining)
             };
             if produced > 0 {
-                if let Err(e) = io.write_all(&out_buf[..produced]) {
-                    return e;
+                match io.write_all(&out_buf[..produced]) {
+                    Err(e) => {
+                        return e;
+                    }
+                    Ok(_) => {}
                 }
             }
             let drained = if end { remaining == 0 } else { input.pos() == got };
@@ -152,8 +155,11 @@ pub fn decompress_stream(io: &Io) -> c_int {
                 output.pos()
             };
             if produced > 0 {
-                if let Err(e) = io.write_all(&out_buf[..produced]) {
-                    return e;
+                match io.write_all(&out_buf[..produced]) {
+                    Err(e) => {
+                        return e;
+                    }
+                    Ok(_) => {}
                 }
             }
         }

--- a/rust/darc-codecs/tests/roundtrip.rs
+++ b/rust/darc-codecs/tests/roundtrip.rs
@@ -285,10 +285,14 @@ fn dict_roundtrips_text() {
         DICT_MIN_SMALL,
         DICT_MIN_RATIO,
     );
-    // Declining an input is legitimate; decoding it to the wrong bytes is not.
-    if let Ok(encoded) = encoded {
-        let out = dict::decode(&encoded, input.len() * 4 + 65_536)
-            .expect("dict::decode rejected dict_encode's own output");
-        assert_eq!(out, input);
+    match encoded {
+        Ok(encoded) => {
+            let out = dict::decode(&encoded, input.len() * 4 + 65_536)
+                .expect("dict::decode rejected dict_encode's own output");
+            assert_eq!(out, input);
+        }
+        // Declining an input is legitimate; decoding it to the wrong bytes is
+        // not. Spelled out rather than left implicit by an `if let`.
+        Err(_) => {}
     }
 }

--- a/rust/darc-crypto/src/lib.rs
+++ b/rust/darc-crypto/src/lib.rs
@@ -11,6 +11,19 @@
 // crate level; the FFI boundary (ffi, exports) needs unsafe and opts back in
 // per-module, so the guarantee holds everywhere it can.
 #![deny(unsafe_code)]
+// Totality, matching darc-codecs. CI additionally rejects `if let` anywhere under
+// rust/, so an unhandled case has to be written down rather than being the shape
+// of the code. This crate had zero `if let` when that gate was widened.
+//
+// The three existing `_ =>` arms in exports.rs are unaffected: they match on
+// integers from the C caller (`cipher`, `key.len()`), not enums, so this lint
+// does not apply to them -- and they are correct as they stand, rejecting an
+// unknown cipher id with FREEARC_ERRCODE_INVALID_COMPRESSOR. A c_int cannot be
+// matched exhaustively; an enum can, which is what this guards.
+#![deny(clippy::wildcard_enum_match_arm)]
+#![deny(clippy::todo, clippy::unimplemented, clippy::mem_forget)]
+#![deny(unused_must_use)]
+#![allow(clippy::single_match)]
 
 pub mod cfb;
 pub mod ffi;


### PR DESCRIPTION
Exhaustive `match` with every case handled, so a branch carrying archive or crypto
behaviour has to be written down and cannot be silently absent. That is the shape
of the Tornado presets 7-11 bug (#102), of the DisPack `_ =>` that carried F_DR's
real logic (#104), and of the lz4hc fall-through below.

**33 sites converted; zero `if let` remain under `rust/` outside `target`.**

## There is no clippy lint for this, which is why CI greps

Checked against the complete lint list (`clippy-driver -W help`): nothing bans
`if let`, and the whole related family points the **other** way.

| lint | level | direction |
|---|---|---|
| `clippy::single_match` | **warn, via `clippy::all`** | `match` → **`if let`** |
| `clippy::single_match_else` | pedantic | `match` → `if let` |
| `clippy::manual_let_else` | pedantic | `if let` → `let else` |
| `clippy::option_if_let_else` | nursery | `if let/else` → `map_or` |

`single_match` asked **by name** for `grzip/block.rs`'s mode dispatch to become an
`if let`, so both crate roots now allow it, documented.

Totality is therefore three things together:

* `deny(clippy::wildcard_enum_match_arm)` — no `_ =>`, every arm named
* `allow(clippy::single_match)` — so clippy stops fighting the convention
* a CI grep step — the part clippy cannot express

`while let` and `let … else` are deliberately **not** covered: a loop's termination
condition and a diverging `else` already say what happens in the other case.
Banning those would be ceremony, not totality.

## The lz4hc site is the one that mattered

It was `if let (true, Strategy::Optimal(..))` on a **tuple**, followed by
`else if input_size >= LZ4_MIN_LENGTH`. So a **new `Strategy` variant would have
fallen silently into the hash-chain parser** — the same silent-fallback class this
whole line of work is about.

Now `match (input_size >= LZ4_MIN_LENGTH, strategy)` with all four combinations
spelled out — `(false, _)` deliberately avoided — so a new variant is a compile
error. 150 lines re-indented, no logic changed.

## darc-crypto

Zero `if let` already, so the gate costs nothing there. It gained the matching
lint gates, because banning `if let` **without** denying `_ =>` would only half
enforce totality.

Its three existing wildcards are untouched and correct: they match on **integers**
from the C caller (`cipher`, `key.len()`), which cannot be matched exhaustively,
and reject an unknown cipher id with `FREEARC_ERRCODE_INVALID_COMPRESSOR`. That is
input validation, not a missing case.

## How the conversions were done

A transformer rather than 33 hand edits — it only touches sites whose complement
has a name (`Some`/`None`, `Ok`/`Err`) and whose scrutinee fits one line, and
reports anything it will not guess at. Two sites it correctly refused (a
multi-line scrutinee, the lz4hc tuple) were done by hand.

⚠️ It was also **wrong once**, worth recording: being single-pass, a nested
`if let` inside an already-converted body was copied verbatim and never revisited,
so it reported *"29 converted, 0 skipped"* while three sites remained. Fixed by
running to a fixpoint. Its clean summary was not measuring what it claimed.

Widening the gate from `darc-codecs/src` to all of `rust/` then caught a 33rd site
in `darc-codecs/tests/roundtrip.rs` that the original survey never scanned.

## Verified

`clippy --workspace --all-targets` 0 errors · `nextest --workspace` **220 passed**

Byte-identical against the pinned C, one harness per touched file:

| harness | result |
|---|---|
| `lz4hc-check` | **0 differing** — the restructured if-chain |
| `dict-check` | **0 differing** over 198 comparisons |
| `grzip-check` | **0 differing** — 11 modes × 21 inputs + stream |
| `grzip-stage-check` | all 7 stages agree, LZP 828/828 |
| `bsc-lzp-encode-check` | **0 differing** |
| `tornado-check` (decode) | **0 differing**, all presets |
| `tornado-encode-check` | **0 differing** — 28 presets × 29 inputs, 417s |
| `run.sh diff` | delta byte for byte |

`zstd.rs` has no difftest — it wraps the `zstd-safe` crate — and is covered by
nextest only.

**The gate is itself tested**: it passes on a clean tree, rejects a planted
`if let` in *either* crate, ignores the phrase in a comment, and ignores
`while let`. `--exclude-dir=target` is load-bearing — without it the gate scans
vendored crate sources and always fails, which is how I found that bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
