### PR TITLE
Ban `unwrap` and `expect` in production paths

### DIFF
--- a/rust/darc-codecs/src/dict_encode.rs
+++ b/rust/darc-codecs/src/dict_encode.rs
@@ -913,9 +913,16 @@ pub fn compress(io: &crate::ffi::Io, block_size: u32, min_compression: c_int, mi
                 return FREEARC_ERRCODE_IO;
             }
         } else {
-            let out = encoded.unwrap();
-            if io.write(&(out.len() as u32).to_le_bytes()) < 0 || io.write(&out) < 0 {
-                return FREEARC_ERRCODE_IO;
+            // `store` is true for `Err`, so this branch only runs on `Ok` -- but
+            // matched rather than unwrapped, so that relationship is stated
+            // instead of assumed.
+            match &encoded {
+                Ok(out) => {
+                    if io.write(&(out.len() as u32).to_le_bytes()) < 0 || io.write(out) < 0 {
+                        return FREEARC_ERRCODE_IO;
+                    }
+                }
+                Err(_) => return FREEARC_ERRCODE_GENERAL,
             }
         }
     }

--- a/rust/darc-codecs/src/exports.rs
+++ b/rust/darc-codecs/src/exports.rs
@@ -1521,10 +1521,9 @@ mod bsc_ppmd_sa {
 #[inline]
 #[allow(static_mut_refs)]
 unsafe fn sa() -> &'static mut bsc_ppmd_sa::SubAllocator {
-    if PPMD_SA.is_none() {
-        PPMD_SA = Some(bsc_ppmd_sa::SubAllocator::new());
-    }
-    PPMD_SA.as_mut().unwrap()
+    // `get_or_insert_with`, not `is_none()` + `unwrap()`: this is an FFI helper,
+    // and a panic here would unwind across `extern "C"`.
+    PPMD_SA.get_or_insert_with(bsc_ppmd_sa::SubAllocator::new)
 }
 
 /// # Safety

--- a/rust/darc-codecs/src/lib.rs
+++ b/rust/darc-codecs/src/lib.rs
@@ -47,6 +47,19 @@
 #![deny(clippy::todo, clippy::unimplemented, clippy::mem_forget)]
 #![deny(unused_must_use)]
 #![allow(clippy::single_match)]
+//! ## No `unwrap` / `expect` in production paths
+//!
+//! `cfg_attr(not(test), ...)`, so the deny applies to the normal library build
+//! while unit-test modules -- which are compiled with `cfg(test)` -- keep both.
+//! Integration tests under `tests/` are separate crates and never see this
+//! attribute at all.
+//!
+//! The reason is specific to this crate: every entry point is reached across a C
+//! ABI, and an unwind across `extern "C"` is undefined behaviour. A panic here is
+//! not a crash report, it is a corrupted process. `src/bin/` is deliberately NOT
+//! covered -- those are dev helpers, separate crate targets, where panicking on a
+//! failed stdin read is the right behaviour.
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod bsc;
 pub mod delta;

--- a/rust/darc-codecs/src/lz4hc.rs
+++ b/rust/darc-codecs/src/lz4hc.rs
@@ -613,7 +613,11 @@ fn read64(src: &[u8], p: i32) -> Option<u64> {
         return None;
     }
     let p = p as usize;
-    src.get(p..p + 8).map(|b| u64::from_le_bytes(b.try_into().unwrap()))
+    // `get` already guarantees 8 bytes, but say so with `ok()` rather than an
+    // `unwrap` -- the None simply cannot arise, and no panic path is emitted.
+    src.get(p..p + 8)
+        .and_then(|b| b.try_into().ok())
+        .map(u64::from_le_bytes)
 }
 
 /// `LZ4MID_compressBlock` (`lz4hc.c:529`) -- the strategy the C selects for

