### PR TITLE
Implement the CLI options the port parsed and then refused

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -18,7 +18,7 @@ working tree so the oracle survives the C being deleted and cannot drift.
 
 ```bash
 rust/difftest/lzma-decode-check.sh     # exit 0 or the port diverged
-cd rust && cargo nextest run --profile ci   # 557 unit tests
+cd rust && cargo nextest run --profile ci   # 648 unit tests
 ```
 
 Two properties every harness here is expected to have, learned the hard way:

--- a/e
+++ b/e
@@ -1,1 +1,0 @@
-ERROR: -ld10%: percentage limits are not implemented -- this port's physical-memory figure does not yet match the reference's, and guessing it would write a different archive. Give an explicit size instead, e.g. -ld1gb.

--- a/e
+++ b/e
@@ -1,0 +1,1 @@
+ERROR: -ld10%: percentage limits are not implemented -- this port's physical-memory figure does not yet match the reference's, and guessing it would write a different archive. Give an explicit size instead, e.g. -ld1gb.

--- a/rust/darc-arc/src/archive.rs
+++ b/rust/darc-arc/src/archive.rs
@@ -158,7 +158,23 @@ fn read_service_block(data: &[u8], b: &ArchiveBlock, pw: &Passwords) -> Result<V
 pub fn read_info(path: &std::path::Path, pw: &Passwords) -> Result<ArchiveInfo, Error> {
     let data = read_all(path)?;
     let (_base, footer) = read_footer(&data, pw)?;
+    read_info_with(&data, footer, pw)
+}
 
+/// `read_info`, but with the block list recovered by scanning — `-ba`.
+pub fn read_info_broken(path: &std::path::Path, pw: &Passwords) -> Result<ArchiveInfo, Error> {
+    let data = read_all(path)?;
+    let footer = scan_broken(&data)?;
+    read_info_with(&data, footer, pw)
+}
+
+/// The half of `read_info` that follows a footer, however that footer was
+/// obtained.
+pub fn read_info_with(
+    data: &[u8],
+    footer: FooterBlock,
+    pw: &Passwords,
+) -> Result<ArchiveInfo, Error> {
     let dir_blocks: Vec<&ArchiveBlock> =
         footer.blocks.iter().filter(|b| b.block_type == BlockType::Dir).collect();
 
@@ -239,4 +255,58 @@ pub fn read_entry(
 /// without reading it twice.
 pub fn open(path: &std::path::Path) -> Result<Vec<u8>, Error> {
     read_all(path)
+}
+
+/// `findBlocksInBrokenArchive` (`ArhiveStructure.hs:96`) — recover the block
+/// list by SCANNING for descriptors instead of trusting the footer.
+///
+/// A DArc archive is normally read from its end: the last thing in the file is
+/// the FOOTER block, which lists every other block. Lose it — a truncated
+/// download, a bad sector — and nothing is readable even when every data block
+/// survives. `-ba` walks the file instead, collecting the descriptor each block
+/// carries, and fabricates a footer from what it finds.
+///
+/// Backwards in `HUGE_BUFFER_SIZE` windows, because `find_descriptor` searches
+/// DOWNWARD from the end of what it is handed, so each call returns the highest
+/// descriptor below the previous one.
+///
+/// The fabricated footer cannot know what only the real one recorded: no
+/// comment, no recovery info, not locked, and an SFX size taken from the
+/// earliest block (`:113`).
+pub fn scan_broken(data: &[u8]) -> Result<FooterBlock, Error> {
+    // Every offset carrying the descriptor signature, in file order. A
+    // signature can also occur by chance inside compressed data; the CRC below
+    // is what separates the two, exactly as it does for the footer.
+    let sig = block::SIGNATURE.to_le_bytes();
+    let candidates: Vec<usize> = (0..data.len().saturating_sub(4))
+        .filter(|i| data[*i..*i + 4] == sig)
+        .collect();
+
+    // `read_descriptor` takes the CRC from the LAST FOUR BYTES of the window it
+    // is handed, so the window has to end exactly where the descriptor ends.
+    // For the footer that is EOF, which is why the normal read can pass a
+    // window straight to it -- but nothing tells a scan where any other
+    // descriptor stops. So each candidate end is tried in turn and the CRC
+    // decides. `aSCAN_MAX` is the bound: a descriptor is certainly shorter
+    // (ArhiveStructure.hs:100 sizes its buffer on exactly that assumption).
+    let mut blocks: Vec<ArchiveBlock> = Vec::new();
+    for p in candidates {
+        let limit = (p + block::SCAN_MAX as usize).min(data.len());
+        for end in (p + 8)..=limit {
+            match block::read_descriptor(p as u64, &data[p..end]) {
+                Ok(b) => {
+                    blocks.push(b);
+                    break;
+                }
+                Err(_) => {}
+            }
+        }
+    }
+    if blocks.is_empty() {
+        // `"0356 archive directory not found"`.
+        return Err(Error::NoSignature);
+    }
+    blocks.reverse();
+    let sfx_size = blocks.iter().map(|b| b.pos).min().unwrap_or(0);
+    Ok(FooterBlock { blocks, locked: false, comment: String::new(), recovery: String::new(), sfx_size })
 }

--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -64,8 +64,8 @@ options (a selection):
   -s<size>      solid block size; -s- for non-solid
   -p<password>  encrypt; -op<password> to decrypt with an old one
   -rr[<size>]   add recovery records; -rr+ to also protect the directory
-  -sfx[<name>]  make a self-extracting archive
-  -o+ / -o-     overwrite always / never
+  -sfx<name>    make a self-extracting archive with that module
+  -o+ -o- -o    on extract: overwrite always / never / ask (the default)
   -ep<n>        how much of the path to store
   --dirs        store directory entries explicitly
   --noarcext    do not append .arc to the archive name
@@ -158,7 +158,7 @@ fn main() {
         "OldPassword", "password", "recompress", "recursive", "solid", "sync",
         "update", "include", "exclude", "dirs", "nodirs",
         "SizeMore", "SizeLess", "TimeBefore", "TimeAfter", "TimeNewer", "TimeOlder",
-        "recovery", "volume", "sfx", "noarcext", "charset", "original",
+        "recovery", "volume", "sfx", "noarcext", "charset", "original", "overwrite",
         // Accepted and deliberately ignored: UI only.
         "yes", "indicator", "display",
     ];
@@ -351,7 +351,21 @@ fn main() {
                 }
             };
             let extracting = command != "t";
-            run_blocks(&info, &data, &layout, extracting, &pw, &selected)
+            // Testing writes nothing, so it has nothing to overwrite.
+            let skip = match extracting {
+                true => {
+                    let mode = match overwrite_mode(&parsed) {
+                        Ok(m) => m,
+                        Err(e) => {
+                            eprintln!("ERROR: {e}");
+                            std::process::exit(2);
+                        }
+                    };
+                    resolve_overwrites(&layout, &selected, mode, parsed.flag("yes"))
+                }
+                false => std::collections::HashSet::new(),
+            };
+            run_blocks(&info, &data, &layout, extracting, &pw, &selected, &skip)
         }
         // One function: every one of these is `runArchiveAdd` with a different
         // archive filter and a different source of files (Arc.hs:122-131).
@@ -2141,6 +2155,102 @@ fn list(command: &str, info: &archive::ArchiveInfo, entries: &[Entry]) -> i32 {
 ///
 /// Testing and extracting differ only in what happens after the CRC check, so
 /// they share the loop rather than duplicating the block handling.
+/// What `-o` says to do when the file is already on disk.
+///
+/// `testOption "overwrite" "o" … (words "+ - p")` (`Cmdline.hs:160`): the three
+/// legal values, defaulting to `p`. `-op<something>` is NOT one of them — it is
+/// an old password, peeled off before this is read (`is_op_option`,
+/// `Cmdline.hs:156`), which is why `-o` values of length > 1 beginning with `p`
+/// never reach here.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Overwrite {
+    Always,
+    Never,
+    Ask,
+}
+
+/// `last ("p" : o_rest)` (`Cmdline.hs:157`) — the LAST `-o` wins, and the
+/// default is to ask.
+fn overwrite_mode(parsed: &options::Parsed) -> Result<Overwrite, String> {
+    let mut mode = Overwrite::Ask;
+    for v in parsed.all("overwrite") {
+        // The old-password spelling, already consumed by cook_passwords.
+        if v.len() > 1 && v.starts_with('p') {
+            continue;
+        }
+        mode = match v {
+            "+" => Overwrite::Always,
+            "-" => Overwrite::Never,
+            "p" | "" => Overwrite::Ask,
+            other => return Err(format!("-o{other}: expected one of +, -, p")),
+        };
+    }
+    Ok(mode)
+}
+
+/// Decide, for every file that already exists, whether it may be overwritten.
+///
+/// Serial and BEFORE the parallel loop on purpose: `Ask` reads from stdin, and
+/// prompting from inside `par_iter` would interleave questions from several
+/// threads and answer them against the wrong file.
+///
+/// Returns the set of stored names to skip.
+fn resolve_overwrites(
+    layout: &Layout,
+    entries: &[Entry],
+    mode: Overwrite,
+    assume_yes: bool,
+) -> std::collections::HashSet<String> {
+    use std::io::BufRead;
+    let mut skip = std::collections::HashSet::new();
+    if mode == Overwrite::Always || assume_yes {
+        return skip;
+    }
+    let mut all = false;
+    let mut none = false;
+    for e in entries.iter().filter(|e| !e.is_dir) {
+        if !std::path::Path::new(&layout.disk_name(e)).exists() {
+            continue;
+        }
+        let overwrite = match mode {
+            Overwrite::Always => true,
+            Overwrite::Never => false,
+            Overwrite::Ask => match (all, none) {
+                (true, _) => true,
+                (_, true) => false,
+                _ => {
+                    print!("{} already exists. Overwrite? [y]es/[n]o/[A]ll/[N]one: ", layout.disk_name(e));
+                    match std::io::Write::flush(&mut std::io::stdout()) {
+                        Ok(()) => {}
+                        Err(_) => {}
+                    }
+                    let mut line = String::new();
+                    // EOF (no terminal, or stdin closed) is NOT consent: an
+                    // unanswered question must not clobber the user's file.
+                    match std::io::stdin().lock().read_line(&mut line) {
+                        Ok(0) | Err(_) => false,
+                        Ok(_) => match line.trim() {
+                            "A" => {
+                                all = true;
+                                true
+                            }
+                            "N" => {
+                                none = true;
+                                false
+                            }
+                            a => a.eq_ignore_ascii_case("y"),
+                        },
+                    }
+                }
+            },
+        };
+        if !overwrite {
+            skip.insert(e.stored_name.clone());
+        }
+    }
+    skip
+}
+
 fn run_blocks(
     info: &archive::ArchiveInfo,
     data: &[u8],
@@ -2148,6 +2258,7 @@ fn run_blocks(
     extracting: bool,
     pw: &darc_arc::passwords::Passwords,
     entries: &[Entry],
+    skip: &std::collections::HashSet<String>,
 ) -> i32 {
     // The safety check runs on the archive's contribution alone: the
     // destination is the user's own and may be absolute.
@@ -2246,6 +2357,11 @@ fn run_blocks(
                 }
                 if !darc_arc::extract::is_safe(&relative.disk_name(e)) {
                     bad.push(format!("refusing unsafe path {:?}", e.stored_name));
+                    continue;
+                }
+                // `-o-`, or an existing file the user declined to overwrite.
+                // Decided serially before this loop; see resolve_overwrites.
+                if skip.contains(&e.stored_name) {
                     continue;
                 }
                 let name = layout.disk_name(e);
@@ -2938,4 +3054,46 @@ fn show_memory(bytes: u64) -> String {
         }
     }
     format!("{bytes} bytes")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mode_of(args: &[&str]) -> Result<Overwrite, String> {
+        let owned: Vec<String> = args.iter().map(|s| (*s).to_string()).collect();
+        overwrite_mode(&options::parse(&owned).expect("parses"))
+    }
+
+    /// `last ("p" : o_rest)` (`Cmdline.hs:157`). The default is to ask, and a
+    /// later `-o` overrides an earlier one rather than combining with it.
+    #[test]
+    fn the_last_overwrite_option_wins_and_the_default_is_ask() {
+        assert!(matches!(mode_of(&[]), Ok(Overwrite::Ask)));
+        assert!(matches!(mode_of(&["-o+"]), Ok(Overwrite::Always)));
+        assert!(matches!(mode_of(&["-o-"]), Ok(Overwrite::Never)));
+        assert!(matches!(mode_of(&["-o-", "-o+"]), Ok(Overwrite::Always)));
+        assert!(matches!(mode_of(&["-o+", "-o-"]), Ok(Overwrite::Never)));
+    }
+
+    /// `-op<something>` is an old PASSWORD, not an overwrite mode
+    /// (`is_op_option`, `Cmdline.hs:156`). It must not be read as one, and it
+    /// must not disturb a real `-o` given alongside it.
+    #[test]
+    fn op_is_a_password_and_not_an_overwrite_mode() {
+        assert!(matches!(mode_of(&["-opsecret"]), Ok(Overwrite::Ask)));
+        assert!(matches!(mode_of(&["-o+", "-opsecret"]), Ok(Overwrite::Always)));
+        assert!(matches!(mode_of(&["-opsecret", "-o-"]), Ok(Overwrite::Never)));
+        // A BARE -op is the mode `p`, not a password: is_op_option needs at
+        // least one character after the p.
+        assert!(matches!(mode_of(&["-op"]), Ok(Overwrite::Ask)));
+    }
+
+    /// Anything outside `+ - p` is refused rather than silently treated as the
+    /// default -- `testOption "overwrite" "o" … (words "+ - p")`.
+    #[test]
+    fn an_unknown_overwrite_value_is_refused() {
+        assert!(mode_of(&["-oz"]).is_err());
+        assert!(mode_of(&["-o1"]).is_err());
+    }
 }

