### PR TITLE
Item 4, codec 5: model Tornado's entropy back-end as a type

### DIFF
--- a/rust/darc-codecs/src/tornado/decode.rs
+++ b/rust/darc-codecs/src/tornado/decode.rs
@@ -17,7 +17,7 @@ use super::lz77::BitDecoder;
 use super::range::ArithDecoder;
 use super::stream::{InputBitStream, InputByteStream, BAD};
 use super::tables::DataTables;
-use super::{ARICODER, BITCODER, BYTECODER, HUFCODER, PAD_FOR_TABLES};
+use super::{Coder, PAD_FOR_TABLES};
 use crate::ffi::{Io, OK};
 use core::ffi::c_int;
 
@@ -241,15 +241,19 @@ fn run(io: &Io) -> Result<(), c_int> {
     }
     // The header stream has already buffered part of the payload, so the
     // back-end must continue from it rather than opening a second one.
-    match method {
-        BYTECODER => decompress0(io, ByteDecoder::new(hdr), bufsize, minlen),
-        BITCODER => decompress0(io, BitDecoder::new(InputBitStream::from_bytes(hdr)), bufsize, minlen),
-        HUFCODER => {
+    match Coder::from_stream(method) {
+        Some(Coder::Byte) => decompress0(io, ByteDecoder::new(hdr), bufsize, minlen),
+        Some(Coder::Bit) => {
+            decompress0(io, BitDecoder::new(InputBitStream::from_bytes(hdr)), bufsize, minlen)
+        }
+        Some(Coder::Huf) => {
             decompress0(io, GenericDecoder::new(HufBackend::new(InputBitStream::from_bytes(hdr))), bufsize, minlen)
         }
-        ARICODER => {
+        Some(Coder::Ari) => {
             decompress0(io, GenericDecoder::new(ArithDecoder::new(hdr, super::CODES)), bufsize, minlen)
         }
-        _ => Err(BAD),
+        // STORING, and anything above ARICODER. The C rejects STORING here too
+        // (`Tornado.cpp:522`) even though its encoder emits it.
+        None => Err(BAD),
     }
 }

--- a/rust/darc-codecs/src/tornado/encode.rs
+++ b/rust/darc-codecs/src/tornado/encode.rs
@@ -37,7 +37,7 @@ use super::matchfinder::{
     CachingMatchFinder, CombineMF, CycledCachingMatchFinder, ExactMatchFinder, Hash3,
     LazyMatching, MatchFinder, MatchFinder1, MatchFinder2, MAX_HASHED_BYTES,
 };
-use super::{ARICODER, BITCODER, BYTECODER, HUFCODER, STORING};
+use super::{Coder, ARICODER, BITCODER, BYTECODER, HUFCODER, STORING};
 use crate::ffi::{Io, FREEARC_ERRCODE_GENERAL};
 use core::ffi::c_int;
 
@@ -106,7 +106,7 @@ fn compress_chunk(
     io: &Io,
     m: &PackMethod,
     mf: &mut dyn MatchFinder,
-    coder_kind: u32,
+    coder_kind: Coder,
     all_at_once: bool,
 ) -> Result<(), c_int> {
     let bufsize = m.buffer as usize;
@@ -156,8 +156,7 @@ fn compress_chunk(
     // still writing 0 as the encoding method (:331-333). The resulting stream is
     // one no decoder accepts -- the C's own switch rejects STORING with
     // BAD_COMPRESSED_DATA (:522) -- but that is what the C produces.
-    let mut coder = DynamicCoder::new(coder_kind, io, outbuf_size(bufsize, all_at_once), chunk * 2)
-        .ok_or(FREEARC_ERRCODE_GENERAL)?;
+    let mut coder = DynamicCoder::new(coder_kind, io, outbuf_size(bufsize, all_at_once), chunk * 2);
 
     // Six-byte header (:154).
     coder.put8(m.encoding_method as u32);
@@ -366,13 +365,13 @@ pub fn compress(mut m: PackMethod, io: &Io, all_at_once: bool) -> c_int {
 
     let r = if (e == BYTECODER && row == 1 && plain) || e == STORING {
         // (:331) LZ77_ByteCoder either way -- STORING included.
-        run(io, &m, MatchFinder1::new(m.hashsize, row), BYTECODER, all_at_once)
+        run(io, &m, MatchFinder1::new(m.hashsize, row), Coder::Byte, all_at_once)
     } else if e == BITCODER && row == 1 && plain {
         // (:334)
-        run(io, &m, MatchFinder1::new(m.hashsize, row), BITCODER, all_at_once)
+        run(io, &m, MatchFinder1::new(m.hashsize, row), Coder::Bit, all_at_once)
     } else if e == HUFCODER && row == 2 && plain {
         // (:336)
-        run(io, &m, MatchFinder2::new(m.hashsize, row), HUFCODER, all_at_once)
+        run(io, &m, MatchFinder2::new(m.hashsize, row), Coder::Huf, all_at_once)
     } else if e == HUFCODER
         && row >= 2
         && m.hash3 == 0
@@ -381,7 +380,7 @@ pub fn compress(mut m: PackMethod, io: &Io, all_at_once: bool) -> c_int {
     {
         // (:338) CachingMatchFinder<4>. The condition tests `m.caching_finder`
         // for truth, not for 1.
-        run(io, &m, CachingMatchFinder::new(4, m.hashsize, row), HUFCODER, all_at_once)
+        run(io, &m, CachingMatchFinder::new(4, m.hashsize, row), Coder::Huf, all_at_once)
     } else if (e == ARICODER || e == HUFCODER)
         && row >= 2
         && m.hash3 == 1
@@ -401,7 +400,13 @@ pub fn compress(mut m: PackMethod, io: &Io, all_at_once: bool) -> c_int {
             10,
             false,
         ));
-        run(io, &m, mf, e, all_at_once)
+        // `e` is the preset's encoding_method, so it can in principle be STORING
+        // or out of range; that used to surface as `DynamicCoder::new` returning
+        // None. Same error, decided one step earlier.
+        match Coder::from_stream(e) {
+            Some(c) => run(io, &m, mf, c, all_at_once),
+            None => Err(FREEARC_ERRCODE_GENERAL),
+        }
     } else if row >= 2 && m.hash3 == 2 && m.match_parser == LAZY_ON && (5..=7).contains(&m.caching_finder)
     {
         // (:347), (:351) and (:354): three arms differing only in the cycled
@@ -434,7 +439,13 @@ pub fn compress(mut m: PackMethod, io: &Io, all_at_once: bool) -> c_int {
             CycledCachingMatchFinder::new(n, m.hashsize, row),
             aux,
         ));
-        run(io, &m, mf, e, all_at_once)
+        // `e` is the preset's encoding_method, so it can in principle be STORING
+        // or out of range; that used to surface as `DynamicCoder::new` returning
+        // None. Same error, decided one step earlier.
+        match Coder::from_stream(e) {
+            Some(c) => run(io, &m, mf, c, all_at_once),
+            None => Err(FREEARC_ERRCODE_GENERAL),
+        }
     } else {
         // The remaining instantiations need the cycled caching finder, the
         // exact finder and CombineMF, or the data-table detector, none of
@@ -456,7 +467,7 @@ fn run<M: MatchFinder + 'static>(
     io: &Io,
     m: &PackMethod,
     mut mf: M,
-    coder_kind: u32,
+    coder_kind: Coder,
     all_at_once: bool,
 ) -> Result<(), c_int> {
     match mf.error() {

--- a/rust/darc-codecs/src/tornado/lz77_enc.rs
+++ b/rust/darc-codecs/src/tornado/lz77_enc.rs
@@ -25,7 +25,7 @@ use super::huffman::HuffmanEncoder;
 use super::out_stream::{OutputBitStream, OutputByteStream};
 use super::range::ArithEncoder;
 use super::vle::Tables;
-use super::{CODES, EOB_CODE, LEN_CODES, REPCHAR, REPDIST_CODES};
+use super::{Coder, CODES, EOB_CODE, LEN_CODES, REPCHAR, REPDIST_CODES};
 use crate::ffi::Io;
 use core::ffi::c_int;
 
@@ -475,22 +475,21 @@ pub enum DynamicCoder<'a> {
 }
 
 impl<'a> DynamicCoder<'a> {
-    /// `coder` is the `encoding_method`; 1..4 are BYTECODER..ARICODER. STORING
-    /// never reaches here, and the C's switch silently does nothing for anything
-    /// else, so an unknown method is reported rather than ignored.
-    pub fn new(coder: u32, io: &'a Io, chunk: usize, pad: usize) -> Option<Self> {
-        Some(match coder {
-            super::BYTECODER => DynamicCoder::Byte(ByteCoder::new(io, chunk, pad)),
-            super::BITCODER => DynamicCoder::Bit(BitCoder::new(io, chunk, pad)),
-            super::HUFCODER => {
-                DynamicCoder::Huf(GenericEncoder::new(HufBackend::new(io, chunk, pad)))
-            }
-            super::ARICODER => DynamicCoder::Ari(GenericEncoder::new(ArithEncoder::new(
+    /// Takes a classified [`Coder`], so there is no failure case left: STORING and
+    /// unknown methods are rejected by `Coder::from_stream` at the boundary, which
+    /// is where the C reports them too. This used to take a `u32` and return
+    /// `Option`, whose `None` arm a newly added coder would have fallen into
+    /// silently.
+    pub fn new(coder: Coder, io: &'a Io, chunk: usize, pad: usize) -> Self {
+        match coder {
+            Coder::Byte => DynamicCoder::Byte(ByteCoder::new(io, chunk, pad)),
+            Coder::Bit => DynamicCoder::Bit(BitCoder::new(io, chunk, pad)),
+            Coder::Huf => DynamicCoder::Huf(GenericEncoder::new(HufBackend::new(io, chunk, pad))),
+            Coder::Ari => DynamicCoder::Ari(GenericEncoder::new(ArithEncoder::new(
                 OutputByteStream::new(io, chunk, pad),
                 CODES,
             ))),
-            _ => return None,
-        })
+        }
     }
 
     fn inner(&mut self) -> &mut dyn Lz77Encoder {

--- a/rust/darc-codecs/src/tornado/mod.rs
+++ b/rust/darc-codecs/src/tornado/mod.rs
@@ -66,6 +66,57 @@ pub const BITCODER: u32 = 2;
 pub const HUFCODER: u32 = 3;
 pub const ARICODER: u32 = 4;
 
+/// The entropy back-end, as stored in the stream header's first byte.
+///
+/// Four variants and no `Storing`, deliberately. `STORING` (0) is a value the
+/// encoder *writes* -- the C's dispatch chain builds an `LZ77_ByteCoder` for it
+/// while still emitting 0 as the method (`Tornado.cpp:331-333`) -- but no decoder
+/// accepts it: the C's own switch rejects STORING with `BAD_COMPRESSED_DATA`
+/// (`:522`). So STORING is not a back-end, it is a value that fails to name one,
+/// which is `None` from [`Coder::from_stream`].
+///
+/// The gain over the bare `u32` constants is narrow but real: both dispatch sites
+/// already handled an unknown method correctly (`Err(BAD)` decoding, `None` from
+/// `DynamicCoder::new`), so nothing was silently wrong -- but a *newly added*
+/// coder would have been silently rejected by those catch-alls instead of failing
+/// to compile.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum Coder {
+    /// `BYTECODER`
+    Byte,
+    /// `BITCODER`
+    Bit,
+    /// `HUFCODER`
+    Huf,
+    /// `ARICODER`
+    Ari,
+}
+
+impl Coder {
+    /// Classify a method byte. `None` for `STORING` and for anything above
+    /// `ARICODER` -- both of which callers turn into the error the C returns.
+    pub fn from_stream(method: u32) -> Option<Coder> {
+        match method {
+            BYTECODER => Some(Coder::Byte),
+            BITCODER => Some(Coder::Bit),
+            HUFCODER => Some(Coder::Huf),
+            ARICODER => Some(Coder::Ari),
+            _ => None,
+        }
+    }
+
+    /// The method byte. Note the header is written from `m.encoding_method`, not
+    /// from this -- see the note at `encode.rs`'s `coder_kind`.
+    pub fn to_u32(self) -> u32 {
+        match self {
+            Coder::Byte => BYTECODER,
+            Coder::Bit => BITCODER,
+            Coder::Huf => HUFCODER,
+            Coder::Ari => ARICODER,
+        }
+    }
+}
+
 /// Code-space layout for the Huffman/arith back-ends (LZ77_Coder.cpp:388-398).
 pub const REPDIST_CODES: usize = 4;
 pub const DIST_CODES: usize = vle::EXTRA_DBITS.len() + REPDIST_CODES; // 36

--- a/rust/darc-codecs/tests/tornado.rs
+++ b/rust/darc-codecs/tests/tornado.rs
@@ -195,6 +195,7 @@ fn a_write_error_is_propagated_not_ignored() {
 
 use darc_codecs::ffi::Io as EncIo;
 use darc_codecs::tornado::lz77_enc::{DynamicCoder, Lz77Encoder, IMPOSSIBLE_LEN};
+use darc_codecs::tornado::Coder;
 
 /// `IMPOSSIBLE_DIST` (LZ77_Coder.cpp:8).
 const IMPOSSIBLE_DIST: i32 = i32::MAX / 2;
@@ -233,8 +234,12 @@ fn encode_tokens(method: u32, minlen: i32, bufsize: u32, tokens: &[Token]) -> Ve
     {
         let io = unsafe { EncIo::new(Some(mem_callback), &mut mem as *mut Mem as *mut c_void) }
             .expect("callback was not null");
-        let mut coder =
-            DynamicCoder::new(method, &io, 1 << 16, 1 << 16).expect("known encoding method");
+        // `DynamicCoder::new` takes a classified `Coder` now, so the "unknown
+        // method" case cannot be expressed here at all -- it is rejected by
+        // `Coder::from_stream` at the boundary. Callers of this helper pass a
+        // real back-end; `expect` documents that rather than guarding it.
+        let coder_kind = Coder::from_stream(method).expect("known encoding method");
+        let mut coder = DynamicCoder::new(coder_kind, &io, 1 << 16, 1 << 16);
 
         // Tornado.cpp:154 -- method, minimum match length, window size.
         coder.put8(method);


### PR DESCRIPTION
The **last** codec of `RUST_PORT_PROGRESS.md` §10b item 4, after DisPack (#105),
GRZip (#106/#107), MM (#109) and TTA (#110). A fourth distinct shape — and the
smallest gain of the five, which is worth saying plainly rather than overselling.

## Nothing was silently wrong here

Both dispatch sites already handled an unknown method **correctly**: `_ => Err(BAD)`
decoding, `_ => return None` from `DynamicCoder::new`. Unlike DisPack's `_ =>` that
carried F_DR's real logic (#104), there was no latent bug to find.

What the enum buys is narrower: a **newly added** coder would have fallen into
those catch-alls and been silently rejected. Now it fails to compile in three
places — decode dispatch, encode construction, and `to_u32` — so a back-end cannot
be introduced without being readable, writable, and given a method byte.

## `Coder` has no `Storing` variant, deliberately

STORING is not a back-end. It is a value the encoder **writes** while building an
`LZ77_ByteCoder` (`Tornado.cpp:331-333`), producing a stream the C's own decoder
rejects with `BAD_COMPRESSED_DATA` (`:522`). So it is `None` from `from_stream`: a
value that *fails to name* a back-end, which is precisely what it is.

`DynamicCoder::new` therefore cannot fail and no longer returns `Option`, so the
`.ok_or(FREEARC_ERRCODE_GENERAL)?` at its caller is gone. The test that used
`.expect("known encoding method")` now **cannot express** an unknown method — it
classifies first.

## What I did NOT touch, and why

The 78-line, 7-arm encode if-chain at `encode.rs:367-444` stays as it is:

* its **order is the semantics** — it is a transliteration of the C's `#else`
  chain (`:329-360`) and the arms are not mutually exclusive
* it dispatches on combinations of **five** parameters (`encoding_method`,
  `hash_row_width`, `hash3`, `caching_finder`, `match_parser`), which no enum over
  one of them can make exhaustive
* rewriting it as a `match` would risk changing which arm wins, in the exact
  neighbourhood where #102's silent-no-op bug lived, for no compile-time gain

Its two dynamic arms now classify `e` where they use it, via an exhaustive match
reproducing the same `FREEARC_ERRCODE_GENERAL` the old
`DynamicCoder::new(..).ok_or(..)?` produced.

`caching_finder` is likewise left alone: an encoder-side preset parameter feeding
that cascade, not a mode byte, and it never enters the stream.

## Verified

| gate | result |
|---|---|
| `clippy --all-targets` | 0 errors |
| `nextest` | **186 passed** |
| `tornado-check.sh` | **0 differing** — decoder, all presets |
| `tornado-encode-check.sh` | **0 differing** — 28 presets × 29 inputs (628s) |
| `debug-assert-check.sh` | **320 clean runs**, 0 assertions fired |

## Item 4 after this

All five candidate codecs done — and they landed on **four different designs**,
each driven by where the value comes from rather than by preference:

| codec | shape | why |
|---|---|---|
| DisPack | exhaustive, no `Option` | two-bit mask: four values by arithmetic |
| GRZip | four variants + `Option` | rec mode read from the stream |
| MM | four variants + `Option` | width from an unvalidated header byte |
| TTA | exhaustive, classify at the guard | width validated before the filtered path |
| Tornado | four variants + `Option` | method read from the stream; STORING names no back-end |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