--- a/rust/darc-codecs/src/tta.rs
+++ b/rust/darc-codecs/src/tta.rs
@@ -688,7 +688,11 @@ fn run(io: &Io) -> Result<(), c_int> {
             for row in buffer.iter_mut() {
                 read_exact(io, &mut raw)?;
                 for (slot, chunk) in row.iter_mut().zip(raw.chunks_exact(8)) {
-                    *slot = i64::from_le_bytes(chunk.try_into().unwrap());
+                    // `chunks_exact(8)` yields exactly 8 bytes, so this cannot
+                    // fail; expressed as an error return rather than a panic
+                    // because this runs under a C caller.
+                    let word: [u8; 8] = chunk.try_into().map_err(|_| BAD)?;
+                    *slot = i64::from_le_bytes(word);
                 }
                 filters_decompress(row, level, bytes);
             }

--- a/rust/darc-crypto/src/cfb.rs
+++ b/rust/darc-crypto/src/cfb.rs
@@ -91,6 +91,18 @@ where
     }
 }
 
+// Opts out of the crate-level `expect_used` deny. `Cfb::new` asserts
+// `iv.len() == block_size` before this is ever reached, and `keystream` is
+// allocated from that same length, so the conversion cannot fail.
+//
+// Note what the deny does and does not buy: it bans two SPELLINGS of panic, not
+// panicking. The `assert_eq!` in `Cfb::new` one screen up is still a panic, as
+// are slice indexing and arithmetic overflow throughout. The total fix here is to
+// type the buffer as `Array<u8, C::BlockSize>` in the struct instead of `Vec<u8>`,
+// which deletes the conversion rather than justifying it -- contained (both
+// structs are already generic over `C`) but a crypto refactor, so it is its own
+// change.
+#[allow(clippy::expect_used)]
 fn encrypt_in_place<C>(cipher: &C, block: &mut [u8])
 where
     C: BlockCipherEncrypt + BlockSizeUser,

--- a/rust/darc-crypto/src/ctr.rs
+++ b/rust/darc-crypto/src/ctr.rs
@@ -78,6 +78,10 @@ where
                 }
                 self.started = true;
                 self.pad.copy_from_slice(&self.counter);
+                // Same opt-out and same reasoning as `cfb::encrypt_in_place`:
+                // `pad` is `vec![0u8; C::block_size()]`, so the conversion cannot
+                // fail, and the total fix is to type it as `Array<u8, C::BlockSize>`.
+                #[allow(clippy::expect_used)]
                 let block = <&mut Array<u8, C::BlockSize>>::try_from(&mut self.pad[..])
                     .expect("pad is allocated at exactly one block");
                 self.cipher.encrypt_block(block);

--- a/rust/darc-crypto/src/exports.rs
+++ b/rust/darc-crypto/src/exports.rs
@@ -143,8 +143,12 @@ pub unsafe extern "C" fn darc_rs_pbkdf2_hmac_sha512(
     let pwd = std::slice::from_raw_parts(pwd, pwd_len as usize);
     let salt = std::slice::from_raw_parts(salt, salt_len as usize);
     let out = std::slice::from_raw_parts_mut(out, out_len as usize);
-    pbkdf2_hmac_sha512(pwd, salt, iterations as u32, out);
-    OK
+    match pbkdf2_hmac_sha512(pwd, salt, iterations as u32, out) {
+        Ok(()) => OK,
+        // Only reachable for an out_len the KDF refuses; the C caller sees an
+        // error code instead of a panic crossing the ABI.
+        Err(()) => FREEARC_ERRCODE_GENERAL,
+    }
 }
 
 /// Fill `buf` with cryptographically secure random bytes. Backs the fortuna_*

--- a/rust/darc-crypto/src/lib.rs
+++ b/rust/darc-crypto/src/lib.rs
@@ -24,6 +24,11 @@
 #![deny(clippy::todo, clippy::unimplemented, clippy::mem_forget)]
 #![deny(unused_must_use)]
 #![allow(clippy::single_match)]
+// Same policy as darc-codecs, and the same reason: these functions are reached
+// over the C ABI, where an unwind is undefined behaviour. Three sites opt out
+// individually with their justification attached; see them for why, and for the
+// better fix that would remove the need.
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod cfb;
 pub mod ffi;
@@ -48,7 +53,15 @@ use sha2::Sha512;
 /// stored archive may name any count, and refusing to reproduce it would make
 /// that archive unreadable. Policy about acceptable counts belongs to the
 /// caller creating archives, not to the function reading them.