--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -228,7 +228,7 @@ fn main() {
         "recovery", "volume", "sfx", "noarcext", "charset", "original", "overwrite",
         "keepbroken", "keeptime", "timetolast", "test", "autogenerate",
         "pause-before-exit", "queue", "pretest", "logfile", "proxy", "bypass",
-        "type", "dirmethod",
+        "type", "dirmethod", "adddir",
         // Accepted and deliberately ignored: UI only.
         "yes", "indicator", "display",
         // Accepted and deliberately ignored: these change SPEED or a Windows
@@ -1055,7 +1055,26 @@ fn add(
     // relocates where files are READ and leaves stored names alone. It was
     // being parsed into extract::Layout, which only the EXTRACT path consults,
     // so on `a` it was accepted and silently did nothing at all.
-    let disk_base = parsed.arg("diskpath", "").trim_end_matches('/').to_string();
+    // `-ad`/`--adddir` (Arc.hs:144): `opt_disk_basedir </> takeBaseName
+    // arcname` -- the archive's own base name, without directory or extension,
+    // APPENDED to any -dp rather than replacing it. Measured on the reference:
+    // `a -ad backup.arc .` is byte-identically `a -dpbackup backup.arc .`.
+    let disk_base = {
+        let dp = parsed.arg("diskpath", "").trim_end_matches('/').to_string();
+        match parsed.flag("adddir") {
+            false => dp,
+            true => {
+                let stem = std::path::Path::new(archive_name)
+                    .file_stem()
+                    .map(|s| s.to_string_lossy().into_owned())
+                    .unwrap_or_default();
+                match dp.is_empty() {
+                    true => stem,
+                    false => format!("{dp}/{stem}"),
+                }
+            }
+        }
+    };
     let under_base = |p: &str| -> std::path::PathBuf {
         let rel = match p.is_empty() {
             true => ".",

--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -875,22 +875,6 @@ fn add(
     let dlimit: u64 = match parsed.arg("LimitDecompMem", "--") {
         "--" => darc_arc::memlimit::ADD_DECOMPRESSION_LIMIT,
         "-" => u64::MAX,
-        // A percentage is REFUSED, not approximated. Measured: `-ld10%` on
-        // this machine writes an archive one byte different from the
-        // reference's, so the RAM figure or its rounding does not yet match
-        // `getPhysicalMemory `roundTo` (4*mb)` (Cmdline.hs:230). Every other
-        // spelling is byte-identical. Shipping the percentage would mean
-        // writing a DIFFERENT archive than the reference for a documented
-        // option, which is the one failure mode this project cannot absorb.
-        s if s.ends_with('%') || s.ends_with('p') => {
-            eprintln!(
-                "ERROR: -ld{s}: percentage limits are not implemented -- this \
-                 port's physical-memory figure does not yet match the \
-                 reference's, and guessing it would write a different archive. \
-                 Give an explicit size instead, e.g. -ld1gb."
-            );
-            return 2;
-        }
         s => match darc_arc::memlimit::parse_mem_with_percents(
             darc_arc::memlimit::physical_memory(),
             s,

--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -359,6 +359,7 @@ fn main() {
         for (name, hint) in [
             ("dictionary", Some("-md<N>")),
             ("StoreCompressed", Some("-ms")),
+            ("MultiThreaded", Some("-mt<N>")),
             // multimedia is the exception: -mm is not implemented EITHER, so
             // there is no working spelling to point at.
             ("multimedia", None),

--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -92,6 +92,95 @@ fn main() {
     // The command is the first argument and is NOT an option, matching
     // `parseCmdline`: options may appear anywhere after it.
     let command = argv[0].clone();
+
+    // `arc.ini` and `$FREEARC`, PREPENDED to the command line
+    // (Cmdline.hs:102). The user's own arguments stay last, so every
+    // last-wins option still overrides the defaults. Without this a machine
+    // with `-mx` in its arc.ini gets a different archive from the reference
+    // for the same command line, silently.
+    //
+    // `-cfg-` disables BOTH the file and the variable (Cmdline.hs:49); `-cfg
+    // <path>` names a different file; `-env <VAR>` names a different variable
+    // and `-env-` disables it. Those three are read from the RAW arguments,
+    // because they decide what the real parse will see.
+    //
+    // A DELIBERATE divergence, measured: the 9a127e6 reference built on macOS
+    // never finds arc.ini by itself. Not beside the executable, not in the
+    // working directory -- `getExeName` (Files.hs:227) is a Windows/Linux
+    // idiom and evidently fails here, so only an explicit `-cfg<path>` has any
+    // effect there. This port implements the search `Files.hs:224` describes,
+    // because that is the documented behaviour and what a user who drops an
+    // arc.ini beside the binary expects.
+    //
+    // The consequence is worth stating plainly: on macOS, with an arc.ini
+    // present, this port and that reference build write DIFFERENT archives.
+    // What is gated below is the part that can be gated -- the parsing and the
+    // injection order -- using `-cfg<path>`, which the reference does honour:
+    // 12 of 12 byte-identical across global lines, per-command sections,
+    // repeated and multi-name left-hand sides, comments, $FREEARC, and the
+    // command line overriding all of them.
+    let pre = options::parse(&argv[1..]).unwrap_or_default();
+    let no_configs = pre.all("config").contains(&"-");
+    let cfg_text = match no_configs {
+        true => None,
+        false => match pre.arg("config", "--") {
+            "--" => darc_arc::config::Config::find().and_then(|p| std::fs::read_to_string(p).ok()),
+            path => match std::fs::read_to_string(path) {
+                Ok(t) => Some(t),
+                Err(e) => {
+                    eprintln!("ERROR: -cfg{path}: {e}");
+                    std::process::exit(2);
+                }
+            },
+        },
+    };
+    let mut extra: Vec<String> = Vec::new();
+    match &cfg_text {
+        Some(text) => {
+            let cfg = darc_arc::config::Config::parse(text);
+            // Named rather than silently skipped: an EDITED [Compression
+            // methods] section changes what -m9 means in the reference and
+            // not here, and this port's table is built in.
+            let unapplied = cfg.has_unapplied_sections();
+            if !unapplied.is_empty() {
+                eprintln!(
+                    "WARNING: {} in the config file {} not applied; this port's \
+                     compression-method table is built in",
+                    unapplied.join(", "),
+                    match unapplied.len() {
+                        1 => "is",
+                        _ => "are",
+                    }
+                );
+            }
+            extra.extend(cfg.global_options().split_whitespace().map(str::to_string));
+            extra.extend(cfg.command_options(&command).split_whitespace().map(str::to_string));
+        }
+        None => {}
+    }
+    if !no_configs {
+        let var = match pre.arg("env", "--") {
+            "--" => darc_arc::config::CONFIG_ENV_VAR,
+            "-" => "",
+            v => v,
+        };
+        if !var.is_empty() {
+            match std::env::var(var) {
+                Ok(v) => extra.extend(v.split_whitespace().map(str::to_string)),
+                Err(_) => {}
+            }
+        }
+    }
+    let argv: Vec<String> = match extra.is_empty() {
+        true => argv,
+        false => {
+            let mut v = vec![argv[0].clone()];
+            v.extend(extra);
+            v.extend(argv[1..].iter().cloned());
+            v
+        }
+    };
+
     let parsed = match options::parse(&argv[1..]) {
         Ok(p) => p,
         Err(e) => {
@@ -228,7 +317,7 @@ fn main() {
         "recovery", "volume", "sfx", "noarcext", "charset", "original", "overwrite",
         "keepbroken", "keeptime", "timetolast", "test", "autogenerate",
         "pause-before-exit", "queue", "pretest", "logfile", "proxy", "bypass",
-        "type", "dirmethod", "adddir", "nodata", "crconly", "LimitDecompMem", "nodir", "LimitCompMem", "sort",
+        "type", "dirmethod", "adddir", "nodata", "crconly", "LimitDecompMem", "nodir", "LimitCompMem", "sort", "config", "env",
         // Accepted and deliberately ignored: UI only.
         "yes", "indicator", "display",
         // Accepted and deliberately ignored: these change SPEED or a Windows
@@ -273,6 +362,9 @@ fn main() {
             // multimedia is the exception: -mm is not implemented EITHER, so
             // there is no working spelling to point at.
             ("multimedia", None),
+            // Inert in the reference too: measured, `a --print-config` still
+            // creates the archive and prints no config at all.
+            ("print-config", None),
         ] {
             if names.contains(&name) {
                 match hint {

--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -317,7 +317,7 @@ fn main() {
         "recovery", "volume", "sfx", "noarcext", "charset", "original", "overwrite",
         "keepbroken", "keeptime", "timetolast", "test", "autogenerate",
         "pause-before-exit", "queue", "pretest", "logfile", "proxy", "bypass",
-        "type", "dirmethod", "adddir", "nodata", "crconly", "LimitDecompMem", "nodir", "LimitCompMem", "sort", "config", "env", "workdir", "create-in-workdir",
+        "type", "dirmethod", "adddir", "nodata", "crconly", "LimitDecompMem", "nodir", "LimitCompMem", "sort", "config", "env", "workdir", "create-in-workdir", "save-bad-ranges",
         // Accepted and deliberately ignored: UI only.
         "yes", "indicator", "display",
         // Accepted and deliberately ignored: these change SPEED or a Windows
@@ -755,6 +755,7 @@ fn main() {
             parsed.arg("original", "--"),
             parsed.arg("proxy", "--"),
             parsed.arg("bypass", ""),
+            parsed.arg("save-bad-ranges", ""),
         ),
         // `rr…` is `ch -rr…` and `s…` is `ch -sfx…` (Cmdline.hs:124, :166) --
         // the same copy path, with the setting read off the command's own
@@ -2758,6 +2759,35 @@ fn list(command: &str, info: &archive::ArchiveInfo, entries: &[Entry]) -> i32 {
 ///
 /// Testing and extracting differ only in what happens after the CRC check, so
 /// they share the loop rather than duplicating the block handling.
+/// `--save-bad-ranges` — the damaged BYTE ranges, for a caller to act on.
+///
+/// `joinWith "," $ map byte_range bad_sectors` (ArcRecover.hs:337-342): each
+/// sector becomes `START-END` where START is `sector*sector_size + init_pos`
+/// and END is the last byte of that sector, inclusive. Comma separated, no
+/// trailing newline -- the file is meant to be read by another program, and a
+/// stray byte would be part of the last range.
+///
+/// Written only when the option was given; an empty path means "do not".
+fn save_bad_ranges(path: &str, sectors: &[u64], control: &darc_arc::recovery::Control) {
+    if path.is_empty() {
+        return;
+    }
+    let text = sectors
+        .iter()
+        .map(|s| {
+            let start = s * control.sector_size + control.init_pos;
+            format!("{start}-{}", start + control.sector_size - 1)
+        })
+        .collect::<Vec<String>>()
+        .join(",");
+    match std::fs::write(path, text.as_bytes()) {
+        Ok(()) => {}
+        // The recovery itself has already happened or failed; losing the
+        // report does not change that, so it warns rather than returning.
+        Err(e) => eprintln!("WARNING: --save-bad-ranges {path}: {e}"),
+    }
+}
+
 /// `--pretest` — check an existing archive BEFORE operating on it.
 ///
 /// The modes are `Options.hs:80`: 0 none, 1 recovery info only, 2 recovery or
@@ -3629,6 +3659,7 @@ fn recover(
     original: &str,
     proxy: &str,
     bypass: &str,
+    save_ranges: &str,
 ) -> i32 {
     // `arcname `replaceBaseName` ("fixed."++takeBaseName arcname)` -- the
     // extension is kept and the base name prefixed, so `a.arc` becomes
@@ -3752,6 +3783,7 @@ fn recover(
     // loaded bytes instead made the port refuse where the reference wrote a
     // file.
     if recoverable.is_empty() && original_name.is_empty() {
+        save_bad_ranges(save_ranges, &lost, &scan.control);
         eprintln!(
             "ERROR: {} unrecoverable errors ({}) found, can't restore anything!",
             show3(lost.len() as u64),
@@ -3795,6 +3827,11 @@ fn recover(
         }
     }
     println!("Recovered archive saved to {}", fixed.display());
+    // `save_bad_ranges errors` (ArcRecover.hs:430), AFTER the archive is
+    // written -- these are the ranges that could not be repaired, not the
+    // ones that were damaged. Written even when the list is empty, which is
+    // how a caller tells "repaired everything" from "never ran".
+    save_bad_ranges(save_ranges, &still_bad, &scan.control);
     if !still_bad.is_empty() {
         eprintln!(
             "WARNING: {} errors ({}) remain unrecovered",

--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -250,6 +250,45 @@ fn main() {
         let mut names: Vec<&str> = unimplemented;
         names.sort_unstable();
         names.dedup();
+        // Three of these are NOT awaiting implementation, and saying so would
+        // promise work that must never be done. `Options.hs:170-172` gives
+        // `-md`/`--dictionary`, `-ms`/`--StoreCompressed` and
+        // `-mm`/`--multimedia` a long spelling that nothing in the reference
+        // ever reads: the values are consumed inside the `-m` grammar, under
+        // the name `method`, because `method` wins the prefix tie.
+        //
+        // Measured on the reference: `-md1m` changes the archive and
+        // `--dictionary=1m` is byte-identical to giving nothing at all. It
+        // accepts the option, exits 0, and hands back an archive with the
+        // DEFAULT dictionary. Refusing surfaces that; matching it would be the
+        // silent no-op this list exists to prevent. Routing the long spelling
+        // into the grammar instead would be worse still -- it would write a
+        // different archive than the reference for the same command line.
+        //
+        // So the behaviour stays and only the message changes, to name the
+        // spelling that is actually read.
+        for (name, hint) in [
+            ("dictionary", Some("-md<N>")),
+            ("StoreCompressed", Some("-ms")),
+            // multimedia is the exception: -mm is not implemented EITHER, so
+            // there is no working spelling to point at.
+            ("multimedia", None),
+        ] {
+            if names.contains(&name) {
+                match hint {
+                    Some(spelling) => eprintln!(
+                        "ERROR: --{name} is not a separate option -- the reference \
+                         accepts it and then ignores it, writing the default. Use \
+                         {spelling}, which is where the value is actually read."
+                    ),
+                    None => eprintln!(
+                        "ERROR: --{name} is not implemented, and neither is its \
+                         -mm spelling: it changes the compression chain."
+                    ),
+                }
+                std::process::exit(2);
+            }
+        }
         eprintln!(
             "ERROR: this port does not implement {} yet, and ignoring it would \
              write an archive that is not what you asked for",

--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -1050,6 +1050,23 @@ fn add(
     // subdirectory.
     let named_dir = |spec: &str| spec.ends_with('/') || std::path::Path::new(spec).is_dir();
 
+    // `-dp`/`--diskpath` (Cmdline.hs:683). Measured against the reference:
+    // `a -dpX … .` and `cd X && a … .` write byte-identical archives, so -dp
+    // relocates where files are READ and leaves stored names alone. It was
+    // being parsed into extract::Layout, which only the EXTRACT path consults,
+    // so on `a` it was accepted and silently did nothing at all.
+    let disk_base = parsed.arg("diskpath", "").trim_end_matches('/').to_string();
+    let under_base = |p: &str| -> std::path::PathBuf {
+        let rel = match p.is_empty() {
+            true => ".",
+            false => p,
+        };
+        match disk_base.is_empty() {
+            true => std::path::PathBuf::from(rel),
+            false => std::path::Path::new(&disk_base).join(rel),
+        }
+    };
+
     // Pass one: addDir, in the order the specs were given, because the
     // reference runs every filespec's addDir pass before any main walk.
     for spec in spec_list {
@@ -1059,7 +1076,7 @@ fn add(
         // when the filespec HAS a last component, so `.`, `..` and `/`
         // contribute nothing -- exactly what `file_name()` reports.
         if named_dir(spec) && std::path::Path::new(root).file_name().is_some() {
-            named_dirs.push((root.to_string(), std::path::PathBuf::from(root), true));
+            named_dirs.push((root.to_string(), under_base(root), true));
         }
     }
 
@@ -1103,10 +1120,8 @@ fn add(
     groups.sort_by_key(|g| g.0.to_lowercase());
 
     for (dir_part, masks, dir_slash) in groups {
-        let base = match dir_part.is_empty() {
-            true => std::path::Path::new("."),
-            false => std::path::Path::new(dir_part.as_str()),
-        };
+        let base_buf = under_base(dir_part.as_str());
+        let base: &std::path::Path = &base_buf;
         // `recursive = scan_subdirs || dir_slash` and `include_all = dir_slash
         // || masks `contains` reANY_FILE` (FileInfo.hs:456).
         let rec = recursive || dir_slash;

--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -228,7 +228,7 @@ fn main() {
         "recovery", "volume", "sfx", "noarcext", "charset", "original", "overwrite",
         "keepbroken", "keeptime", "timetolast", "test", "autogenerate",
         "pause-before-exit", "queue", "pretest", "logfile", "proxy", "bypass",
-        "type", "dirmethod", "adddir", "nodata", "crconly", "LimitDecompMem", "nodir",
+        "type", "dirmethod", "adddir", "nodata", "crconly", "LimitDecompMem", "nodir", "LimitCompMem",
         // Accepted and deliberately ignored: UI only.
         "yes", "indicator", "display",
         // Accepted and deliberately ignored: these change SPEED or a Windows
@@ -872,6 +872,29 @@ fn add(
     // ADD command and `75%` of RAM otherwise; `-` is unlimited; anything else
     // is a size or a percentage. Archive-visible -- it is what reduces -m9's
     // `ppmd:25:2047m` to `ppmd:22:1gb`.
+    // `-lc`/`--LimitCompMem` (Cmdline.hs:298). The default is 75% of the
+    // capped RAM figure, which on any machine with 4 GiB or more is 3 GiB --
+    // large enough that it does not bind for the chains DArc ships, which is
+    // why the port wrote byte-identical archives before this existed.
+    let climit: u64 = match parsed.arg("LimitCompMem", "--") {
+        "--" => darc_arc::memlimit::parse_mem_with_percents(
+            darc_arc::memlimit::physical_memory(),
+            "75%",
+        )
+        .unwrap_or(u64::MAX),
+        "-" => u64::MAX,
+        s => match darc_arc::memlimit::parse_mem_with_percents(
+            darc_arc::memlimit::physical_memory(),
+            s,
+        ) {
+            Some(v) => v,
+            None => {
+                eprintln!("ERROR: -lc{s}: not a memory size (N, Nb, Nk, Nm, Ng, N%)");
+                return 2;
+            }
+        },
+    };
+
     let dlimit: u64 = match parsed.arg("LimitDecompMem", "--") {
         "--" => darc_arc::memlimit::ADD_DECOMPRESSION_LIMIT,
         "-" => u64::MAX,
@@ -1645,6 +1668,15 @@ fn add(
         "" => solid.dir_method.clone(),
         m => m.to_string(),
     };
+    // Even with no -dm and no preset, the writer's DEFAULT directory chain
+    // (`lzma:1mb:mf=BT4`) is subject to -lc -- so the limit has to be applied
+    // whether or not the user named a directory method. Skipping the empty
+    // case left the default unlimited and was why the first fix changed
+    // nothing.
+    let dir_method = match dir_method.is_empty() {
+        false => dir_method,
+        true => darc_arc::writer::Writer::dir_compressor().join("+"),
+    };
     if !dir_method.is_empty() {
         let decoded = darc_arc::methodtable::decode_method(&dir_method);
         match decoded.first() {
@@ -1657,7 +1689,27 @@ fn add(
             // Named methods were unaffected because their chains are one
             // element long, which is exactly why this went unnoticed.
             Some((_, chain)) => match chain.last() {
-                Some(last) => w.set_dir_compressor(vec![last.clone()]),
+                // The DIRECTORY compressor is subject to -lc as well.
+                // Measured: `-mlzma:64m -lc8m` writes the directory with
+                // `lzma:190650b`, which is (8mb - 6mb) / 11 -- the same
+                // formula the data chain gets -- where an unlimited port keeps
+                // `lzma:1mb`. Nothing in Cmdline.hs's dirCompressor pipeline
+                // says so; only the archives do.
+                Some(last) => {
+                    let limited = match darc_arc::method::Method::parse(last) {
+                        Some(mut m) => {
+                            match darc_arc::memlimit::get_compression_mem(&m) {
+                                Some(have) if have > climit => {
+                                    darc_arc::memlimit::set_compression_mem(&mut m, climit);
+                                }
+                                _ => {}
+                            }
+                            darc_arc::canonize::show(&m)
+                        }
+                        None => last.clone(),
+                    };
+                    w.set_dir_compressor(vec![limited]);
+                }
                 None => {
                     eprintln!("ERROR: -dm{dir_method}: expanded to an empty chain");
                     return 2;
@@ -1819,7 +1871,7 @@ fn add(
                     kept_entries.push(e);
                 }
                 let original = src.compressor.join("+");
-                let fitted = match darc_arc::memlimit::fit_for_add_limited(&original, body.len() as u64, dlimit) {
+                let fitted = match darc_arc::memlimit::fit_for_add_limits(&original, body.len() as u64, climit, dlimit) {
                     Some(f) => f,
                     None => {
                         eprintln!("ERROR: cannot fit {original} to {} bytes", body.len());
@@ -1905,7 +1957,7 @@ fn add(
                 reordered.push(e);
             }
             at += len;
-            let fitted = match darc_arc::memlimit::fit_for_add_limited(chain, body.len() as u64, dlimit) {
+            let fitted = match darc_arc::memlimit::fit_for_add_limits(chain, body.len() as u64, climit, dlimit) {
                 Some(f) => f,
                 None => {
                     eprintln!("ERROR: cannot fit {chain} to {} bytes", body.len());

--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -381,6 +381,30 @@ fn main() {
                 std::process::exit(2);
             }
         }
+        // -ba is refused rather than half-implemented, and the reason is
+        // worth stating: it reads the block list by SCANNING for descriptors
+        // instead of following the footer (ArhiveDirectory.hs:79,
+        // findBlocksInBrokenArchive at ArhiveStructure.hs:96), so an archive
+        // whose footer is gone can still be read.
+        //
+        // A scan built on this port's `block::find_descriptor` produced no
+        // blocks at all, and there is no oracle to debug it against: the
+        // 9a127e6 reference's OWN -ba fails for every value, on an intact
+        // archive as well as a truncated one, with "archive directory not
+        // found". Measured on both, not assumed.
+        //
+        // A scanner that quietly returns nothing would list a GOOD archive as
+        // empty, which reads as "no files" rather than as a failure. That is
+        // the outcome refusing avoids.
+        if names.contains(&"BrokenArchive") {
+            eprintln!(
+                "ERROR: -ba is not implemented: reading an archive by scanning \
+                 for block descriptors, rather than through its footer, is a \
+                 feature this port does not have. Repair the archive with the \
+                 `r` command instead."
+            );
+            std::process::exit(2);
+        }
         eprintln!(
             "ERROR: this port does not implement {} yet, and ignoring it would \
              write an archive that is not what you asked for",
@@ -522,6 +546,10 @@ fn main() {
 
     let path = std::path::Path::new(&archive_name);
     // Only the read commands need an existing archive; `a` creates one.
+    // `-ba`/`--BrokenArchive` (ArhiveDirectory.hs:79): anything other than
+    // the default "-" reads the block list by SCANNING for descriptors rather
+    // than following the footer, so an archive whose footer is gone can still
+    // be listed and extracted. `-ba` bare is "0" (Cmdline.hs:128).
     let open_existing = || match archive::read_info(path, &pw) {
         Ok(i) => i,
         Err(e) => {

--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -228,7 +228,7 @@ fn main() {
         "recovery", "volume", "sfx", "noarcext", "charset", "original", "overwrite",
         "keepbroken", "keeptime", "timetolast", "test", "autogenerate",
         "pause-before-exit", "queue", "pretest", "logfile", "proxy", "bypass",
-        "type", "dirmethod", "adddir", "nodata", "crconly", "LimitDecompMem",
+        "type", "dirmethod", "adddir", "nodata", "crconly", "LimitDecompMem", "nodir",
         // Accepted and deliberately ignored: UI only.
         "yes", "indicator", "display",
         // Accepted and deliberately ignored: these change SPEED or a Windows
@@ -1731,7 +1731,12 @@ fn add(
             }
         },
     }
-    w.write_header();
+    // `--nodir` suppresses every service block, the archive header included:
+    // the reference's output carries no `ArC` signature at all.
+    let nodir = parsed.flag("nodir");
+    if !nodir {
+        w.write_header();
+    }
 
     // `dirs &&& [(aNO_COMPRESSION, dirs)]` (ArhiveFileList.hs:291): the
     // directories block exists only when there ARE directories. Writing an
@@ -1941,7 +1946,13 @@ fn add(
     let mut entries = dir_entries;
     entries.extend(kept_entries);
     entries.extend(file_entries);
-    w.write_directory(&data_blocks, &entries);
+    // Under `--nodir` the directory is a service block like any other, so it
+    // is not written either -- its PAYLOAD would otherwise still land in the
+    // output even with the header and footer suppressed, which is exactly what
+    // made the first attempt ~120 bytes too long.
+    if !nodir {
+        w.write_directory(&data_blocks, &entries);
+    }
 
     // `-tl`/`--timetolast` (ArcCreate.hs:170): stamp the finished archive with
     // the mtime of the newest file IN it, so the archive is never older than
@@ -2061,7 +2072,12 @@ fn add(
     }
     // The recommendation depends on the archive's size, which is not known
     // until the blocks are written; `finish` is where it lands.
-    let bytes = match darc_arc::recovery::resolve(rr_option, &old_recovery, 0).is_empty()
+    //
+    // `--nodir` stops short of all of it: no footer means no recovery record
+    // either, because a recovery block IS a service block.
+    let bytes = match nodir {
+        true => w.into_data_only(),
+        false => match darc_arc::recovery::resolve(rr_option, &old_recovery, 0).is_empty()
         && rr_option != ""
         && rr_option != "+"
     {
@@ -2093,7 +2109,7 @@ fn add(
                 }
             }
         }
-    };
+    }};
 
     // `-tk`/`--keeptime` (ArcCreate.hs:168) restores the archive's OWN mtime
     // after an update, so refreshing an archive does not make it look new.

--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -228,7 +228,7 @@ fn main() {
         "recovery", "volume", "sfx", "noarcext", "charset", "original", "overwrite",
         "keepbroken", "keeptime", "timetolast", "test", "autogenerate",
         "pause-before-exit", "queue", "pretest", "logfile", "proxy", "bypass",
-        "type", "dirmethod", "adddir",
+        "type", "dirmethod", "adddir", "nodata", "crconly",
         // Accepted and deliberately ignored: UI only.
         "yes", "indicator", "display",
         // Accepted and deliberately ignored: these change SPEED or a Windows
@@ -851,15 +851,28 @@ fn add(
     // `(mainMethod ||| aDEFAULT_COMPRESSOR) ++ userMethods` (Cmdline.hs:334):
     // the per-type suffixes are appended to the main method, and the whole
     // string is what decode_method expands.
-    let method = format!(
-        "{}{}",
-        match mopts.method.is_empty() {
-            true => "4",
-            false => &mopts.method,
-        },
-        mopts.methods
-    );
+    //
+    // `--nodata` and `--crconly` REPLACE the whole compressor (Cmdline.hs:332),
+    // per-type suffixes included; nodata wins, which is the guard order there.
+    // Measured on the reference: `--nodata` is byte-identically `-mfake` and
+    // `--crconly` is `-mcrc`.
+    let method = match (parsed.flag("nodata"), parsed.flag("crconly")) {
+        (true, _) => "fake".to_string(),
+        (_, true) => "crc".to_string(),
+        _ => format!(
+            "{}{}",
+            match mopts.method.is_empty() {
+                true => "4",
+                false => &mopts.method,
+            },
+            mopts.methods
+        ),
+    };
     let decoded = darc_arc::methodtable::decode_method(&method);
+    // Only `fake` zeroes the CRC; `crc` is the whole point of recording one.
+    let zero_crc = decoded
+        .iter()
+        .all(|(_, ch)| ch.len() == 1 && ch[0].split(':').next() == Some("fake"));
     if decoded.is_empty() {
         eprintln!("ERROR: -m{method} expanded to nothing");
         return 2;
@@ -1249,7 +1262,14 @@ fn add(
             size: body.len() as u64,
             time,
             is_dir: false,
-            crc: crc::calc(&body),
+            // `fake` does not READ the files (ArcvProcessRead.hs:139), so its
+            // entries carry a zero CRC; `crc` reads them and records the real
+            // one. Both store no data. Verified against the reference: -mfake
+            // lists every file with 00000000, -mcrc with its true CRC32.
+            crc: match zero_crc {
+                true => 0,
+                false => crc::calc(&body),
+            },
             block: 0,
             pos_in_block: 0,
         });

--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -2010,10 +2010,33 @@ fn add(
                 _ => None,
             })
             .collect();
+        // A block that carries encryption cannot be copied VERBATIM when the
+        // output is encrypted differently: its bytes are ciphertext under the
+        // old key, and copying them leaves the archive readable with the OLD
+        // password however the new one was spelled.
+        //
+        // The reference has this bug -- measured, `ch -opOLD -pNEW` exits 0
+        // there and the archive still opens with OLD -- and this port
+        // reproduced it faithfully. Fixed here deliberately, so the port
+        // writes DIFFERENT bytes than the reference for that one command line.
+        // The result is an ordinary archive any DArc can read; the
+        // reference's is one the user did not ask for.
+        let src_encrypted = src.compressor.iter().any(|m| darc_arc::block::is_encryption(m));
+        // `-p-` explicitly DROPS encryption, and is the same bug in the other
+        // direction: the reference exits 0 and leaves the archive encrypted.
+        // Read from the raw option because Passwords cannot tell "-p-" from
+        // "no -p at all" -- `dont_ask_passwords` is set by `-op-` as well.
+        //
+        // `ch -opOLD` with no -p is NOT this: keeping the encryption a plain
+        // copy already had is the right answer there.
+        let drop_encryption = parsed.all("password").contains(&"-");
+        let reencrypting = src_encrypted && (!pw.data.is_empty() || drop_encryption);
+
         let whole = positions.len() == group.len()
             && positions.first() == Some(&0)
             && src.files == Some(group.len())
-            && positions.windows(2).all(|w| w[0] <= w[1]);
+            && positions.windows(2).all(|w| w[0] <= w[1])
+            && !reencrypting;
 
         let block = match whole {
             true => {
@@ -2054,7 +2077,16 @@ fn add(
                     }
                     kept_entries.push(e);
                 }
-                let original = src.compressor.join("+");
+                // The stale encryption is STRIPPED: write_compressed_data
+                // appends the output's own, and leaving the old one here
+                // would encrypt the block twice.
+                let original = src
+                    .compressor
+                    .iter()
+                    .filter(|m| !darc_arc::block::is_encryption(m))
+                    .cloned()
+                    .collect::<Vec<String>>()
+                    .join("+");
                 let fitted = match darc_arc::memlimit::fit_for_add_limits(&original, body.len() as u64, climit, dlimit) {
                     Some(f) => f,
                     None => {

--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -317,7 +317,7 @@ fn main() {
         "recovery", "volume", "sfx", "noarcext", "charset", "original", "overwrite",
         "keepbroken", "keeptime", "timetolast", "test", "autogenerate",
         "pause-before-exit", "queue", "pretest", "logfile", "proxy", "bypass",
-        "type", "dirmethod", "adddir", "nodata", "crconly", "LimitDecompMem", "nodir", "LimitCompMem", "sort", "config", "env",
+        "type", "dirmethod", "adddir", "nodata", "crconly", "LimitDecompMem", "nodir", "LimitCompMem", "sort", "config", "env", "workdir", "create-in-workdir",
         // Accepted and deliberately ignored: UI only.
         "yes", "indicator", "display",
         // Accepted and deliberately ignored: these change SPEED or a Windows
@@ -2311,11 +2311,72 @@ fn add(
         true => std::fs::metadata(archive_name).and_then(|m| m.modified()).ok(),
     };
 
-    match std::fs::write(archive_name, &bytes) {
+    // `tempfileWrapper` (ArcCreate.hs:185): the archive is written to
+    // `$$temparc$$<n>.tmp` and only then renamed into place. Not
+    // archive-visible -- the bytes are the same either way -- but an
+    // interrupted run now leaves the temporary file rather than a TRUNCATED
+    // archive under the real name, which is the actual point.
+    //
+    // The directory is `-w` if given, else the archive's own. `%VAR` reads an
+    // environment variable, and `--create-in-workdir` with no -w means
+    // $TMPDIR, then $TEMP, then /tmp (Cmdline.hs:623-628).
+    let workdir: String = match parsed.arg("workdir", "--") {
+        "--" => match parsed.flag("create-in-workdir") {
+            false => String::new(),
+            true => std::env::var("TMPDIR")
+                .or_else(|_| std::env::var("TEMP"))
+                .unwrap_or_else(|_| "/tmp".to_string()),
+        },
+        v => match v.strip_prefix('%') {
+            Some(var) => std::env::var(var).unwrap_or_default(),
+            None => v.to_string(),
+        },
+    };
+    let temp_dir = match workdir.is_empty() {
+        true => std::path::Path::new(archive_name)
+            .parent()
+            .map(std::path::Path::to_path_buf)
+            .unwrap_or_default(),
+        false => std::path::PathBuf::from(&workdir),
+    };
+    // `find 0`: the first free `$$temparc$$<n>.tmp`, giving up at 999 rather
+    // than looping.
+    let mut temp_path = None;
+    for n in 0..1000 {
+        let p = temp_dir.join(format!("$$temparc$${n}.tmp"));
+        if !p.exists() {
+            temp_path = Some(p);
+            break;
+        }
+    }
+    let temp_path = match temp_path {
+        Some(p) => p,
+        None => {
+            eprintln!("ERROR: can't create temporary file in {}", temp_dir.display());
+            return 2;
+        }
+    };
+    match std::fs::write(&temp_path, &bytes) {
         Ok(()) => {}
         Err(e) => {
-            eprintln!("ERROR: {archive_name}: {e}");
+            eprintln!("ERROR: {}: {e}", temp_path.display());
             return 2;
+        }
+    }
+    // `fileRename tempname filename`, falling back to a copy when the rename
+    // fails -- which is what happens when -w names a different filesystem.
+    match std::fs::rename(&temp_path, archive_name) {
+        Ok(()) => {}
+        Err(_) => {
+            println!("Copying temporary archive {} to {archive_name}", temp_path.display());
+            match std::fs::copy(&temp_path, archive_name) {
+                Ok(_) => drop(std::fs::remove_file(&temp_path)),
+                Err(e) => {
+                    eprintln!("ERROR: {archive_name}: {e}");
+                    drop(std::fs::remove_file(&temp_path));
+                    return 2;
+                }
+            }
         }
     }
 

--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -1029,17 +1029,25 @@ fn add(
     // capped RAM figure, which on any machine with 4 GiB or more is 3 GiB --
     // large enough that it does not bind for the chains DArc ships, which is
     // why the port wrote byte-identical archives before this existed.
+    // physical_memory() is 0 when the figure is unavailable, which is every
+    // platform but macOS and Linux. Zero must mean NO LIMIT here: taken
+    // literally it shrank every chain, and the Windows builds then wrote
+    // different archives from the Linux one on all 14 interop methods.
+    let ram = darc_arc::memlimit::physical_memory();
     let climit: u64 = match parsed.arg("LimitCompMem", "--") {
-        "--" => darc_arc::memlimit::parse_mem_with_percents(
-            darc_arc::memlimit::physical_memory(),
-            "75%",
-        )
-        .unwrap_or(u64::MAX),
+        "--" | "-" if ram == 0 => u64::MAX,
+        "--" => darc_arc::memlimit::parse_mem_with_percents(ram, "75%").unwrap_or(u64::MAX),
         "-" => u64::MAX,
-        s => match darc_arc::memlimit::parse_mem_with_percents(
-            darc_arc::memlimit::physical_memory(),
-            s,
-        ) {
+        // An explicit percentage of an unknown quantity is refused rather than
+        // silently ignored -- the user asked for a limit and would not get one.
+        s if (s.ends_with('%') || s.ends_with('p')) && ram == 0 => {
+            eprintln!(
+                "ERROR: -lc{s}: this platform does not report physical memory, \
+                 so a percentage cannot be resolved. Give an explicit size."
+            );
+            return 2;
+        }
+        s => match darc_arc::memlimit::parse_mem_with_percents(ram, s) {
             Some(v) => v,
             None => {
                 eprintln!("ERROR: -lc{s}: not a memory size (N, Nb, Nk, Nm, Ng, N%)");
@@ -1051,10 +1059,14 @@ fn add(
     let dlimit: u64 = match parsed.arg("LimitDecompMem", "--") {
         "--" => darc_arc::memlimit::ADD_DECOMPRESSION_LIMIT,
         "-" => u64::MAX,
-        s => match darc_arc::memlimit::parse_mem_with_percents(
-            darc_arc::memlimit::physical_memory(),
-            s,
-        ) {
+        s if (s.ends_with('%') || s.ends_with('p')) && ram == 0 => {
+            eprintln!(
+                "ERROR: -ld{s}: this platform does not report physical memory, \
+                 so a percentage cannot be resolved. Give an explicit size."
+            );
+            return 2;
+        }
+        s => match darc_arc::memlimit::parse_mem_with_percents(ram, s) {
             Some(v) => v,
             None => {
                 eprintln!("ERROR: -ld{s}: not a memory size (N, Nb, Nk, Nm, Ng, N%)");

--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -168,6 +168,16 @@ fn main() {
         },
     };
 
+    // `--type` (Cmdline.hs:515): `arc` is the only archive format there is, and
+    // anything else is refused. The message is the reference's own, verbatim,
+    // because `-t` resolves HERE rather than to `--test` and a user who typed
+    // `-tk` meaning `--keeptime` gets this and should be able to search for it.
+    let archive_type = parsed.arg("type", "arc");
+    if archive_type != "arc" {
+        eprintln!("ERROR: --type={archive_type}: only arc format is supported");
+        std::process::exit(2);
+    }
+
     // `--pretest` (Cmdline.hs:127): the value defaults to "1", and `-` `+` and
     // an empty value are spellings of 0, 2 and 2.
     let pretest: i32 = match parsed.arg("pretest", "1") {
@@ -218,6 +228,7 @@ fn main() {
         "recovery", "volume", "sfx", "noarcext", "charset", "original", "overwrite",
         "keepbroken", "keeptime", "timetolast", "test", "autogenerate",
         "pause-before-exit", "queue", "pretest", "logfile", "proxy", "bypass",
+        "type", "dirmethod",
         // Accepted and deliberately ignored: UI only.
         "yes", "indicator", "display",
         // Accepted and deliberately ignored: these change SPEED or a Windows
@@ -1551,15 +1562,36 @@ fn add(
         pw.data.clone(),
         pw.headers.clone(),
     );
-    // `defaultDirCompressor = thd3 grouping ||| aDEFAULT_DIR_COMPRESSION`
-    // (Cmdline.hs:117): three of the -s presets force an UNCOMPRESSED
-    // directory, which is archive-visible.
-    if !solid.dir_method.is_empty() {
-        let decoded = darc_arc::methodtable::decode_method(&solid.dir_method);
+    // `orig_dir_compressor = findReqArg o "dirmethod" defaultDirCompressor`
+    // (Cmdline.hs:118), where `defaultDirCompressor = thd3 grouping |||
+    // aDEFAULT_DIR_COMPRESSION` (:117): three of the -s presets force an
+    // UNCOMPRESSED directory, and -dm REPLACES whatever the preset chose. All
+    // of this is archive-visible -- measured on the reference, `-dm0`,
+    // `-dmlzma` and `-dmtor` each produce a different archive.
+    let dir_method = match parsed.arg("dirmethod", "") {
+        "" => solid.dir_method.clone(),
+        m => m.to_string(),
+    };
+    if !dir_method.is_empty() {
+        let decoded = darc_arc::methodtable::decode_method(&dir_method);
         match decoded.first() {
-            Some((_, chain)) => w.set_dir_compressor(chain.clone()),
+            // The LAST method of the chain, not the whole chain. Measured
+            // against the reference: `-dm4` decodes to
+            // `rep:96mb+exe+delta+4x4:b16mb:lzma:...` and the reference writes
+            // the directory with `4x4:b16mb:lzma:...` alone -- the
+            // preprocessing filters are dropped, which is sensible on a small
+            // structured block and is not something the chain itself says.
+            // Named methods were unaffected because their chains are one
+            // element long, which is exactly why this went unnoticed.
+            Some((_, chain)) => match chain.last() {
+                Some(last) => w.set_dir_compressor(vec![last.clone()]),
+                None => {
+                    eprintln!("ERROR: -dm{dir_method}: expanded to an empty chain");
+                    return 2;
+                }
+            },
             None => {
-                eprintln!("ERROR: -dm{}: expanded to nothing", solid.dir_method);
+                eprintln!("ERROR: -dm{dir_method}: expanded to nothing");
                 return 2;
             }
         }

--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -114,8 +114,32 @@ fn main() {
             false => format!("{name}.arc"),
         }
     };
+    // `-ag`/`--autogenerate` (Cmdline.hs:180-182): append a timestamp to the
+    // archive's BASE name, before the extension is added, so `-ag x.arc`
+    // becomes `x20260804123000.arc` rather than `x.arc20260804…`. The default
+    // format is the one at Cmdline.hs:122.
+    let add_ag = |name: &str| -> String {
+        match parsed.arg("autogenerate", "--") {
+            "--" => name.to_string(),
+            f => {
+                let fmt = match f.is_empty() {
+                    true => "%Y%m%d%H%M%S",
+                    false => f,
+                };
+                let stamp = strftime_local(fmt, now_unix());
+                match name.rfind('.') {
+                    // Only a REAL extension is split around; a dot in a
+                    // directory component is not one.
+                    Some(i) if !name[i..].contains(['/', '\\']) => {
+                        format!("{}{stamp}{}", &name[..i], &name[i..])
+                    }
+                    _ => format!("{name}{stamp}"),
+                }
+            }
+        }
+    };
     let archive_name = match parsed.free.first() {
-        Some(a) => add_arc_ext(a),
+        Some(a) => add_arc_ext(&add_ag(a)),
         None if command == "canonize" || command == "fit" || command == "types" => {
             String::new()
         }
@@ -123,6 +147,25 @@ fn main() {
             eprintln!("ERROR: no archive name given");
             std::process::exit(2);
         }
+    };
+
+    // `--queue` (Arc.hs:80): serialise with other darc processes through an
+    // advisory lock, so two runs do not compete for the whole machine's memory
+    // and CPU. Held for the life of the process — the guard is bound here and
+    // dropped when main returns.
+    //
+    // flock, not a lockfile's existence: a process killed while holding it
+    // releases it, where a stale file would block every later run until someone
+    // deleted it by hand.
+    let queue_guard = match parsed.flag("queue") {
+        false => None,
+        true => match queue_acquire() {
+            Ok(f) => Some(f),
+            Err(e) => {
+                eprintln!("ERROR: --queue: {e}");
+                std::process::exit(2);
+            }
+        },
     };
 
     // `dir_exclude_path` (Cmdline.hs:137): 0 for the `e` command, otherwise the
@@ -159,9 +202,18 @@ fn main() {
         "update", "include", "exclude", "dirs", "nodirs",
         "SizeMore", "SizeLess", "TimeBefore", "TimeAfter", "TimeNewer", "TimeOlder",
         "recovery", "volume", "sfx", "noarcext", "charset", "original", "overwrite",
-        "keepbroken", "keeptime", "timetolast", "test",
+        "keepbroken", "keeptime", "timetolast", "test", "autogenerate",
+        "pause-before-exit", "queue",
         // Accepted and deliberately ignored: UI only.
         "yes", "indicator", "display",
+        // Accepted and deliberately ignored: these change SPEED or a Windows
+        // file attribute, never a byte of the archive nor which files go in
+        // it, so honouring them by doing nothing is honest rather than a
+        // silent no-op. --cache sizes a read-ahead buffer this port does not
+        // have (it builds the archive in memory); -ac/-ao are the Windows
+        // Archive attribute, which does not exist on the platforms this is
+        // gated on.
+        "cache", "ClearArchiveBit", "SelectArchiveBit",
     ];
     let unimplemented: Vec<&str> = parsed
         .options
@@ -542,6 +594,32 @@ fn main() {
             2
         }
     };
+
+    // `--pause-before-exit` (Cmdline.hs:699). The reference's values are
+    // `on`/`off`/`on-error`/`on-warning`; anything that is not "off" and does
+    // not restrict itself to failures pauses always.
+    //
+    // Skipped when stdin is not a terminal: a pause nobody can end would turn
+    // every scripted run into a hang, which is a worse failure than not
+    // pausing.
+    // Held until here, then released explicitly so the next queued process
+    // starts as soon as this one is finished rather than mid-teardown.
+    drop(queue_guard);
+
+    let pause = parsed.arg("pause-before-exit", "off");
+    let want_pause = match pause {
+        "off" | "" => false,
+        "on-error" => code != 0,
+        "on-warning" => code != 0,
+        _ => true,
+    };
+    if want_pause && std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+        print!("Press Enter to exit...");
+        drop(std::io::Write::flush(&mut std::io::stdout()));
+        let mut line = String::new();
+        drop(std::io::BufRead::read_line(&mut std::io::stdin().lock(), &mut line));
+    }
+
     std::process::exit(code);
 }
 
@@ -2222,6 +2300,88 @@ fn list(command: &str, info: &archive::ArchiveInfo, entries: &[Entry]) -> i32 {
 ///
 /// Testing and extracting differ only in what happens after the CRC check, so
 /// they share the loop rather than duplicating the block handling.
+/// Take the `--queue` advisory lock, blocking until it is ours.
+///
+/// The file lives next to the temp directory rather than in the archive's
+/// directory: the point is to serialise this MACHINE's darc processes, and two
+/// runs on different archives still compete for the same memory and cores.
+///
+/// The returned handle owns the lock; dropping it releases it. On a platform
+/// without `flock` this returns the open file and no lock, which serialises
+/// nothing but also blocks nothing — the option is a courtesy, not a
+/// correctness mechanism, and failing the whole run would be worse.
+#[cfg(unix)]
+fn queue_acquire() -> std::io::Result<std::fs::File> {
+    use std::os::unix::io::AsRawFd;
+    let path = std::env::temp_dir().join("darc.queue.lock");
+    let f = std::fs::OpenOptions::new().create(true).write(true).truncate(false).open(&path)?;
+    extern "C" {
+        fn flock(fd: i32, operation: i32) -> i32;
+    }
+    const LOCK_EX: i32 = 2;
+    // SAFETY: the fd is owned by `f` and outlives the call.
+    match unsafe { flock(f.as_raw_fd(), LOCK_EX) } {
+        0 => Ok(f),
+        _ => Err(std::io::Error::last_os_error()),
+    }
+}
+
+#[cfg(not(unix))]
+fn queue_acquire() -> std::io::Result<std::fs::File> {
+    let path = std::env::temp_dir().join("darc.queue.lock");
+    std::fs::OpenOptions::new().create(true).write(true).truncate(false).open(&path)
+}
+
+/// Seconds since the Unix epoch, or 0 if the clock is before it.
+fn now_unix() -> i64 {
+    match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+        Ok(d) => d.as_secs() as i64,
+        Err(_) => 0,
+    }
+}
+
+/// The `strftime` subset `-ag` needs, in LOCAL time.
+///
+/// Not a crate: `chrono` would be a new dependency for eight conversions, and
+/// a dependency here is a licence question. The specifiers are the ones a
+/// filename can actually use — anything that would introduce a `/` or a space
+/// is deliberately absent, because the result becomes part of a path.
+///
+/// An unknown specifier is left verbatim, `%` and all, rather than silently
+/// dropped: a name that quietly loses part of its stamp can collide with
+/// another run's.
+fn strftime_local(fmt: &str, unix: i64) -> String {
+    let local = unix + local_offset_seconds();
+    let days = local.div_euclid(86_400);
+    let tod = local.rem_euclid(86_400);
+    let (y, mo, d) = civil_from_days(days);
+    let (h, mi, s) = (tod / 3600, (tod % 3600) / 60, tod % 60);
+    let mut out = String::new();
+    let mut it = fmt.chars();
+    while let Some(c) = it.next() {
+        if c != '%' {
+            out.push(c);
+            continue;
+        }
+        match it.next() {
+            Some('Y') => out.push_str(&format!("{y:04}")),
+            Some('y') => out.push_str(&format!("{:02}", y.rem_euclid(100))),
+            Some('m') => out.push_str(&format!("{mo:02}")),
+            Some('d') => out.push_str(&format!("{d:02}")),
+            Some('H') => out.push_str(&format!("{h:02}")),
+            Some('M') => out.push_str(&format!("{mi:02}")),
+            Some('S') => out.push_str(&format!("{s:02}")),
+            Some('%') => out.push('%'),
+            Some(other) => {
+                out.push('%');
+                out.push(other);
+            }
+            None => out.push('%'),
+        }
+    }
+    out
+}
+
 /// Set a file's mtime, leaving its atime alone.
 ///
 /// `std::fs::FileTimes` rather than a crate: this is the whole of what the
@@ -3173,6 +3333,22 @@ mod tests {
         // A BARE -op is the mode `p`, not a password: is_op_option needs at
         // least one character after the p.
         assert!(matches!(mode_of(&["-op"]), Ok(Overwrite::Ask)));
+    }
+
+    /// The `-ag` stamp. Fixed instant, so the assertion is on the FORMAT and
+    /// not on the clock: 2026-08-04 06:57:44 UTC.
+    #[test]
+    fn strftime_covers_what_a_filename_can_use() {
+        // Compared against UTC by cancelling the local offset out, so the test
+        // does not depend on the machine the suite runs on.
+        let t = 1_785_826_664 - local_offset_seconds();
+        assert_eq!(strftime_local("%Y%m%d%H%M%S", t), "20260804065744");
+        assert_eq!(strftime_local("%Y-%m-%d", t), "2026-08-04");
+        assert_eq!(strftime_local("%y", t), "26");
+        // A literal percent, and an unknown specifier kept verbatim rather
+        // than dropped -- a name that loses part of its stamp can collide.
+        assert_eq!(strftime_local("%%%q", t), "%%q");
+        assert_eq!(strftime_local("plain", t), "plain");
     }
 
     /// Anything outside `+ - p` is refused rather than silently treated as the

--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -228,7 +228,7 @@ fn main() {
         "recovery", "volume", "sfx", "noarcext", "charset", "original", "overwrite",
         "keepbroken", "keeptime", "timetolast", "test", "autogenerate",
         "pause-before-exit", "queue", "pretest", "logfile", "proxy", "bypass",
-        "type", "dirmethod", "adddir", "nodata", "crconly", "LimitDecompMem", "nodir", "LimitCompMem",
+        "type", "dirmethod", "adddir", "nodata", "crconly", "LimitDecompMem", "nodir", "LimitCompMem", "sort",
         // Accepted and deliberately ignored: UI only.
         "yes", "indicator", "display",
         // Accepted and deliberately ignored: these change SPEED or a Windows
@@ -986,7 +986,31 @@ fn add(
     // default type's chain, which is `decoded[0]`.
     let per_file = solid.data == vec![darc_arc::grouping::Grouping::None];
     let fast_main = darc_arc::method::disables_solid_sorting(&decoded[0].1);
-    let sort_order = if fast_main || per_file { "" } else { "gerpn" };
+    // `-ds`/`--sort` (Cmdline.hs:631-634) overrides both: an explicit order
+    // wins over the non-solid and fast-compressor cases, and `-ds-` disables
+    // sorting outright. Only when it is absent do the defaults apply.
+    let sort_order: &str = match parsed.arg("sort", "--") {
+        "--" => match fast_main || per_file {
+            true => "",
+            false => "gerpn",
+        },
+        "-" => "",
+        // `'c':xs` is not a key character: it PARTITIONS the list at 128 kb,
+        // sorts the small half by the remaining order and the large half by
+        // "s", then concatenates (ArhiveFileList.hs:48). This port sorts by a
+        // flat key vector, which cannot express that -- measured, `-dscn`
+        // writes a different archive than the reference. Refused rather than
+        // written wrongly.
+        x if x.contains('c') => {
+            eprintln!(
+                "ERROR: -ds{x}: the 'c' order partitions the file list at 128 kb \
+                 and sorts each half differently, which this port does not \
+                 implement; every other order is supported"
+            );
+            return 2;
+        }
+        x => x,
+    };
     let recursive = parsed.flag("recursive");
     let nodates = parsed.flag("nodates");
     // `runDelete = runArchiveAdd . setArcFilter ((not.) . fullFileFilter)`

--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -159,6 +159,7 @@ fn main() {
         "update", "include", "exclude", "dirs", "nodirs",
         "SizeMore", "SizeLess", "TimeBefore", "TimeAfter", "TimeNewer", "TimeOlder",
         "recovery", "volume", "sfx", "noarcext", "charset", "original", "overwrite",
+        "keepbroken", "keeptime", "timetolast", "test",
         // Accepted and deliberately ignored: UI only.
         "yes", "indicator", "display",
     ];
@@ -365,7 +366,7 @@ fn main() {
                 }
                 false => std::collections::HashSet::new(),
             };
-            run_blocks(&info, &data, &layout, extracting, &pw, &selected, &skip)
+            run_blocks(&info, &data, &layout, extracting, &pw, &selected, &skip, parsed.flag("keepbroken"))
         }
         // One function: every one of these is `runArchiveAdd` with a different
         // archive filter and a different source of files (Arc.hs:122-131).
@@ -1673,6 +1674,18 @@ fn add(
     entries.extend(kept_entries);
     entries.extend(file_entries);
     w.write_directory(&data_blocks, &entries);
+
+    // `-tl`/`--timetolast` (ArcCreate.hs:170): stamp the finished archive with
+    // the mtime of the newest file IN it, so the archive is never older than
+    // its own contents. Directories are included -- `find_last_time` folds over
+    // the whole directory listing, not just the files.
+    //
+    // Captured here rather than after the write because `entries` is what was
+    // actually stored, which is not the same as what was on the command line.
+    let time_to_last: Option<i64> = match parsed.flag("timetolast") {
+        false => None,
+        true => entries.iter().map(|e| e.time).max(),
+    };
     // An archive with nothing left in it is REMOVED, not written empty.
     // Measured: `arc d a.arc "*"` leaves no file behind, because the basename
     // match takes the directories too. Writing a 161-byte archive of nothing
@@ -1814,12 +1827,44 @@ fn add(
         }
     };
 
+    // `-tk`/`--keeptime` (ArcCreate.hs:168) restores the archive's OWN mtime
+    // after an update, so refreshing an archive does not make it look new.
+    // Read before the write, because the write is what destroys it, and only
+    // when the archive already existed -- there is nothing to keep otherwise.
+    let kept_time: Option<std::time::SystemTime> = match parsed.flag("keeptime") {
+        false => None,
+        true => std::fs::metadata(archive_name).and_then(|m| m.modified()).ok(),
+    };
+
     match std::fs::write(archive_name, &bytes) {
         Ok(()) => {}
         Err(e) => {
             eprintln!("ERROR: {archive_name}: {e}");
             return 2;
         }
+    }
+
+    // The two mtime options, in the reference's order (ArcCreate.hs:168-171):
+    // -tk first, then -tl, so giving both leaves the newest-file time. Applied
+    // before the SFX rename, which carries the mtime with it.
+    match kept_time {
+        Some(t) => match set_mtime(archive_name, t) {
+            Ok(()) => {}
+            Err(e) => eprintln!("WARNING: -tk: cannot restore {archive_name}'s time: {e}"),
+        },
+        None => {}
+    }
+    match time_to_last {
+        // A negative or absurd stamp is the archive's problem, not ours;
+        // UNIX_EPOCH + a negative offset is simply refused by the conversion.
+        Some(t) if t >= 0 => {
+            let when = std::time::UNIX_EPOCH + std::time::Duration::from_secs(t as u64);
+            match set_mtime(archive_name, when) {
+                Ok(()) => {}
+                Err(e) => eprintln!("WARNING: -tl: cannot set {archive_name}'s time: {e}"),
+            }
+        }
+        _ => {}
     }
 
     // `renameArchiveAsSFX` (ArcCreate.hs:172) -- after writing, in every case,
@@ -1925,6 +1970,28 @@ fn add(
                     drop(std::fs::remove_dir(disk));
                 }
             }
+        }
+    }
+
+    // `-t`/`--test` (ArcCreate.hs:201): read the archive back and check every
+    // CRC before reporting success. Run last so it covers the finished
+    // artefact, including the SFX rename above.
+    if parsed.flag("test") {
+        println!("Testing {archive_name}");
+        let path = std::path::Path::new(archive_name);
+        let rc = match (archive::read_info(path, pw), archive::open(path)) {
+            (Ok(info), Ok(data)) => {
+                let all: Vec<Entry> = info.entries.clone();
+                let empty = std::collections::HashSet::new();
+                run_blocks(&info, &data, &Layout::default(), false, pw, &all, &empty, false)
+            }
+            (Err(e), _) | (_, Err(e)) => {
+                eprintln!("ERROR: {archive_name}: {e}");
+                2
+            }
+        };
+        if rc != 0 {
+            return rc;
         }
     }
 
@@ -2155,6 +2222,17 @@ fn list(command: &str, info: &archive::ArchiveInfo, entries: &[Entry]) -> i32 {
 ///
 /// Testing and extracting differ only in what happens after the CRC check, so
 /// they share the loop rather than duplicating the block handling.
+/// Set a file's mtime, leaving its atime alone.
+///
+/// `std::fs::FileTimes` rather than a crate: this is the whole of what the
+/// `filetime` crate would be pulled in for, and a new dependency here is a
+/// licence question (see THIRD-PARTY.md). Opening for write is required on
+/// Windows, where the handle needs write access to accept a time change.
+fn set_mtime(path: &str, when: std::time::SystemTime) -> std::io::Result<()> {
+    let f = std::fs::File::options().write(true).open(path)?;
+    f.set_times(std::fs::FileTimes::new().set_modified(when))
+}
+
 /// What `-o` says to do when the file is already on disk.
 ///
 /// `testOption "overwrite" "o" … (words "+ - p")` (`Cmdline.hs:160`): the three
@@ -2259,6 +2337,7 @@ fn run_blocks(
     pw: &darc_arc::passwords::Passwords,
     entries: &[Entry],
     skip: &std::collections::HashSet<String>,
+    keep_broken: bool,
 ) -> i32 {
     // The safety check runs on the archive's contribution alone: the
     // destination is the user's own and may be absolute.
@@ -2348,9 +2427,16 @@ fn run_blocks(
                         continue;
                     }
                 };
-                if crc::calc(bytes) != e.crc {
+                // `-kb`/`--keepbroken` (ArcExtract.hs:99): a file that failed
+                // its CRC is normally not left on disk. With -kb it is kept,
+                // and the failure is still reported -- keeping the bytes is not
+                // the same as calling them good.
+                let crc_ok = crc::calc(bytes) == e.crc;
+                if !crc_ok {
                     bad.push(format!("{}: CRC failed", e.stored_name));
-                    continue;
+                    if !keep_broken {
+                        continue;
+                    }
                 }
                 if !extracting {
                     continue;

--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -168,6 +168,20 @@ fn main() {
         },
     };
 
+    // `--pretest` (Cmdline.hs:127): the value defaults to "1", and `-` `+` and
+    // an empty value are spellings of 0, 2 and 2.
+    let pretest: i32 = match parsed.arg("pretest", "1") {
+        "-" => 0,
+        "+" | "" => 2,
+        s => match s.parse() {
+            Ok(n @ 0..=3) => n,
+            _ => {
+                eprintln!("ERROR: --pretest{s}: expected one of 0, 1, 2, 3");
+                std::process::exit(2);
+            }
+        },
+    };
+
     // `dir_exclude_path` (Cmdline.hs:137): 0 for the `e` command, otherwise the
     // -ep value, defaulting to 9.
     let ep: u32 = if command == "e" {
@@ -203,7 +217,7 @@ fn main() {
         "SizeMore", "SizeLess", "TimeBefore", "TimeAfter", "TimeNewer", "TimeOlder",
         "recovery", "volume", "sfx", "noarcext", "charset", "original", "overwrite",
         "keepbroken", "keeptime", "timetolast", "test", "autogenerate",
-        "pause-before-exit", "queue",
+        "pause-before-exit", "queue", "pretest", "logfile", "proxy", "bypass",
         // Accepted and deliberately ignored: UI only.
         "yes", "indicator", "display",
         // Accepted and deliberately ignored: these change SPEED or a Windows
@@ -347,6 +361,22 @@ fn main() {
     // The passwords, cooked once: the prompt must not appear twice, and both
     // the reader and the writer need the same answer.
     let pw = cook_passwords(&parsed, &command);
+
+    // `--pretest`: only for commands that READ an existing archive, and only
+    // once the passwords are known -- an encrypted archive cannot be scanned
+    // without them. `a` on a new archive has nothing to pretest.
+    if pretest > 0
+        && !archive_name.is_empty()
+        && std::path::Path::new(&archive_name).exists()
+        && matches!(
+            command.as_str(),
+            "t" | "x" | "e" | "l" | "v" | "lb" | "lt" | "a" | "u" | "f" | "d" | "ch" | "c"
+                | "k" | "j" | "m" | "mf"
+        )
+        && !pretest_archive(pretest, std::path::Path::new(&archive_name), &pw)
+    {
+        std::process::exit(2);
+    }
 
     let path = std::path::Path::new(&archive_name);
     // Only the read commands need an existing archive; `a` creates one.
@@ -577,7 +607,13 @@ fn main() {
         }
         // `runArchiveRecovery` (ArcRecover.hs:301) -- repair an archive using
         // its own recovery records, writing `fixed.<name>` beside it.
-        "r" => recover(path, &archive_name, parsed.arg("original", "--")),
+        "r" => recover(
+            path,
+            &archive_name,
+            parsed.arg("original", "--"),
+            parsed.arg("proxy", "--"),
+            parsed.arg("bypass", ""),
+        ),
         // `rr…` is `ch -rr…` and `s…` is `ch -sfx…` (Cmdline.hs:124, :166) --
         // the same copy path, with the setting read off the command's own
         // suffix.
@@ -602,6 +638,39 @@ fn main() {
     // Skipped when stdin is not a terminal: a pause nobody can end would turn
     // every scripted run into a hang, which is a worse failure than not
     // pausing.
+    // `--logfile` (Cmdline.hs:728): one line per run, APPENDED, so a series of
+    // scheduled backups leaves a history rather than only its last result.
+    // Written after the command has finished because the outcome is part of
+    // the record, and a failure to write the log never changes the exit code —
+    // the archiving already happened either way.
+    //
+    // WHAT IT DOES NOT CATCH, measured rather than assumed: every path that
+    // reaches this point is logged, including command failures (`t` on a
+    // damaged archive logs rc=2). Paths that `std::process::exit` earlier are
+    // not — a missing archive, an unparseable option, a refused option, and a
+    // failed --pretest. Those are precondition errors, reported on stderr, and
+    // covering them means routing every early exit through one place, which is
+    // a refactor rather than an option.
+    let logfile = parsed.arg("logfile", "");
+    if !logfile.is_empty() {
+        let line = format!(
+            "{} {} {} rc={code}\n",
+            format_time(now_unix()),
+            command,
+            match archive_name.is_empty() {
+                true => "-",
+                false => &archive_name,
+            }
+        );
+        match std::fs::OpenOptions::new().create(true).append(true).open(logfile) {
+            Ok(mut f) => match std::io::Write::write_all(&mut f, line.as_bytes()) {
+                Ok(()) => {}
+                Err(e) => eprintln!("WARNING: --logfile {logfile}: {e}"),
+            },
+            Err(e) => eprintln!("WARNING: --logfile {logfile}: {e}"),
+        }
+    }
+
     // Held until here, then released explicitly so the next queued process
     // starts as soon as this one is finished rather than mid-teardown.
     drop(queue_guard);
@@ -2300,6 +2369,66 @@ fn list(command: &str, info: &archive::ArchiveInfo, entries: &[Entry]) -> i32 {
 ///
 /// Testing and extracting differ only in what happens after the CRC check, so
 /// they share the loop rather than duplicating the block handling.
+/// `--pretest` — check an existing archive BEFORE operating on it.
+///
+/// The modes are `Options.hs:80`: 0 none, 1 recovery info only, 2 recovery or
+/// full, 3 full testing. `pretestArchive` (ArcRecover.hs:224) scans the
+/// recovery records first in every non-zero mode, and then runs a full test
+/// when the mode is 3, or when it is 2 and the archive carries no recovery
+/// information at all. An archive that fails either check stops the operation:
+/// the point is to refuse to build on damage, not to report it afterwards.
+///
+/// Returns false when the archive is damaged and the caller must stop.
+fn pretest_archive(mode: i32, path: &std::path::Path, pw: &darc_arc::passwords::Passwords) -> bool {
+    if mode <= 0 {
+        return true;
+    }
+    let data = match archive::open(path) {
+        Ok(d) => d,
+        // Unreadable is not the same as damaged, and the operation itself is
+        // about to fail on it with a better message.
+        Err(_) => return true,
+    };
+    let footer = match archive::read_footer(&data, pw) {
+        Ok((_, f)) => f,
+        Err(_) => return true,
+    };
+    // `isNothing result` is the "no recovery information" case, not an error.
+    let had_recovery = match darc_arc::recovery::scan(&footer.blocks, &data) {
+        Ok(scan) => {
+            if !scan.bad.is_empty() {
+                eprintln!(
+                    "ERROR: {}: found {} damaged sector(s); refusing to work on a broken archive",
+                    path.display(),
+                    scan.bad.len()
+                );
+                return false;
+            }
+            println!("Archive integrity OK");
+            true
+        }
+        Err(_) => false,
+    };
+    if mode != 3 && !(mode == 2 && !had_recovery) {
+        return true;
+    }
+    // The full test: every block, every CRC.
+    match (archive::read_info(path, pw), Ok::<&[u8], ()>(data.as_slice())) {
+        (Ok(info), Ok(bytes)) => {
+            let all: Vec<Entry> = info.entries.clone();
+            let empty = std::collections::HashSet::new();
+            let rc =
+                run_blocks(&info, bytes, &Layout::default(), false, pw, &all, &empty, false);
+            if rc != 0 {
+                eprintln!("ERROR: {}: failed its pretest", path.display());
+                return false;
+            }
+            true
+        }
+        _ => true,
+    }
+}
+
 /// Take the `--queue` advisory lock, blocking until it is ours.
 ///
 /// The file lives next to the temp directory rather than in the archive's
@@ -2981,12 +3110,23 @@ fn now_seconds() -> i64 {
 /// the same warning any unreadable copy produces — the reference behaves
 /// identically when built `-DFREEARC_NOURL`.
 #[cfg(feature = "url")]
-fn remote_original(url: &str) -> Option<Box<dyn darc_arc::recovery::Original>> {
-    Some(Box::new(darc_arc::fetch::Url::new(url)))
+fn remote_original(
+    url: &str,
+    proxy: &str,
+    bypass: &str,
+) -> Option<Box<dyn darc_arc::recovery::Original>> {
+    Some(Box::new(darc_arc::fetch::Url::with_proxy(url, proxy, bypass)))
 }
 
 #[cfg(not(feature = "url"))]
-fn remote_original(url: &str) -> Option<Box<dyn darc_arc::recovery::Original>> {
+fn remote_original(
+    url: &str,
+    proxy: &str,
+    bypass: &str,
+) -> Option<Box<dyn darc_arc::recovery::Original>> {
+    // Named and dropped rather than underscore-bound: the CI gate bans
+    // `let _`, and this build genuinely has nowhere to send them.
+    drop((proxy, bypass));
     eprintln!("WARNING: can't open original at {url}: built without URL support");
     None
 }
@@ -3094,7 +3234,13 @@ fn find_url(s: &str) -> Option<String> {
     }
 }
 
-fn recover(path: &std::path::Path, archive_name: &str, original: &str) -> i32 {
+fn recover(
+    path: &std::path::Path,
+    archive_name: &str,
+    original: &str,
+    proxy: &str,
+    bypass: &str,
+) -> i32 {
     // `arcname `replaceBaseName` ("fixed."++takeBaseName arcname)` -- the
     // extension is kept and the base name prefixed, so `a.arc` becomes
     // `fixed.a.arc`.
@@ -3174,7 +3320,7 @@ fn recover(path: &std::path::Path, archive_name: &str, original: &str) -> i32 {
         match original_name.is_empty() {
             true => None,
             false => match original_name.contains("://") {
-                true => remote_original(&original_name),
+                true => remote_original(&original_name, proxy, bypass),
                 false => match std::fs::read(&original_name) {
                     Ok(b) => Some(Box::new(darc_arc::recovery::Bytes(b))),
                     Err(e) => {

--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -228,7 +228,7 @@ fn main() {
         "recovery", "volume", "sfx", "noarcext", "charset", "original", "overwrite",
         "keepbroken", "keeptime", "timetolast", "test", "autogenerate",
         "pause-before-exit", "queue", "pretest", "logfile", "proxy", "bypass",
-        "type", "dirmethod", "adddir", "nodata", "crconly",
+        "type", "dirmethod", "adddir", "nodata", "crconly", "LimitDecompMem",
         // Accepted and deliberately ignored: UI only.
         "yes", "indicator", "display",
         // Accepted and deliberately ignored: these change SPEED or a Windows
@@ -868,6 +868,41 @@ fn add(
             mopts.methods
         ),
     };
+    // `-ld`/`--LimitDecompMem` (Cmdline.hs:299-303). Not given is `1gb` for an
+    // ADD command and `75%` of RAM otherwise; `-` is unlimited; anything else
+    // is a size or a percentage. Archive-visible -- it is what reduces -m9's
+    // `ppmd:25:2047m` to `ppmd:22:1gb`.
+    let dlimit: u64 = match parsed.arg("LimitDecompMem", "--") {
+        "--" => darc_arc::memlimit::ADD_DECOMPRESSION_LIMIT,
+        "-" => u64::MAX,
+        // A percentage is REFUSED, not approximated. Measured: `-ld10%` on
+        // this machine writes an archive one byte different from the
+        // reference's, so the RAM figure or its rounding does not yet match
+        // `getPhysicalMemory `roundTo` (4*mb)` (Cmdline.hs:230). Every other
+        // spelling is byte-identical. Shipping the percentage would mean
+        // writing a DIFFERENT archive than the reference for a documented
+        // option, which is the one failure mode this project cannot absorb.
+        s if s.ends_with('%') || s.ends_with('p') => {
+            eprintln!(
+                "ERROR: -ld{s}: percentage limits are not implemented -- this \
+                 port's physical-memory figure does not yet match the \
+                 reference's, and guessing it would write a different archive. \
+                 Give an explicit size instead, e.g. -ld1gb."
+            );
+            return 2;
+        }
+        s => match darc_arc::memlimit::parse_mem_with_percents(
+            darc_arc::memlimit::physical_memory(),
+            s,
+        ) {
+            Some(v) => v,
+            None => {
+                eprintln!("ERROR: -ld{s}: not a memory size (N, Nb, Nk, Nm, Ng, N%)");
+                return 2;
+            }
+        },
+    };
+
     let decoded = darc_arc::methodtable::decode_method(&method);
     // Only `fake` zeroes the CRC; `crc` is the whole point of recording one.
     let zero_crc = decoded
@@ -1795,7 +1830,7 @@ fn add(
                     kept_entries.push(e);
                 }
                 let original = src.compressor.join("+");
-                let fitted = match darc_arc::memlimit::fit_for_add(&original, body.len() as u64) {
+                let fitted = match darc_arc::memlimit::fit_for_add_limited(&original, body.len() as u64, dlimit) {
                     Some(f) => f,
                     None => {
                         eprintln!("ERROR: cannot fit {original} to {} bytes", body.len());
@@ -1881,7 +1916,7 @@ fn add(
                 reordered.push(e);
             }
             at += len;
-            let fitted = match darc_arc::memlimit::fit_for_add(chain, body.len() as u64) {
+            let fitted = match darc_arc::memlimit::fit_for_add_limited(chain, body.len() as u64, dlimit) {
                 Some(f) => f,
                 None => {
                     eprintln!("ERROR: cannot fit {chain} to {} bytes", body.len());

--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -317,7 +317,7 @@ fn main() {
         "recovery", "volume", "sfx", "noarcext", "charset", "original", "overwrite",
         "keepbroken", "keeptime", "timetolast", "test", "autogenerate",
         "pause-before-exit", "queue", "pretest", "logfile", "proxy", "bypass",
-        "type", "dirmethod", "adddir", "nodata", "crconly", "LimitDecompMem", "nodir", "LimitCompMem", "sort", "config", "env", "workdir", "create-in-workdir", "save-bad-ranges",
+        "type", "dirmethod", "adddir", "nodata", "crconly", "LimitDecompMem", "nodir", "LimitCompMem", "sort", "config", "env", "workdir", "create-in-workdir", "save-bad-ranges", "BrokenArchive",
         // Accepted and deliberately ignored: UI only.
         "yes", "indicator", "display",
         // Accepted and deliberately ignored: these change SPEED or a Windows
@@ -380,30 +380,6 @@ fn main() {
                 }
                 std::process::exit(2);
             }
-        }
-        // -ba is refused rather than half-implemented, and the reason is
-        // worth stating: it reads the block list by SCANNING for descriptors
-        // instead of following the footer (ArhiveDirectory.hs:79,
-        // findBlocksInBrokenArchive at ArhiveStructure.hs:96), so an archive
-        // whose footer is gone can still be read.
-        //
-        // A scan built on this port's `block::find_descriptor` produced no
-        // blocks at all, and there is no oracle to debug it against: the
-        // 9a127e6 reference's OWN -ba fails for every value, on an intact
-        // archive as well as a truncated one, with "archive directory not
-        // found". Measured on both, not assumed.
-        //
-        // A scanner that quietly returns nothing would list a GOOD archive as
-        // empty, which reads as "no files" rather than as a failure. That is
-        // the outcome refusing avoids.
-        if names.contains(&"BrokenArchive") {
-            eprintln!(
-                "ERROR: -ba is not implemented: reading an archive by scanning \
-                 for block descriptors, rather than through its footer, is a \
-                 feature this port does not have. Repair the archive with the \
-                 `r` command instead."
-            );
-            std::process::exit(2);
         }
         eprintln!(
             "ERROR: this port does not implement {} yet, and ignoring it would \
@@ -550,7 +526,23 @@ fn main() {
     // the default "-" reads the block list by SCANNING for descriptors rather
     // than following the footer, so an archive whose footer is gone can still
     // be listed and extracted. `-ba` bare is "0" (Cmdline.hs:128).
-    let open_existing = || match archive::read_info(path, &pw) {
+    // `findReqArg o "BrokenArchive" "-" ||| "0"` (Cmdline.hs:128): absent is
+    // "-", a BARE -ba is the empty string and becomes "0". The value is only
+    // ever tested against "-" (ArhiveDirectory.hs:79), so 0 and 1 behave
+    // identically -- the option is on or off -- but the other values are still
+    // refused, as `testOption` refuses them.
+    let broken = match parsed.arg("BrokenArchive", "-") {
+        "" => "0",
+        v => v,
+    };
+    if !matches!(broken, "-" | "0" | "1") {
+        eprintln!("ERROR: -ba{broken}: expected one of -, 0, 1");
+        std::process::exit(2);
+    }
+    let open_existing = || match match broken {
+        "-" => archive::read_info(path, &pw),
+        _ => archive::read_info_broken(path, &pw),
+    } {
         Ok(i) => i,
         Err(e) => {
             eprintln!("ERROR: {e}");

--- a/rust/darc-arc/src/canonize.rs
+++ b/rust/darc-arc/src/canonize.rs
@@ -60,6 +60,8 @@ fn match_finder_name(id: u32) -> &'static str {
 pub fn show(method: &Method) -> String {
     match method {
         Method::Storing => "storing".to_string(),
+        Method::Fake => "fake".to_string(),
+        Method::Crc => "crc".to_string(),
         Method::Lzma(p) => show_lzma(p),
         Method::Ppmd(p) => show_ppmd(p),
         Method::Delta(p) => show_delta("delta", p),

--- a/rust/darc-arc/src/config.rs
+++ b/rust/darc-arc/src/config.rs
@@ -1,0 +1,170 @@
+//! `arc.ini` and `$FREEARC` — the default options every command starts with.
+//!
+//! This is not a convenience feature. `Cmdline.hs:49-102` reads the config file
+//! and the environment variable BEFORE parsing the command line and prepends
+//! what it finds, so a machine with `-mx` in its `arc.ini` gets a different
+//! archive from the same command line. A port that ignores them writes
+//! different bytes than the reference and says nothing about it.
+//!
+//! Order is `config_1st_line ++ [Default options] ++ $FREEARC ++ argv`
+//! (`Cmdline.hs:102`). The user's own arguments come LAST, so for every
+//! last-wins option they override the defaults.
+//!
+//! # What is read, and what is not
+//!
+//! Only the default-options parts. `arc.ini` also carries a
+//! `[Compression methods]` section that defines the method table itself, and
+//! `[External compressor:…]` sections; neither is applied here — the port's
+//! method table is built in, and it was derived from that very section. A
+//! config whose method table has been EDITED would therefore be ignored, which
+//! is why [`Config::has_unapplied_sections`] exists to warn rather than let it
+//! pass silently.
+
+/// The file name searched for beside the executable (`Options.hs:407`).
+pub const CONFIG_FILE: &str = "arc.ini";
+
+/// The environment variable holding default options (`Options.hs:410`).
+pub const CONFIG_ENV_VAR: &str = "FREEARC";
+
+/// A parsed `arc.ini`.
+pub struct Config {
+    /// Significant lines: trimmed, with blanks and `;` comments dropped.
+    lines: Vec<String>,
+}
+
+impl Config {
+    /// `parseFile1 'i' cfgfile >>== map trim >>== deleteIfs [null, match ";*"]`
+    /// (`Cmdline.hs:65`).
+    pub fn parse(text: &str) -> Config {
+        Config {
+            lines: text
+                .lines()
+                .map(|l| l.trim().to_string())
+                .filter(|l| !l.is_empty() && !l.starts_with(';'))
+                .collect(),
+        }
+    }
+
+    /// `configFilePlaces` (`Files.hs:224`) — beside the executable, and
+    /// nowhere else on this platform.
+    pub fn find() -> Option<std::path::PathBuf> {
+        let exe = std::env::current_exe().ok()?;
+        let path = exe.parent()?.join(CONFIG_FILE);
+        match path.is_file() {
+            true => Some(path),
+            false => None,
+        }
+    }
+
+    /// The options common to EVERY command: the first significant line, but
+    /// only when it is not a section heading (`Cmdline.hs:92-94`).
+    pub fn global_options(&self) -> &str {
+        match self.lines.first() {
+            Some(l) if !l.starts_with('[') => l,
+            _ => "",
+        }
+    }
+
+    /// The `[Default options]` entry for one command.
+    ///
+    /// `sectionElement` (`Cmdline.hs:85`): a line is `NAMES = VALUE`, the left
+    /// side may list SEVERAL commands, and a command may appear on several
+    /// lines — in which case every value applies, joined. Both were easy to
+    /// miss and the shipped `arc.ini` documents them in its own comments.
+    pub fn command_options(&self, command: &str) -> String {
+        let mut out: Vec<&str> = Vec::new();
+        let mut in_section = false;
+        for line in &self.lines {
+            if line.starts_with('[') {
+                in_section = section_name(line) == "default options";
+                continue;
+            }
+            if !in_section {
+                continue;
+            }
+            match line.split_once('=') {
+                Some((names, value)) => {
+                    if names.split_whitespace().any(|n| n == command) {
+                        out.push(value.trim());
+                    }
+                }
+                None => {}
+            }
+        }
+        out.join(" ")
+    }
+
+    /// Sections this port reads the command line from but does NOT apply.
+    ///
+    /// Returns the section headings found, so the caller can say which. An
+    /// edited `[Compression methods]` would otherwise change what `-m9` means
+    /// in the reference and not here, with nothing to show for it.
+    pub fn has_unapplied_sections(&self) -> Vec<String> {
+        self.lines
+            .iter()
+            .filter(|l| l.starts_with('['))
+            .filter(|l| {
+                let n = section_name(l);
+                n == "compression methods" || n.starts_with("external compressor")
+            })
+            .cloned()
+            .collect()
+    }
+}
+
+/// `cleanupSectionName` — the heading without its brackets, lower-cased so
+/// comparisons do not depend on how the user capitalised it.
+fn section_name(heading: &str) -> String {
+    heading.trim_matches(['[', ']']).trim().to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Config;
+
+    const SAMPLE: &str = "\
+;a comment
+-mx --display=hnwftsr
+
+[Default options]
+;another comment
+a create = -m5
+a create t e x = -di+$
+x = -o+
+[Compression methods]
+9 = lzma:64m
+";
+
+    /// The first significant line is global options only when it is not a
+    /// heading. Comments and blanks must not count as significant, or a file
+    /// that opens with a comment would take the comment as its options.
+    #[test]
+    fn the_first_significant_line_is_the_global_options() {
+        let c = Config::parse(SAMPLE);
+        assert_eq!(c.global_options(), "-mx --display=hnwftsr");
+        // A file that opens with a section heading has no global options.
+        let c2 = Config::parse("[Default options]\na = -m1\n");
+        assert_eq!(c2.global_options(), "");
+    }
+
+    /// A command may appear on several lines and beside other commands; every
+    /// matching line contributes.
+    #[test]
+    fn command_options_merge_across_lines_and_name_lists() {
+        let c = Config::parse(SAMPLE);
+        assert_eq!(c.command_options("a"), "-m5 -di+$");
+        assert_eq!(c.command_options("create"), "-m5 -di+$");
+        assert_eq!(c.command_options("x"), "-di+$ -o+");
+        assert_eq!(c.command_options("l"), "");
+    }
+
+    /// Lines outside `[Default options]` must not leak in -- the
+    /// `[Compression methods]` entry `9 = lzma:64m` is not an option for
+    /// command `9`.
+    #[test]
+    fn other_sections_do_not_contribute_options() {
+        let c = Config::parse(SAMPLE);
+        assert_eq!(c.command_options("9"), "");
+        assert_eq!(c.has_unapplied_sections(), vec!["[Compression methods]".to_string()]);
+    }
+}

--- a/rust/darc-arc/src/decompress.rs
+++ b/rust/darc-arc/src/decompress.rs
@@ -58,6 +58,10 @@ fn undo(method: &Method, src: &[u8], hint: usize) -> Result<Vec<u8>, Error> {
     match method {
         // aNO_COMPRESSION: the bytes are already the data.
         Method::Storing => Ok(src.to_vec()),
+        // `--nodata` / `--crconly`: the data is deliberately not stored, so
+        // there is nothing to compress. The CRCs these record live in the
+        // DIRECTORY, not here.
+        Method::Fake | Method::Crc => Ok(Vec::new()),
         // LZMA is the exception: DArc writes no header, so it needs the property
         // bytes rebuilt from the method string rather than a callback.
         Method::Lzma(params) => undo_lzma(*params, src, hint),
@@ -254,6 +258,9 @@ pub fn compress_one(method: &Method, src: &[u8]) -> Result<Vec<u8>, Error> {
 pub fn compress_one_with(method: &Method, src: &[u8], all_at_once: bool) -> Result<Vec<u8>, Error> {
     match method {
         Method::Storing => Ok(src.to_vec()),
+        // Nothing was stored, so nothing comes back. An archive written with
+        // these cannot yield its files -- which is what the options ask for.
+        Method::Fake | Method::Crc => Ok(Vec::new()),
         Method::Tornado(p) => {
             // PackMethod crosses the C ABI by value, so every field must be
             // present -- including caching_finder/hash3/shift, which no method

--- a/rust/darc-arc/src/fetch.rs
+++ b/rust/darc-arc/src/fetch.rs
@@ -32,16 +32,39 @@ pub struct Url {
 
 impl Url {
     pub fn new(url: &str) -> Self {
-        Self {
-            url: url.to_string(),
-            // The reference sets a user agent (URL.cpp:295) and honours the
-            // proxy environment, which ureq does by default.
-            agent: ureq::Agent::config_builder()
-                .user_agent(concat!("DArc/", env!("CARGO_PKG_VERSION")))
-                .build()
-                .into(),
-            size: None,
-        }
+        Self::with_proxy(url, "--", "")
+    }
+
+    /// `--proxy` and `--bypass` (Cmdline.hs:133-134).
+    ///
+    /// `proxy` is `"--"` for "not given", in which case the environment is
+    /// honoured — which is ureq's default and the reference's behaviour too.
+    /// An explicit `-` disables proxying entirely, so a machine with
+    /// `http_proxy` set can still be told to go direct.
+    ///
+    /// `bypass` is the reference's no-proxy list. ureq takes that only from
+    /// `no_proxy`, so a list given on the command line is applied here by
+    /// matching the host ourselves and dropping the proxy for that request.
+    pub fn with_proxy(url: &str, proxy: &str, bypass: &str) -> Self {
+        let builder = ureq::Agent::config_builder()
+            // The reference sets a user agent (URL.cpp:295).
+            .user_agent(concat!("DArc/", env!("CARGO_PKG_VERSION")));
+        let builder = match (proxy, host_is_bypassed(url, bypass)) {
+            // Not given: leave ureq's environment handling alone.
+            ("--", false) => builder,
+            // Explicitly disabled, or this host is in the bypass list.
+            ("-", _) | (_, true) => builder.proxy(None),
+            (p, false) => match ureq::Proxy::new(p) {
+                Ok(px) => builder.proxy(Some(px)),
+                // A proxy that cannot be parsed is not a reason to silently go
+                // direct: say so, and let the request fail or not on its own.
+                Err(e) => {
+                    eprintln!("WARNING: --proxy={p}: {e}; ignoring it");
+                    builder
+                }
+            },
+        };
+        Self { url: url.to_string(), agent: builder.build().into(), size: None }
     }
 
     /// `url_size` — `HEAD`, for the same-size check.
@@ -54,6 +77,59 @@ impl Url {
             .trim()
             .parse()
             .ok()
+    }
+}
+
+/// Does `--bypass` cover this URL's host?
+///
+/// The list is comma or semicolon separated, and an entry matches the host
+/// exactly or as a domain suffix, so `example.com` covers `www.example.com`.
+/// A bare `*` bypasses everything. Matching is case-insensitive because host
+/// names are.
+fn host_is_bypassed(url: &str, bypass: &str) -> bool {
+    if bypass.is_empty() {
+        return false;
+    }
+    let host = url
+        .split_once("://")
+        .map_or(url, |(_, rest)| rest)
+        .split(['/', ':', '?', '#'])
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    if host.is_empty() {
+        return false;
+    }
+    bypass.split([',', ';']).map(str::trim).filter(|e| !e.is_empty()).any(|entry| {
+        let e = entry.to_ascii_lowercase();
+        if e == "*" {
+            return true;
+        }
+        // A leading dot is the conventional spelling of "and subdomains", and
+        // means the same as the bare name here.
+        let e = e.strip_prefix('.').unwrap_or(&e).to_string();
+        host == e || host.ends_with(&format!(".{e}"))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::host_is_bypassed;
+
+    /// The list is what decides whether a proxy is used at all, so an entry
+    /// that fails to match sends the request somewhere the user said not to.
+    #[test]
+    fn bypass_matches_host_and_subdomains_only() {
+        assert!(host_is_bypassed("http://example.com/a.arc", "example.com"));
+        assert!(host_is_bypassed("https://www.example.com/a", "example.com"));
+        assert!(host_is_bypassed("http://EXAMPLE.COM:8080/a", "example.com"));
+        assert!(host_is_bypassed("http://a.b/x", "other, .b"));
+        assert!(host_is_bypassed("http://anything/x", "*"));
+        // A suffix that is not a domain boundary must NOT match: notexample.com
+        // is a different host from example.com.
+        assert!(!host_is_bypassed("http://notexample.com/a", "example.com"));
+        assert!(!host_is_bypassed("http://example.com/a", "other.com"));
+        assert!(!host_is_bypassed("http://example.com/a", ""));
     }
 }
 

--- a/rust/darc-arc/src/lib.rs
+++ b/rust/darc-arc/src/lib.rs
@@ -48,6 +48,7 @@ pub mod archive;
 pub mod block;
 pub mod bytestream;
 pub mod canonize;
+pub mod config;
 pub mod charset;
 pub mod codec_io;
 pub mod crc;

--- a/rust/darc-arc/src/memlimit.rs
+++ b/rust/darc-arc/src/memlimit.rs
@@ -491,8 +491,23 @@ pub fn fit_for_add(chain: &str, total_bytes: u64) -> Option<String> {
 
 /// `fit_for_add` with the `-ld` figure supplied rather than defaulted.
 pub fn fit_for_add_limited(chain: &str, total_bytes: u64, dlimit: u64) -> Option<String> {
+    fit_for_add_limits(chain, total_bytes, u64::MAX, dlimit)
+}
+
+/// `fit_for_add` with both memory limits supplied.
+///
+/// The order is the reference's: `limitCompressionMem` then
+/// `limitDecompressionMem` (Cmdline.hs:339-340), both before the dictionary is
+/// fitted to the data.
+pub fn fit_for_add_limits(
+    chain: &str,
+    total_bytes: u64,
+    climit: u64,
+    dlimit: u64,
+) -> Option<String> {
     let names: Vec<String> = chain.split('+').map(str::to_string).collect();
     let mut methods = Method::parse_chain(&names)?;
+    limit_compression_mem(&mut methods, climit);
     limit_decompression_mem(&mut methods, dlimit);
     limit_dictionary(&mut methods, dictionary_limit(total_bytes));
     Some(methods.iter().map(crate::canonize::show).collect::<Vec<_>>().join("+"))
@@ -598,4 +613,142 @@ pub fn parse_mem_with_percents(memory: u64, s: &str) -> Option<u64> {
         // so the two spellings cannot drift apart.
         _ => crate::method::parse_mem(s).map(u64::from),
     }
+}
+
+/// `GetCompressionMem` — what each method needs to PACK, from `C_*.h`.
+///
+/// Returns `None` for a method whose formula this port has not reproduced. The
+/// caller must decide what to do about that; [`limit_compression_mem`] treats
+/// it as "do not touch", which is exactly what the port did before `-lc`
+/// existed and so cannot change an archive that used to be written.
+pub fn get_compression_mem(m: &Method) -> Option<u64> {
+    match m {
+        // No compression, no memory.
+        Method::Storing | Method::Fake | Method::Crc => Some(0),
+        // `mfMem + 6mb`, where the multiplier is the match finder's
+        // (`C_LZMA.cpp`). kBT2=10, kBT3/kBT4=11, kHC4=7, kHT4=6.
+        Method::Lzma(p) => {
+            Some(u64::from(p.dictionary_size) * lzma_mf_multiplier(p.match_finder) + 6 * MB)
+        }
+        Method::Ppmd(p) => Some(u64::from(p.mem)),
+        Method::Dict(p) => Some(u64::from(p.block_size) * 2),
+        Method::Delta(p) => Some(u64::from(p.block_size)),
+        Method::Bsc(p) => Some(u64::from(p.block_size) * 5),
+        // `{return 2*mb;}` for both, and TTA's setter is `{}`.
+        Method::Mm(_) | Method::Tta(_) => Some(2 * MB),
+        Method::Dispack(p) => {
+            let bs = u64::from(p.block_size);
+            Some(3 * bs + bs / 4 + 1024)
+        }
+        // Not reproduced yet. Tornado needs `tornado_compressor_outbuf_size`,
+        // which branches on a global; REP needs `CalcHashSize`; LZP's setter
+        // shrinks the hash before the block; GRZip's figure scales with the
+        // THREAD count, so it is not a property of the method alone; LZ4 and
+        // Zstd ask their libraries; 4x4 recurses into its inner method.
+        Method::Tornado(_)
+        | Method::Rep(_)
+        | Method::Lzp(_)
+        | Method::Grzip(_)
+        | Method::Lz4(_)
+        | Method::Zstd(_)
+        | Method::FourX4(_)
+        | Method::Encryption(_)
+        | Method::Exe
+        | Method::Unsupported(_) => None,
+    }
+}
+
+/// The match finder's memory multiplier (`C_LZMA.cpp`), shared by the getter
+/// and the setter so the two cannot disagree.
+fn lzma_mf_multiplier(mf: u32) -> u64 {
+    match mf {
+        0 => 10, // kBT2
+        1 => 11, // kBT3
+        2 => 11, // kBT4
+        3 => 7,  // kHC4
+        4 => 6,  // kHT4
+        _ => 11,
+    }
+}
+
+/// `SetCompressionMem`. Returns false when the method has no implementation
+/// here, leaving it untouched.
+pub fn set_compression_mem(m: &mut Method, mem: u64) -> bool {
+    match m {
+        Method::Storing | Method::Fake | Method::Crc => true,
+        Method::Lzma(p) => {
+            // `if (mem < 2*mb) mem = 2*mb;` then `avail = mem > 6mb ? mem-6mb
+            // : mem`, divided by the match finder's multiplier and floored at
+            // 4 kb.
+            let mem = mem.max(2 * MB);
+            let base = 6 * MB;
+            let avail = match mem > base {
+                true => mem - base,
+                false => mem,
+            };
+            let d = avail / lzma_mf_multiplier(p.match_finder);
+            p.dictionary_size = d.max(4 * 1024).min(u64::from(u32::MAX)) as u32;
+            true
+        }
+        // Identical to the decompression setter -- `SetDecompressionMem` IS
+        // `SetCompressionMem` for PPMd (`C_PPMD.h`).
+        Method::Ppmd(p) => {
+            set_ppmd_mem(p, mem);
+            true
+        }
+        Method::Dict(p) => {
+            if mem > 0 {
+                p.block_size = (mem / 2).min(u64::from(u32::MAX)) as u32;
+            }
+            true
+        }
+        Method::Delta(p) => {
+            if mem > 0 {
+                p.block_size = mem.min(u64::from(u32::MAX)) as u32;
+            }
+            true
+        }
+        Method::Bsc(p) => {
+            p.block_size = (mem / 5).min(u64::from(u32::MAX)) as u32;
+            true
+        }
+        // `{}` -- MM and TTA ignore the request entirely.
+        Method::Mm(_) | Method::Tta(_) => true,
+        Method::Dispack(p) => {
+            if mem > 0 {
+                p.block_size = (mem / 13 * 4).max(64 * 1024).min(u64::from(u32::MAX)) as u32;
+            }
+            true
+        }
+        Method::Tornado(_)
+        | Method::Rep(_)
+        | Method::Lzp(_)
+        | Method::Grzip(_)
+        | Method::Lz4(_)
+        | Method::Zstd(_)
+        | Method::FourX4(_)
+        | Method::Encryption(_)
+        | Method::Exe
+        | Method::Unsupported(_) => false,
+    }
+}
+
+/// `LimitCompressionMem` over a chain — `if (Get() > mem) Set(mem)`, method by
+/// method (`Compression.h:285`), like the decompression half.
+///
+/// A method with no formula here is left alone rather than guessed at.
+pub fn limit_compression_mem(chain: &mut [Method], mem: u64) {
+    for m in chain.iter_mut() {
+        match get_compression_mem(m) {
+            Some(have) if have > mem => {
+                set_compression_mem(m, mem);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Does every method in the chain have a compression-memory formula here?
+pub fn compression_mem_is_known(chain: &[Method]) -> bool {
+    chain.iter().all(|m| get_compression_mem(m).is_some())
 }

--- a/rust/darc-arc/src/memlimit.rs
+++ b/rust/darc-arc/src/memlimit.rs
@@ -58,6 +58,8 @@ pub fn dictionary_limit(total_bytes: u64) -> u32 {
 /// not by the data.
 pub fn get_dictionary(m: &Method) -> u32 {
     match m {
+        // No dictionary, and no memory: they compress nothing.
+        Method::Fake | Method::Crc => 0,
         Method::Lzma(p) => p.dictionary_size,
         Method::Tornado(p) => p.buffer,
         Method::Rep(p) => p.block_size,
@@ -91,6 +93,8 @@ pub fn set_dictionary(m: &mut Method, dict: u32) {
         return;
     }
     match m {
+        // Nothing to shrink.
+        Method::Fake | Method::Crc => {}
         Method::Lzma(p) => p.dictionary_size = dict,
         Method::Tornado(p) => set_tornado_dictionary(p, dict),
         Method::Rep(p) => p.block_size = dict,
@@ -307,6 +311,8 @@ fn compression_threads() -> u64 {
 /// `GetDecompressionMem` — what each method needs to UNPACK, from `C_*.h`.
 pub fn get_decompression_mem(m: &Method) -> u64 {
     match m {
+        // Nothing is stored, so nothing is needed to unpack it.
+        Method::Fake | Method::Crc => 0,
         Method::Lzma(p) => u64::from(p.dictionary_size) + 2 * MB,
         Method::Ppmd(p) => u64::from(p.mem),
         Method::Tornado(p) => u64::from(p.buffer),
@@ -360,6 +366,8 @@ pub fn get_decompression_mem(m: &Method) -> u64 {
 /// of the getter.
 pub fn set_decompression_mem(m: &mut Method, mem: u64) {
     match m {
+        // No memory to limit.
+        Method::Fake | Method::Crc => {}
         // `if (mem > 2mb) dictionarySize = mem - 2mb` -- silently does nothing
         // below 2 MB rather than clamping.
         Method::Lzma(p) => {

--- a/rust/darc-arc/src/memlimit.rs
+++ b/rust/darc-arc/src/memlimit.rs
@@ -520,10 +520,17 @@ pub fn fit_for_add_limits(
 /// one would make `-ld75%` produce a slightly different compression chain — and
 /// so a different archive — on two machines with the same nominal RAM.
 ///
-/// Returns 0 when the figure cannot be had, which makes a percentage limit 0
-/// and therefore maximally restrictive. That is the safe direction: a limit
-/// that is too small produces a smaller chain, never one the reader cannot
-/// afford.
+/// Returns 0 when the figure cannot be had — on any platform that is neither
+/// macOS nor Linux, which today means the Windows cross-builds.
+///
+/// **0 means "unknown", and callers must treat it as NO LIMIT, not as a limit
+/// of zero.** An earlier version of this comment argued that zero was the safe
+/// direction because a smaller chain is one the reader can always afford. That
+/// is the wrong criterion. A limit of zero shrank every method, including the
+/// directory's `lzma:1mb`, so the Windows builds wrote different archives from
+/// the Linux one for EVERY method — `store` included, which is how the interop
+/// check caught it. Byte-identity is the property that matters here, not
+/// frugality.
 pub fn physical_memory() -> u64 {
     let raw = physical_memory_raw();
     let rounded = raw - (raw % (4 * MB));

--- a/rust/darc-arc/src/memlimit.rs
+++ b/rust/darc-arc/src/memlimit.rs
@@ -511,7 +511,22 @@ pub fn fit_for_add_limited(chain: &str, total_bytes: u64, dlimit: u64) -> Option
 /// afford.
 pub fn physical_memory() -> u64 {
     let raw = physical_memory_raw();
-    raw - (raw % (4 * MB))
+    let rounded = raw - (raw % (4 * MB));
+    // CAPPED AT 4 GiB, established by measurement rather than by reading.
+    //
+    // On this 16 GB machine the reference answers `-ld10%` with
+    // `ppmd:16:429496729b` and `-ld25%` with `ppmd:22:1gb`. The first is
+    // consistent with a cap of either u32::MAX or 2^32 -- integer division
+    // hides the difference -- but the second is not: 2^32 * 25/100 is exactly
+    // 1073741824 (`1gb`), while u32::MAX * 25/100 is 1073741823, which the
+    // reference would have printed as `1073741823b`. So the figure is 2^32.
+    //
+    // 10% alone would have "confirmed" the wrong constant. Only a percentage
+    // that divides 2^32 evenly separates them.
+    //
+    // What is verified is the CAP. Whether a machine with less than 4 GiB sees
+    // its true RAM here is untested -- nothing available reports less.
+    rounded.min(4 * 1024 * MB)
 }
 
 #[cfg(target_os = "macos")]

--- a/rust/darc-arc/src/memlimit.rs
+++ b/rust/darc-arc/src/memlimit.rs
@@ -486,9 +486,101 @@ pub const ADD_DECOMPRESSION_LIMIT: u64 = 1024 * MB;
 /// `Cmdline.hs` applies them: the memory limits run when the command line is
 /// parsed, the dictionary limit when the block's size is known.
 pub fn fit_for_add(chain: &str, total_bytes: u64) -> Option<String> {
+    fit_for_add_limited(chain, total_bytes, ADD_DECOMPRESSION_LIMIT)
+}
+
+/// `fit_for_add` with the `-ld` figure supplied rather than defaulted.
+pub fn fit_for_add_limited(chain: &str, total_bytes: u64, dlimit: u64) -> Option<String> {
     let names: Vec<String> = chain.split('+').map(str::to_string).collect();
     let mut methods = Method::parse_chain(&names)?;
-    limit_decompression_mem(&mut methods, ADD_DECOMPRESSION_LIMIT);
+    limit_decompression_mem(&mut methods, dlimit);
     limit_dictionary(&mut methods, dictionary_limit(total_bytes));
     Some(methods.iter().map(crate::canonize::show).collect::<Vec<_>>().join("+"))
+}
+
+/// Physical RAM in bytes, rounded down to a 4 MB boundary.
+///
+/// `getPhysicalMemory `roundTo` (4*mb)` (`Cmdline.hs:230`). The rounding is not
+/// cosmetic: a percentage limit is computed from this figure, and an unrounded
+/// one would make `-ld75%` produce a slightly different compression chain — and
+/// so a different archive — on two machines with the same nominal RAM.
+///
+/// Returns 0 when the figure cannot be had, which makes a percentage limit 0
+/// and therefore maximally restrictive. That is the safe direction: a limit
+/// that is too small produces a smaller chain, never one the reader cannot
+/// afford.
+pub fn physical_memory() -> u64 {
+    let raw = physical_memory_raw();
+    raw - (raw % (4 * MB))
+}
+
+#[cfg(target_os = "macos")]
+fn physical_memory_raw() -> u64 {
+    let mut out: u64 = 0;
+    let mut len: usize = std::mem::size_of::<u64>();
+    extern "C" {
+        fn sysctlbyname(
+            name: *const i8,
+            oldp: *mut core::ffi::c_void,
+            oldlenp: *mut usize,
+            newp: *mut core::ffi::c_void,
+            newlen: usize,
+        ) -> i32;
+    }
+    // SAFETY: the name is NUL-terminated, and the buffer and its length match.
+    let rc = unsafe {
+        sysctlbyname(
+            c"hw.memsize".as_ptr(),
+            (&raw mut out).cast(),
+            &raw mut len,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    match rc {
+        0 => out,
+        _ => 0,
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn physical_memory_raw() -> u64 {
+    // MemTotal is in kB, and is the first line of /proc/meminfo.
+    let text = match std::fs::read_to_string("/proc/meminfo") {
+        Ok(t) => t,
+        Err(_) => return 0,
+    };
+    for line in text.lines() {
+        match line.strip_prefix("MemTotal:") {
+            Some(rest) => {
+                let kb: u64 = rest.trim().trim_end_matches("kB").trim().parse().unwrap_or(0);
+                return kb * 1024;
+            }
+            None => {}
+        }
+    }
+    0
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn physical_memory_raw() -> u64 {
+    0
+}
+
+/// `parseMemWithPercents` (`Utils.hs:78`) — a size, or a percentage of RAM.
+///
+/// The default unit is megabytes, `b` means bytes, and `%` or `p` means a
+/// percentage of `memory`. Anything else is an error there, and `None` here.
+pub fn parse_mem_with_percents(memory: u64, s: &str) -> Option<u64> {
+    let digits: String = s.chars().take_while(char::is_ascii_digit).collect();
+    if digits.is_empty() {
+        return None;
+    }
+    let n: u64 = digits.parse().ok()?;
+    match s[digits.len()..].chars().next() {
+        Some('%') | Some('p') => Some(memory.saturating_mul(n) / 100),
+        // Everything else is a plain size, and parse_mem owns the unit table
+        // so the two spellings cannot drift apart.
+        _ => crate::method::parse_mem(s).map(u64::from),
+    }
 }

--- a/rust/darc-arc/src/method.rs
+++ b/rust/darc-arc/src/method.rs
@@ -304,6 +304,13 @@ impl Default for ZstdParams {
 pub enum Method {
     /// `aSTORING` — the block's bytes are its data.
     Storing,
+    /// `aFAKE_COMPRESSION` — `--nodata`. The files are not read at all
+    /// (`ArcvProcessRead.hs:139`): their sizes are recorded, their CRCs stay
+    /// zero, and no data block is written.
+    Fake,
+    /// `aCRC_ONLY_COMPRESSION` — `--crconly`. The files ARE read and their
+    /// CRC32s recorded, but the data is still not stored.
+    Crc,
     Lzma(LzmaParams),
     Ppmd(PpmdParams),
     /// Tornado. The decoder reads everything it needs from the stream header;
@@ -361,6 +368,8 @@ impl Method {
         let params: Vec<&str> = parts.collect();
         match name {
             "storing" => Some(Method::Storing),
+            "fake" => Some(Method::Fake),
+            "crc" => Some(Method::Crc),
             "lzma" => parse_lzma(params.into_iter()).map(Method::Lzma),
             "ppmd" => parse_ppmd(&params).map(Method::Ppmd),
             "tor" => parse_tornado(&params).map(Method::Tornado),
@@ -1241,6 +1250,8 @@ fn parse_lzma<'a, I: Iterator<Item = &'a str>>(params: I) -> Option<LzmaParams> 
 /// archive-visible.
 pub fn block_size(m: &Method) -> u64 {
     match m {
+        // No block-size constraint: these write no blocks at all.
+        Method::Fake | Method::Crc => 0,
         Method::Dict(p) => u64::from(p.block_size),
         Method::Lzp(p) => u64::from(p.block_size),
         Method::Grzip(p) => u64::from(p.block_size),

--- a/rust/darc-arc/src/options.rs
+++ b/rust/darc-arc/src/options.rs
@@ -57,7 +57,7 @@ pub const OPTIONS: &[OptionDef] = &[
     OptionDef { short: "m", long: "method", param: Some("METHOD") },
     OptionDef { short: "dm", long: "dirmethod", param: Some("METHOD") },
     OptionDef { short: "ma", long: "", param: Some("LEVEL") },
-    OptionDef { short: "md", long: "dictionary", param: None },
+    OptionDef { short: "md", long: "dictionary", param: Some("N") },
     OptionDef { short: "mm", long: "multimedia", param: Some("MODE") },
     OptionDef { short: "ms", long: "StoreCompressed", param: None },
     OptionDef { short: "mt", long: "MultiThreaded", param: Some("THREADS") },
@@ -114,9 +114,9 @@ pub const OPTIONS: &[OptionDef] = &[
     OptionDef { short: "v", long: "volume", param: Some("SIZE") },
     OptionDef { short: "", long: "queue", param: None },
     OptionDef { short: "", long: "arc-32bit-legacy", param: None },
-    OptionDef { short: "", long: "cache", param: None },
-    OptionDef { short: "lc", long: "LimitCompMem", param: None },
-    OptionDef { short: "ld", long: "LimitDecompMem", param: None },
+    OptionDef { short: "", long: "cache", param: Some("N") },
+    OptionDef { short: "lc", long: "LimitCompMem", param: Some("N") },
+    OptionDef { short: "ld", long: "LimitDecompMem", param: Some("N") },
     OptionDef { short: "", long: "nodir", param: None },
     OptionDef { short: "", long: "nodata", param: None },
     OptionDef { short: "", long: "crconly", param: None },
@@ -337,6 +337,25 @@ mod tests {
     #[test]
     fn the_parameter_flags_match_the_help_text() {
         let by_long = |l: &str| OPTIONS.iter().find(|o| o.long == l).copied();
+        // A SINGLE uppercase letter is a parameter name too: `paramName` is
+        // `filter (all isUpper) (words descr)`, and `all isUpper "N"` is true.
+        // The mechanical extraction that built this table wanted two or more,
+        // so every `N` row came out wrong -- `-lc64m` and `--dictionary=16m`
+        // were "unknown option" while the reference accepts both. The rows
+        // pinned below this comment are exactly the ones that were wrong, and
+        // they are all single-letter: a check that only pinned multi-letter
+        // names is what let the class through in the first place.
+        assert_eq!(by_long("dictionary").and_then(|o| o.param), Some("N"));
+        assert_eq!(by_long("cache").and_then(|o| o.param), Some("N"));
+        assert_eq!(by_long("LimitCompMem").and_then(|o| o.param), Some("N"));
+        assert_eq!(by_long("LimitDecompMem").and_then(|o| o.param), Some("N"));
+        // "save/check CRC, but don't store data" -- NO parameter, and the
+        // reason is the COMMA: the word is "CRC," and `all isUpper` is false
+        // for punctuation. Checked against the reference, which answers
+        // `--crconly=x` with "unknown option". A sweep that strips punctuation
+        // before testing gets this wrong, and mine did.
+        assert_eq!(by_long("crconly").and_then(|o| o.param), None);
+
         assert_eq!(by_long("recursive").and_then(|o| o.param), None);
         assert_eq!(by_long("arcpath").and_then(|o| o.param), Some("DIR"));
         assert_eq!(by_long("diskpath").and_then(|o| o.param), Some("DIR"));

--- a/rust/darc-arc/src/writer.rs
+++ b/rust/darc-arc/src/writer.rs
@@ -448,6 +448,18 @@ impl Writer {
     }
 
     /// The footer, and the finished archive.
+    /// `--nodir`: everything written so far and nothing more.
+    ///
+    /// `writeControlBlock` returns early under that option
+    /// (`ArcvProcessRead.hs:270`), so NO service block is written -- no header,
+    /// no directory, no footer. What is left is the data blocks' payloads
+    /// concatenated, which for `-m0` is literally the files' bytes. Such a
+    /// file is not an archive and nothing can list or extract it; that is what
+    /// the option asks for.
+    pub fn into_data_only(self) -> Vec<u8> {
+        self.out
+    }
+
     pub fn finish(mut self, comment: &str, recovery: &str, locked: bool) -> Vec<u8> {
         let blocks = self.service.clone();
         let body = footer_block(self.pos(), &blocks, locked, comment, recovery);


### PR DESCRIPTION
22 commits, +1,741 / −60 across 12 files.

`options.rs` knows 79 options; `HONOURED` in `darc.rs` listed 44. The other 35
parsed fine and were then refused — some rightly, most only because nobody had
implemented them. **74 of 79 are now honoured.**

## Gating

The Haskell reference was rebuilt from `9a127e6` (`compile-ghc-probe`, GHC
9.10.3), which also restored the 18 `arc-*-check.sh` harnesses that had been
unrunnable since the port merged. Every option that can change archive bytes is
gated on **byte-identity against it**, and every matrix also counts *distinct*
reference outputs — a matrix where all cases produce the same archive proves
nothing, and two of mine did before that check was added.

Per-commit gates: 65/65 golden, 24/0/0 `run-tests`, 653 unit tests, plus
create 40/0, solid 68/0, update 48/0, copy 60/0, crypt 62/0, list 21×4/0,
extract 24/0, recover 20/0, sfx 22/0, recovery 24/0.

## Implemented

**Extraction and creation:** `-o` (incl. the interactive prompt), `--keepbroken`,
`--keeptime`, `--timetolast`, `--test`, `--pretest`, `-ag`, `--nodata`,
`--crconly`, `--nodir`.

**Archive-visible, byte-identity gated:** `--type`, `-dm`, `--adddir`, `-ds`,
`-lc`, `-ld`, `-dp`.

**Environment and process:** `arc.ini` + `$FREEARC`, `-w`/`--create-in-workdir`
(now writing through a temp file, so an interrupted run no longer leaves a
truncated archive), `--queue`, `--pause-before-exit`, `--logfile`, `--proxy`,
`--bypass`, `--save-bad-ranges`, `-ba`.

## Four bugs that were not on the list

- **`-dp` was accepted and did nothing on `a`** — parsed into `extract::Layout`,
  which only the extract path reads. `a -dpproj .` archived the wrong tree.
- **`arc.ini` and `$FREEARC` were ignored entirely** — the reference prepends
  both to every command line, so a machine with `-mx` in its config wrote
  different archives, silently.
- **Four option rows had the wrong arity** — the reference derives it from an
  ALL-CAPS word in the description, and a *single* uppercase letter counts, so
  every `N` row was read as a flag. `-lc64m` was "unknown option".
- **`ch -op OLD -p NEW` did not re-encrypt** (the reference doesn't either); it
  also exposed a latent double-encryption on partial-block repack.

## Two deliberate divergences, both recorded at the code

- `ch -op OLD -p NEW` re-encrypts here; the reference exits 0 leaving the old
  password. Fixed on request.
- `arc.ini` auto-discovery works here; the macOS reference never finds it
  (`getExeName` is a Windows/Linux idiom). The parsing and injection order are
  gated via explicit `-cfg`, which the reference does honour.

## Known-partial, documented where it matters

`-ds` refuses the `'c'` order (it partitions at 128 KB rather than being a sort
key); `-lc` leaves 7 codecs untouched rather than guess their formulas;
`--logfile` misses early-exit paths; `arc.ini`'s `[Compression methods]` warns
rather than applies. Five long spellings (`--dictionary`, `--multimedia`,
`--StoreCompressed`, `--print-config`, `--MultiThreaded`) are dead in the
reference too and now say so instead of promising future work.

`language` and `shutdown` were dropped by request.

## Not verified here

Everything was validated on macOS. This branch has had **no CI** — that is what
this PR is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)