-pub fn pbkdf2_hmac_sha512(password: &[u8], salt: &[u8], iterations: u32, out: &mut [u8]) {
-    pbkdf2::pbkdf2::<Hmac<Sha512>>(password, salt, iterations, out)
-        .expect("HMAC-SHA512 accepts keys of any length, so this cannot fail");
+/// `Err(())` only for an output length the KDF rejects (zero, or absurdly large).
+/// Returned rather than asserted: the sole caller is an `extern "C"` export that
+/// already reports failure as an error code, and unwinding across that boundary
+/// is undefined behaviour.
+pub fn pbkdf2_hmac_sha512(
+    password: &[u8],
+    salt: &[u8],
+    iterations: u32,
+    out: &mut [u8],
+) -> Result<(), ()> {
+    pbkdf2::pbkdf2::<Hmac<Sha512>>(password, salt, iterations, out).map_err(|_| ())
 }


### PR DESCRIPTION
`#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]` at both
crate roots. Both lints live in clippy's `restriction` group, so they are
allow-by-default and have to be named explicitly.

The reason is specific to this workspace: every entry point is reached across a C
ABI, and **an unwind across `extern "C"` is undefined behaviour**. A panic here is
not a crash report, it is a corrupted process.

## Scope, measured before touching anything

| where | hits |
|---|---|
| **production code** | **10** |
| inside `#[cfg(test)]` modules in `src/` | 47 |
| `tests/` directories | 33 |

`cfg_attr(not(test), …)` leaves all 80 test-side uses alone in one line: the normal
lib build is checked, the unit-test compilation has `cfg(test)` so it isn't, and
integration tests are separate crates that never see the attribute.

## The four library sites, fixed rather than silenced

* **`exports.rs`** — `PPMD_SA.as_mut().unwrap()` in an **FFI helper** became
  `get_or_insert_with`, removing the unwrap *and* the `is_none()` test. This is the
  one that mattered: that function is called from C.
* **`lz4hc.rs`, `tta.rs`** — `try_into().unwrap()` on slices that are infallibly
  the right length; now total, with no panic path emitted.
* **`dict_encode.rs`** — `encoded.unwrap()` where the `store` flag had already
  tested `Err`; now an exhaustive `match`, so that relationship is stated instead
  of assumed.
* **`pbkdf2_hmac_sha512`** now **propagates** instead of asserting. Its only caller
  is an `extern "C"` export already returning `c_int`, so the failure became an
  error code rather than a panic crossing the boundary.

## Three exceptions, argued in place

`cfb::encrypt_in_place` and `ctr`'s pad conversion keep `expect` under a per-site
`#[allow]` with the reasoning attached: the length invariant is asserted at the
constructor above them, so the conversion cannot fail.

The total fix is to type those buffers as `Array<u8, C::BlockSize>` rather than
`Vec<u8>`, which **deletes** the conversion instead of justifying it. Contained —
both structs are already generic over `C` — but a crypto refactor, so it belongs in
its own change. Happy to do it next if you'd rather not carry the exceptions.

## Two things this does NOT do

Both recorded in the code, so the gate isn't mistaken for a guarantee:

* **It bans two *spellings* of panic, not panicking.** `Cfb::new`'s
  `assert_eq!(iv.len(), bs, …)` sits one screen above an exemption granted here, is
  still a panic, still crosses the same ABI, and this lint says nothing about it.
  Slice indexing and arithmetic overflow likewise.
* **`src/bin/dict_phase1.rs` is not covered** — three `unwrap`s in a dev helper
  that is a separate crate target the attribute cannot reach. Panicking on a failed
  stdin read is right for a tool, so it's left alone deliberately rather than the
  ban being claimed as universal.

## Verified

**The gate bites:** planting `Some(1u8).unwrap()` in `tta::decompress` makes
`cargo clippy -p darc-codecs` exit **101**; the clean tree exits **0**.

⚠️ Worth recording how that was nearly missed. Grepping clippy's prose for the
message returned 0 matches and read as *"not caught"* — the pattern didn't account
for a backtick after `unwrap()`. The exit code was the real signal, and this was
the **third** false negative from grepping human-readable output in one session.
The validation script for this change gates on exit codes only.

| gate | result |
|---|---|
| `clippy --workspace --all-targets` | 0 errors |
| `nextest --workspace` | all passed |
| `crypto-check` · `tta-check` · `lz4hc-check` · `dict-check` · `ppmd-check` | **0 differing** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
