### PR TITLE
Method: implement lzma2, and apply -lc everywhere the reference applies it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,12 +36,21 @@ reference too. Note that the *memory formulas* never see `-mt`: the C's
 to `setup_command`, which runs after every limit has been applied. Two different
 numbers, same C function.
 
-**`-lc` is served for every method except top-level `tor` and `grzip`**, which
-are refused. Their memory formulas are ported and produce exactly the
-reference's method strings; what still differs is `genericLimitMemoryUsage`
-splicing a `tempfile` stage into the chain, which changes how the data is fed to
-a chunk-sensitive codec. LZMA is unaffected. `-m4`/`-m9` carry `tor`/`grzip` at
-the top level and so are refused under `-lc` as well.
+**`-lc` is applied THREE times, to three different things**, and missing any of
+them writes a valid archive that is not the reference's:
+
+1. at parse time, to the chain that gets **stored** in the block header;
+2. to the **solid-block grouping**, because a shrunk block method moves where
+   blocks end (`-mgrzip -lc2m` writes two data blocks where `-lc4m` writes one);
+3. per block, *after* the dictionary is fitted, to produce the chain that
+   actually **compresses** -- `real_compressor`, which `ArcvProcessRead.hs:134`
+   passes separately from the stored one, and which sees a **different thread
+   count** because `setup_command` has run by then.
+
+The second pass is why an archive can store `grzip:1181kb` and be compressed
+with `grzip:233016b`. Do not assume the stored method string describes what
+compressed the bytes -- for a DATA_BLOCK under `-lc`, it frequently does not.
+Control blocks are exempt: `writeControlBlock` passes its chain twice.
 
 ## Deeper references — load when the work calls for it
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,12 +21,27 @@ that reference actually wrote. **Read `docs/testing.md` before changing anything
 that touches archive bytes.**
 
 **Every method the reference can write, this can write** -- `Tests/run-tests.sh`
-scores 24/0/0, the same as the reference. `mm`, `tta`, `bsc`, `lz4` and `zstd`
-had no `Method` variant until recently, which made archives using them
+scores 24/0/0, the same as the reference. `mm`, `tta`, `bsc`, `lz4`, `zstd` and
+`lzma2` had no `Method` variant until recently, which made archives using them
 unreadable as well as unwritable; the `-m` VALUE grammar (`-mt`, `-ms`, `-md`,
 `-ma`, `-mc`, `-mm`) was read as method NAMES. Both are fixed and gated. What
 is still refused rather than implemented: `-mm`/`-ma`/`-mc` change the chain
 and are rejected outright, and `-lc-`/`-ld-` are not accepted at all.
+
+**`-mt` is archive-visible through LZMA2 and nothing else.** Above one block
+thread the encoder abandons the solid block and splits the input, so
+`-mlzma2:d64k -mt1` and `-mlzma2:d64k -mt8` write different archives -- in the
+reference too. Note that the *memory formulas* never see `-mt`: the C's
+`compression_threads` global starts at 1 and `SetCompressionThreads` is deferred
+to `setup_command`, which runs after every limit has been applied. Two different
+numbers, same C function.
+
+**`-lc` is served for every method except top-level `tor` and `grzip`**, which
+are refused. Their memory formulas are ported and produce exactly the
+reference's method strings; what still differs is `genericLimitMemoryUsage`
+splicing a `tempfile` stage into the chain, which changes how the data is fed to
+a chunk-sensitive codec. LZMA is unaffected. `-m4`/`-m9` carry `tor`/`grzip` at
+the top level and so are refused under `-lc` as well.
 
 ## Deeper references — load when the work calls for it
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -113,9 +113,17 @@ sort-order decision, and `addBlockSizeCrit` having been ported and never called.
 ### What the port cannot do
 
 `Tests/run-tests.sh` scores 24 passed / 0 failed / 0 skipped — the same as the
-reference. The five methods that had no `Method` variant (`mm`, `tta`, `bsc`,
-`lz4`, `zstd`) and the `-m` value grammar (`-mt`, `-ms`, `-md`) are implemented
-and gated by the golden corpus.
+reference. The six methods that had no `Method` variant (`mm`, `tta`, `bsc`,
+`lz4`, `zstd`, `lzma2`) and the `-m` value grammar (`-mt`, `-ms`, `-md`) are
+implemented and gated by the golden corpus.
+
+`lzma2` was the last of them, and it is the one to copy if another turns up. It
+was gated on 23 method strings byte-identical to the reference, on `-mt1` versus
+`-mt8` — which write *different* archives on both sides, so the pair proves the
+thread count is really plumbed rather than merely accepted — and on all four
+cross-extractions per case, since a missing variant makes an archive unreadable
+as well as unwritable. That last direction is the half a write-side matrix
+cannot see.
 
 The SKIP machinery in `run-tests.sh` and `sfx-roundtrip.sh` is kept even though
 nothing trips it now. It matches on the binary's own "cannot write yet" wording,
@@ -126,6 +134,17 @@ Still refused rather than implemented: `-mm` (multimedia mode), `-ma`
 (autodetect level) and `-mc` (disable an algorithm) each change the chain, so
 they are rejected outright rather than ignored, on the same rule the HONOURED
 option list follows. `-lc-`/`-ld-` are not accepted at all.
+
+`-lc` is the subtler one. Every method now has a `GetCompressionMem` /
+`SetCompressionMem`, and they were checked by reading the method string back out
+of the archive rather than by trusting the arithmetic — `-mgrzip -lc4m` writes
+`grzip:466033b` on both sides, and 466033 is 4194304/9 exactly. But `tor` and
+`grzip` at the top level are still refused, because agreeing on the method
+string turned out not to be enough: `compressionLimitMemoryUsage`
+(`Compression.hs:217`) also splices a `tempfile` stage into the chain, and the
+two codecs' output follows the chunking they are handed. **The archives differed
+while storing the identical method string**, which is worth remembering as a
+failure mode: a canonicalisation check would have called this green.
 
 ## End-to-end
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -135,16 +135,35 @@ Still refused rather than implemented: `-mm` (multimedia mode), `-ma`
 they are rejected outright rather than ignored, on the same rule the HONOURED
 option list follows. `-lc-`/`-ld-` are not accepted at all.
 
-`-lc` is the subtler one. Every method now has a `GetCompressionMem` /
-`SetCompressionMem`, and they were checked by reading the method string back out
-of the archive rather than by trusting the arithmetic — `-mgrzip -lc4m` writes
-`grzip:466033b` on both sides, and 466033 is 4194304/9 exactly. But `tor` and
-`grzip` at the top level are still refused, because agreeing on the method
-string turned out not to be enough: `compressionLimitMemoryUsage`
-(`Compression.hs:217`) also splices a `tempfile` stage into the chain, and the
-two codecs' output follows the chunking they are handed. **The archives differed
-while storing the identical method string**, which is worth remembering as a
-failure mode: a canonicalisation check would have called this green.
+`-lc` is served for every method, and getting there is the cautionary tale in
+this file.
+
+Every method has a `GetCompressionMem`/`SetCompressionMem`, checked by reading
+the stored method string back out of the archive rather than by trusting the
+arithmetic — `-mgrzip -lc4m` stores `grzip:466033b` on both sides, and 466033 is
+4194304/9 exactly. **All of those agreed, and the archives still differed.**
+
+Agreeing on the stored method string is not evidence that the same bytes were
+written, because under `-lc` the stored chain is *not* the chain that
+compresses. `-lc` is applied three times: at parse time to what is stored, to
+the solid-block grouping (a shrunk block method moves where blocks end), and per
+block after the dictionary is fitted to produce `real_compressor`
+(`ArcvProcessRead.hs:134`), which also sees a different thread count because
+`setup_command` has run by then. The port implemented only the first, so it
+stored the right string and compressed with the wrong chain.
+
+Two habits earned here:
+
+* **A canonicalisation check would have called this green.** So would any
+  harness comparing method strings. Only comparing archive bytes caught it.
+* **When the artefacts differ and every intermediate agrees, ask the reference
+  what it did rather than modelling it.** Two threshold models were fitted and
+  both were wrong — one fitted Tornado and mispredicted GRZip, the other the
+  reverse, and a `tempfile` mechanism was blamed that turned out to have no
+  effect on the bytes at all. `-di'$'` makes the reference print
+  `"Using " ++ real_compressor` per block (`ArcvProcessRead.hs:170`), which
+  showed both the real chain and the block split in one run and ended the
+  guessing immediately.
 
 ## End-to-end
 

--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -951,15 +951,20 @@ fn add(
     // `SetCompressionThreads (cthreads)` (Cmdline.hs:294) -- "before the command
     // starts, tell the compression library how many threads it should use".
     //
-    // Here that is rayon's global pool, which is what parallelises 4x4's chunks
-    // and the block decoder. Zero means "as many as the machine has", which is
-    // already rayon's default, so only a positive value does anything.
+    // Two consumers. `memlimit::set_compression_threads` is the C's global,
+    // which GRZip's and 4x4's memory formulas divide by and which LZMA2 hands
+    // straight to its encoder -- there it decides whether the stream is one
+    // solid block or several, so it is archive-visible. The rayon pool below is
+    // this port's own parallelism, and is not.
     //
-    // This does NOT change any archive: measured, `-mgrzip`, `-m4x4:tor` and
-    // `-m9` are byte-identical to the reference under -mt1 and -mt8 alike. The
-    // thread count only reaches GRZip's and 4x4's MEMORY formulas, and those
-    // move the output only when a limit forces a refit. Without this the option
-    // parsed correctly and then controlled nothing at all.
+    // Measured before LZMA2 existed here: `-mgrzip`, `-m4x4:tor` and `-m9` are
+    // byte-identical to the reference under -mt1 and -mt8 alike, because the
+    // thread count reaches only those memory formulas and they move the output
+    // only when a limit forces a refit. `-mlzma2` is the method that breaks
+    // that pattern.
+    darc_arc::memlimit::set_compression_threads(mopts.threads);
+    // Zero means "as many as the machine has", which is already rayon's
+    // default, so only a positive value does anything to the pool.
     if mopts.threads > 0 {
         // Errors only if a pool already exists, which cannot happen this early;
         // either way a failure here just leaves the default pool in place.
@@ -1074,16 +1079,15 @@ fn add(
 
     // An EXPLICIT -lc over a chain this port cannot measure is refused.
     //
-    // `get_compression_mem` returns None for Tornado, REP, LZP, GRZip, LZ4,
-    // Zstd and 4x4, and `limit_compression_mem` leaves those alone -- so
-    // `-mtor -lc8m` would exit 0 with Tornado UNLIMITED. The user asked for a
-    // memory cap and would not get one, which on a small machine is an OOM
-    // rather than a smaller chain. That is the silent no-op this port refuses
-    // everywhere else, and refusing it here too is the consistent answer.
+    // Every method DArc can parse now has a formula, so the only chain that
+    // reaches this is one containing a method with no `Method` variant at all --
+    // and that is refused at write time anyway. The check stays because the
+    // failure it guards against is silent: `limit_compression_mem` leaves a
+    // method with no formula ALONE, so `-lc8m` would exit 0 having capped
+    // nothing, which on a small machine is an OOM rather than a smaller chain.
     //
-    // The DEFAULT limit deliberately does not refuse: it is 75% of RAM, it
-    // does not bind for the chains DArc ships, and refusing there would make
-    // every -mtor archive fail.
+    // The DEFAULT limit deliberately does not refuse: it is 75% of RAM, and
+    // refusing there would make an archive fail for a limit nobody asked for.
     if parsed.arg("LimitCompMem", "--") != "--" {
         for (ty, chain) in &decoded {
             let parsed_chain = darc_arc::method::Method::parse_chain(chain);
@@ -1100,6 +1104,27 @@ fn add(
                     ty
                 );
                 return 2;
+            }
+            // The formulas agree; the chain SPLITTING around them does not.
+            let divergent = match &parsed_chain {
+                Some(ms) => darc_arc::memlimit::lc_divergent(ms),
+                None => None,
+            };
+            match divergent {
+                Some(name) => {
+                    eprintln!(
+                        "ERROR: -lc over {} (file type {:?}) is refused: the reference \
+                         reroutes {name} through a temp-file stage once the limit binds, \
+                         which changes the bytes it writes without changing the method \
+                         string. This port would write a valid archive that is not the \
+                         one the reference writes. Use -lc- , or reach {name} through \
+                         4x4 (-m4x4:{name}), which is byte-identical.",
+                        chain.join("+"),
+                        ty
+                    );
+                    return 2;
+                }
+                None => {}
             }
         }
     }

--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -1105,27 +1105,6 @@ fn add(
                 );
                 return 2;
             }
-            // The formulas agree; the chain SPLITTING around them does not.
-            let divergent = match &parsed_chain {
-                Some(ms) => darc_arc::memlimit::lc_divergent(ms),
-                None => None,
-            };
-            match divergent {
-                Some(name) => {
-                    eprintln!(
-                        "ERROR: -lc over {} (file type {:?}) is refused: the reference \
-                         reroutes {name} through a temp-file stage once the limit binds, \
-                         which changes the bytes it writes without changing the method \
-                         string. This port would write a valid archive that is not the \
-                         one the reference writes. Use -lc- , or reach {name} through \
-                         4x4 (-m4x4:{name}), which is byte-identical.",
-                        chain.join("+"),
-                        ty
-                    );
-                    return 2;
-                }
-                None => {}
-            }
         }
     }
 
@@ -2139,7 +2118,13 @@ fn add(
                     }
                 };
                 let compressor: Vec<String> = fitted.split('+').map(str::to_string).collect();
-                match w.write_compressed_data(&body, compressor, group.len()) {
+                // The chain that COMPRESSES is limited a second time, per block and
+                // after the dictionary was fitted -- and it is not the one stored.
+                let real: Vec<String> = darc_arc::memlimit::real_compressor(&fitted, climit)
+                    .split('+')
+                    .map(str::to_string)
+                    .collect();
+                match w.write_compressed_data(&body, compressor, real, group.len()) {
                     Ok(b) => b,
                     Err(e) => {
                         eprintln!("ERROR: {e}");
@@ -2174,7 +2159,19 @@ fn add(
             _ if darc_arc::method::is_fake_compressor(methods) => Vec::new(),
             _ => {
                 let first = methods.first().map(String::as_str).unwrap_or("");
-                let parsed = darc_arc::method::Method::parse(first);
+                // `-lc` reaches the GROUPING, not just the chain. The criteria
+                // come from `compressor` in `ArhiveFileList.hs`, and that has
+                // already been through `limitCompressionMem climit`
+                // (`Cmdline.hs`) -- so a limit that shrinks a block method's
+                // block size moves where solid blocks END. Measured:
+                // `-mgrzip -lc2m` writes TWO data blocks where `-lc4m` writes
+                // one, and the port wrote one either way until this.
+                let parsed = darc_arc::method::Method::parse(first).map(|m| {
+                    let mut one = [m];
+                    darc_arc::memlimit::limit_compression_mem(&mut one, climit);
+                    let [m] = one;
+                    m
+                });
                 let size = parsed.as_ref().map_or(0, darc_arc::method::block_size);
                 // A DICT chain is capped at its block size wherever dict sits
                 // first; any OTHER block algorithm only when it is alone.
@@ -2225,7 +2222,13 @@ fn add(
                 }
             };
             let compressor: Vec<String> = fitted.split('+').map(str::to_string).collect();
-            match w.write_compressed_data(&body, compressor, len) {
+            // The chain that COMPRESSES is limited a second time, per block and
+            // after the dictionary was fitted -- and it is not the one stored.
+            let real: Vec<String> = darc_arc::memlimit::real_compressor(&fitted, climit)
+                .split('+')
+                .map(str::to_string)
+                .collect();
+            match w.write_compressed_data(&body, compressor, real, len) {
                 Ok(b) => data_blocks.push(b),
                 Err(e) => {
                     eprintln!("ERROR: {e}");

--- a/rust/darc-arc/src/canonize.rs
+++ b/rust/darc-arc/src/canonize.rs
@@ -19,7 +19,8 @@
 //! parameter combinations.
 
 use crate::method::{
-    BscParams, DeltaParams, DictParams, Lz4Params, LzmaParams, LzpParams, Method, MmParams,
+    BscParams, DeltaParams, DictParams, Lz4Params, Lzma2Params, LzmaParams, LzpParams, Method,
+    MmParams,
     PpmdParams, ZstdParams,
 };
 
@@ -63,6 +64,7 @@ pub fn show(method: &Method) -> String {
         Method::Fake => "fake".to_string(),
         Method::Crc => "crc".to_string(),
         Method::Lzma(p) => show_lzma(p),
+        Method::Lzma2(p) => show_lzma2(p),
         Method::Ppmd(p) => show_ppmd(p),
         Method::Delta(p) => show_delta("delta", p),
         // `dispack070` is the name parse_DISPACK prints (C_DisPack.cpp:131).
@@ -88,6 +90,39 @@ pub fn show(method: &Method) -> String {
 fn show_lzma(p: &LzmaParams) -> String {
     let d = LzmaParams::default();
     let mut s = format!("lzma:{}", show_mem(p.dictionary_size));
+    if p.algorithm != d.algorithm {
+        s += &format!(":a{}", p.algorithm);
+    }
+    if p.num_fast_bytes != d.num_fast_bytes {
+        s += &format!(":fb{}", p.num_fast_bytes);
+    }
+    if p.match_finder != d.match_finder {
+        s += &format!(":mf={}", match_finder_name(p.match_finder));
+    }
+    if p.match_finder_cycles != d.match_finder_cycles {
+        s += &format!(":mc{}", p.match_finder_cycles);
+    }
+    if p.pos_state_bits != d.pos_state_bits {
+        s += &format!(":pb{}", p.pos_state_bits);
+    }
+    if p.lit_context_bits != d.lit_context_bits {
+        s += &format!(":lc{}", p.lit_context_bits);
+    }
+    if p.lit_pos_bits != d.lit_pos_bits {
+        s += &format!(":lp{}", p.lit_pos_bits);
+    }
+    s
+}
+
+/// `LZMA2_METHOD::ShowCompressionMethod` (`C_LZMA2.cpp:102`).
+///
+/// The same shape as `show_lzma` and in the same field order, which is the
+/// order the C's `sprintf`s run in. Not shared with it: LZMA's printer also has
+/// an `h` clause, and the two default sets are separate constructors that the
+/// format is entitled to move apart.
+fn show_lzma2(p: &Lzma2Params) -> String {
+    let d = Lzma2Params::default();
+    let mut s = format!("lzma2:{}", show_mem(p.dictionary_size));
     if p.algorithm != d.algorithm {
         s += &format!(":a{}", p.algorithm);
     }

--- a/rust/darc-arc/src/decompress.rs
+++ b/rust/darc-arc/src/decompress.rs
@@ -65,6 +65,10 @@ fn undo(method: &Method, src: &[u8], hint: usize) -> Result<Vec<u8>, Error> {
         // LZMA is the exception: DArc writes no header, so it needs the property
         // bytes rebuilt from the method string rather than a callback.
         Method::Lzma(params) => undo_lzma(*params, src, hint),
+        // LZMA2 carries its own property byte and its own end marker, so unlike
+        // LZMA nothing from the method string is needed to decode it -- the
+        // parameters are for printing the chain back, not for reading it.
+        Method::Lzma2(_) => undo_lzma2(src, hint),
         Method::Ppmd(p) => {
             drive("ppmd", src, hint, |io| {
                 darc_codecs::ppmd::decompress(io, p.order, p.mem, p.mr_method)
@@ -160,6 +164,16 @@ fn undo_lzma(params: LzmaParams, src: &[u8], hint: usize) -> Result<Vec<u8>, Err
     match darc_lzma::decode_stream::decode_stream(&mut source, &mut sink, &props) {
         Ok(_) => Ok(sink.data),
         Err(e) => Err(Error::Codec { method: "lzma".to_string(), detail: format!("{e:?}") }),
+    }
+}
+
+fn undo_lzma2(src: &[u8], hint: usize) -> Result<Vec<u8>, Error> {
+    use darc_lzma::{SliceIn, VecOut};
+    let mut source = SliceIn::new(src);
+    let mut sink = VecOut { data: Vec::with_capacity(hint) };
+    match darc_lzma::lzma2_dec::decode_lzma2_stream(&mut source, &mut sink) {
+        Ok(_) => Ok(sink.data),
+        Err(e) => Err(Error::Codec { method: "lzma2".to_string(), detail: format!("{e:?}") }),
     }
 }
 
@@ -318,6 +332,7 @@ pub fn compress_one_with(method: &Method, src: &[u8], all_at_once: bool) -> Resu
             darc_lzma::encode(src, &props)
                 .map_err(|e| Error::Codec { method: "lzma".to_string(), detail: format!("{e:?}") })
         }
+        Method::Lzma2(p) => do_lzma2(p, src),
         // Named rather than a wildcard, per the crate's exhaustiveness rule: a
         // method added later must show up as a compile error here, not be
         // silently reported as unsupported for writing.
@@ -447,6 +462,52 @@ pub fn compress_one_with(method: &Method, src: &[u8], all_at_once: bool) -> Resu
             }
         }
         other @ Method::Unsupported(_) => Err(Error::Unsupported(format!("{other:?}"))),
+    }
+}
+
+/// `LZMA2_METHOD::compress` (`C_LZMA2.cpp:66`), with `Lzma2EncProps` built the
+/// way `darc_lzma2_compress` builds it so the archiver and the FFI entry point
+/// cannot drift apart.
+///
+/// The `(bt_mode, num_hash_bytes)` pairs are `C_LZMA2.cpp:75-82`'s switch. The C
+/// has a silent `default:` picking BT4; an id outside 0..=4 is refused here
+/// instead, on the rule that two builds must not disagree about what a
+/// malformed method string means. `parse_lzma2` cannot produce one, so this is
+/// a guard, not a path.
+fn do_lzma2(p: &crate::method::Lzma2Params, src: &[u8]) -> Result<Vec<u8>, Error> {
+    use darc_lzma::{SliceIn, VecOut};
+    let fail = |detail: String| Error::Codec { method: "lzma2".to_string(), detail };
+    let mut props = darc_lzma::Lzma2EncProps::init();
+    props.lzma.dict_size = p.dictionary_size;
+    props.lzma.lc = p.lit_context_bits as i32;
+    props.lzma.lp = p.lit_pos_bits as i32;
+    props.lzma.pb = p.pos_state_bits as i32;
+    props.lzma.fb = p.num_fast_bytes as i32;
+    props.lzma.mc = p.match_finder_cycles;
+    props.lzma.algo = p.algorithm as i32;
+    let (bt_mode, num_hash_bytes) = match p.match_finder {
+        0 => (1, 2),
+        1 => (1, 3),
+        2 => (1, 4),
+        3 => (0, 4),
+        4 => (0, 5),
+        mf => return Err(fail(format!("match finder {mf} is not one of BT2..HT4"))),
+    };
+    props.lzma.bt_mode = bt_mode;
+    props.lzma.num_hash_bytes = num_hash_bytes;
+    // `GetCompressionThreads()` (`C_LZMA2.cpp:71-73`). NOT a tuning knob: above
+    // one block thread the encoder splits the input into blocks that each open
+    // with a dictionary reset, so this decides the bytes.
+    let threads = crate::memlimit::compression_threads().clamp(1, u64::from(u32::MAX)) as i32;
+    props.num_total_threads = threads;
+    props.num_block_threads_max = threads;
+    props.normalize();
+
+    let mut source = SliceIn::new(src);
+    let mut sink = VecOut { data: Vec::with_capacity(src.len()) };
+    match darc_lzma::lzma2_enc::compress_stream(&mut source, &mut sink, &props) {
+        Ok(()) => Ok(sink.data),
+        Err(e) => Err(fail(format!("{e:?}"))),
     }
 }
 

--- a/rust/darc-arc/src/memlimit.rs
+++ b/rust/darc-arc/src/memlimit.rs
@@ -61,6 +61,7 @@ pub fn get_dictionary(m: &Method) -> u32 {
         // No dictionary, and no memory: they compress nothing.
         Method::Fake | Method::Crc => 0,
         Method::Lzma(p) => p.dictionary_size,
+        Method::Lzma2(p) => p.dictionary_size,
         Method::Tornado(p) => p.buffer,
         Method::Rep(p) => p.block_size,
         Method::Dict(p) => p.block_size,
@@ -96,6 +97,8 @@ pub fn set_dictionary(m: &mut Method, dict: u32) {
         // Nothing to shrink.
         Method::Fake | Method::Crc => {}
         Method::Lzma(p) => p.dictionary_size = dict,
+        // `SetDictionary` is the same one-liner (C_LZMA2.cpp:100).
+        Method::Lzma2(p) => p.dictionary_size = dict,
         Method::Tornado(p) => set_tornado_dictionary(p, dict),
         Method::Rep(p) => p.block_size = dict,
         Method::Dict(p) => p.block_size = dict,
@@ -301,12 +304,52 @@ mod tests {
 /// pointers, so it follows the machine's width.
 const PTR_SIZE: u64 = 8;
 
-/// `GetCompressionThreads()` — the thread count GRZip's memory formula scales
-/// by. Set from the processor count by default; only GRZip's arithmetic reads
-/// it, and only to divide the limit it is given.
-fn compression_threads() -> u64 {
-    std::thread::available_parallelism().map(|n| n.get() as u64).unwrap_or(1)
+/// What `-mt` was set to, or `None` for "not given".
+///
+/// A global for the same reason the C's is one: `GetCompressionThreads()` is
+/// read from inside method objects that the option never reaches. `-mt` is
+/// scanned once at startup, before any chain is built.
+static COMPRESSION_THREADS: std::sync::atomic::AtomicU32 =
+    std::sync::atomic::AtomicU32::new(0);
+
+/// Record `-mtN`. Zero, which is what `-mt+` means, restores "ask the machine".
+pub fn set_compression_threads(n: u32) {
+    COMPRESSION_THREADS.store(n, std::sync::atomic::Ordering::Relaxed);
 }
+
+/// `GetCompressionThreads()` **as the compressor sees it** — `-mt` if it was
+/// given, else the processor count (`Cmdline.hs:295`).
+///
+/// LZMA2 passes this to its encoder, where it changes the stream outright:
+/// above one block thread `Lzma2EncProps_Normalize` abandons the solid block
+/// and splits the input, so `-mlzma2:d64k -mt1` and `-mlzma2:d64k -mt8` write
+/// different archives on purpose. Measured against the reference in both
+/// states, which is what proves this is plumbed at all.
+pub fn compression_threads() -> u64 {
+    match COMPRESSION_THREADS.load(std::sync::atomic::Ordering::Relaxed) {
+        0 => std::thread::available_parallelism().map(|n| n.get() as u64).unwrap_or(1),
+        n => u64::from(n),
+    }
+}
+
+/// `GetCompressionThreads()` **as the memory formulas see it**, which is always
+/// **one** — and this is not the same number as [`compression_threads`].
+///
+/// `static int compression_threads = 1` (`CompressionLibrary.cpp`), and
+/// `SetCompressionThreads` is deferred: `Cmdline.hs:295` puts it in
+/// `setup_command`, a list that does not run until the command starts. Every
+/// memory limit is applied before that, so GRZip's and 4x4's formulas divide by
+/// the *initial* value and never see `-mt` at all.
+///
+/// Measured, not inferred. `-mgrzip -lc4m` writes `grzip:466033b` in the
+/// reference, and 466033 is 4194304/9 exactly — a divisor of 9, not of 9×8 on
+/// this eight-core machine. `-mt1`, `-mt4` and `-mt8` all leave
+/// `-mgrzip -lc16m` untouched, which they could not if the option reached here.
+///
+/// Reading the processor count instead was a live bug: it made `-lc`/`-ld` on
+/// grzip and 4x4 shrink by a machine-dependent factor, so two hosts wrote
+/// different archives from the same command line.
+const MEMORY_FORMULA_THREADS: u64 = 1;
 
 /// `GetDecompressionMem` — what each method needs to UNPACK, from `C_*.h`.
 pub fn get_decompression_mem(m: &Method) -> u64 {
@@ -314,6 +357,7 @@ pub fn get_decompression_mem(m: &Method) -> u64 {
         // Nothing is stored, so nothing is needed to unpack it.
         Method::Fake | Method::Crc => 0,
         Method::Lzma(p) => u64::from(p.dictionary_size) + 2 * MB,
+        Method::Lzma2(p) => u64::from(p.dictionary_size) + 2 * MB,
         Method::Ppmd(p) => u64::from(p.mem),
         Method::Tornado(p) => u64::from(p.buffer),
         Method::Rep(p) => u64::from(p.block_size),
@@ -337,7 +381,7 @@ pub fn get_decompression_mem(m: &Method) -> u64 {
         Method::Lzp(p) => {
             u64::from(p.block_size) * 2 + (1u64 << p.hash_size_log.clamp(0, 40)) * PTR_SIZE
         }
-        Method::Grzip(p) => u64::from(p.block_size) * 5 * compression_threads(),
+        Method::Grzip(p) => u64::from(p.block_size) * 5 * MEMORY_FORMULA_THREADS,
         Method::Delta(p) => u64::from(p.block_size),
         Method::Dispack(p) => {
             2 * u64::from(p.block_size) + u64::from(p.block_size) / 4 + 1024
@@ -345,7 +389,7 @@ pub fn get_decompression_mem(m: &Method) -> u64 {
         // LARGE_BUFFER_SIZE in C_BCJ.h.
         Method::Exe => 8 * MB,
         Method::FourX4(p) => {
-            let t = if p.num_threads == 0 { compression_threads() } else { u64::from(p.num_threads) };
+            let t = if p.num_threads == 0 { MEMORY_FORMULA_THREADS } else { u64::from(p.num_threads) };
             let d = get_dictionary(&p.inner);
             let bs = if p.block_size != 0 {
                 u64::from(p.block_size)
@@ -375,6 +419,12 @@ pub fn set_decompression_mem(m: &mut Method, mem: u64) {
                 p.dictionary_size = (mem - 2 * MB).min(u64::from(u32::MAX)) as u32;
             }
         }
+        // Identical (C_LZMA2.cpp:95).
+        Method::Lzma2(p) => {
+            if mem > 2 * MB {
+                p.dictionary_size = (mem - 2 * MB).min(u64::from(u32::MAX)) as u32;
+            }
+        }
         // PPMd adjusts its ORDER with its memory, which is why reducing memory
         // changes the method string in two places at once.
         Method::Ppmd(p) => set_ppmd_mem(p, mem),
@@ -392,7 +442,7 @@ pub fn set_decompression_mem(m: &mut Method, mem: u64) {
         Method::Lzp(p) => set_lzp_mem(p, mem),
         // `SetBlockSize (mem/5/threads)`, which also caps the hash.
         Method::Grzip(p) => {
-            let bs = (mem / 5 / compression_threads()).min(u64::from(u32::MAX)) as u32;
+            let bs = (mem / 5 / MEMORY_FORMULA_THREADS).min(u64::from(u32::MAX)) as u32;
             if bs > 0 {
                 p.block_size = bs.min(GRZ_MAX_BLOCK_SIZE);
                 p.hash_size_log =
@@ -647,22 +697,129 @@ pub fn get_compression_mem(m: &Method) -> Option<u64> {
             let bs = u64::from(p.block_size);
             Some(3 * bs + bs / 4 + 1024)
         }
-        // Not reproduced yet. Tornado needs `tornado_compressor_outbuf_size`,
-        // which branches on a global; REP needs `CalcHashSize`; LZP's setter
-        // shrinks the hash before the block; GRZip's figure scales with the
-        // THREAD count, so it is not a property of the method alone; LZ4 and
-        // Zstd ask their libraries; 4x4 recurses into its inner method.
-        Method::Tornado(_)
-        | Method::Rep(_)
-        | Method::Lzp(_)
-        | Method::Grzip(_)
-        | Method::Lz4(_)
-        | Method::Zstd(_)
-        | Method::FourX4(_)
-        | Method::Encryption(_)
-        | Method::Exe
-        | Method::Unsupported(_) => None,
+        // `dict * divisor + 8mb` (C_LZMA2.cpp:76). The divisors are LZMA's
+        // except at BT2, where LZMA2 charges 11 and LZMA charges 10, and the
+        // constant is 8 MB rather than 6 -- so this cannot share
+        // `lzma_mf_multiplier`, however alike the two lines look.
+        Method::Lzma2(p) => {
+            Some(u64::from(p.dictionary_size) * lzma2_mf_multiplier(p.match_finder) + 8 * MB)
+        }
+        // `hashsize + buffer + tornado_compressor_outbuf_size(buffer)`
+        // (C_Tornado.h:33). That last term reads the global
+        // `compress_all_at_once`, which is why this was left unported -- but the
+        // global is 0 everywhere the archiver asks about memory: only
+        // `C_4x4.cpp:571` sets it, and only for the duration of a compress call.
+        // At limit time it is therefore always the `HUGE_BUFFER_SIZE` arm.
+        Method::Tornado(p) => {
+            Some(u64::from(p.hashsize) + u64::from(p.buffer) + HUGE_BUFFER_SIZE)
+        }
+        Method::Rep(p) => Some(rep_compression_mem(p)),
+        // `BlockSize*2 + (1<<HashSizeLog)*sizeof(BYTE*)` (C_LZP.h:39) -- the
+        // same figure as the decompression side, which already carries it.
+        Method::Lzp(p) => Some(
+            u64::from(p.block_size) * 2
+                + (1u64 << p.hash_size_log.clamp(0, 40)) * PTR_SIZE,
+        ),
+        // `BlockSize*9*GetCompressionThreads()` (C_GRZip.h:56). It scales with
+        // the thread count, which makes it machine-dependent -- true of the
+        // reference too, and the reason `golden/manifest.txt` admits no grzip
+        // case rather than a reason to refuse the formula.
+        Method::Grzip(p) => Some(u64::from(p.block_size) * 9 * MEMORY_FORMULA_THREADS),
+        // `BlockSize*2 + sizeof(state)` (C_LZ4.cpp:104).
+        Method::Lz4(p) => Some(u64::from(p.block_size) * 2 + lz4_state_size(p.compressor)),
+        // The C asks the library through `darc_rs_zstd_sizeof_cctx`
+        // (C_Zstd.cpp:61), which is this very function on the other side of the
+        // FFI -- so calling it directly is the same answer, not an estimate of
+        // it.
+        Method::Zstd(p) => {
+            let est = darc_codecs::zstd::sizeof_cctx(p.level, p.window_log) as u64;
+            let est = match p.workers {
+                0 => est,
+                w => est.saturating_mul(u64::from(w) + 1),
+            };
+            Some(match est {
+                0 => 64 * MB,
+                e => e,
+            })
+        }
+        // `t * inner + (t+2) * 2 * bs` (C_4x4.cpp:590), the same shape as the
+        // decompression half. An inner method with no figure has none itself.
+        Method::FourX4(p) => {
+            get_compression_mem(&p.inner).map(|inner| fourx4_mem(p, inner))
+        }
+        // `LARGE_BUFFER_SIZE` (C_BCJ.h:24).
+        Method::Exe => Some(LARGE_BUFFER_SIZE),
+        // `{return 0;}` (C_Encryption.h:44).
+        Method::Encryption(_) => Some(0),
+        // Still the one real gap, and it always will be: a method this port
+        // cannot parse has no parameters to compute a figure from.
+        Method::Unsupported(_) => None,
     }
+}
+
+/// `HUGE_BUFFER_SIZE` and `LARGE_BUFFER_SIZE` (`Compression.h:41,45`).
+const HUGE_BUFFER_SIZE: u64 = 8 * MB;
+const LARGE_BUFFER_SIZE: u64 = 256 * KB;
+
+/// `LZ4_SIZEOF_STATE` / `_HC` (`C_LZ4.cpp:41`) — literal constants there, not
+/// `sizeof` expressions, so they do not follow the machine.
+fn lz4_state_size(compressor: i32) -> u64 {
+    match compressor {
+        0 => 16416,
+        _ => 262200,
+    }
+}
+
+/// LZMA2's match-finder multiplier (`C_LZMA2.cpp:79`).
+fn lzma2_mf_multiplier(mf: u32) -> u64 {
+    match mf {
+        0 | 1 | 2 => 11,
+        3 => 7,
+        _ => 6,
+    }
+}
+
+/// `REP_METHOD::GetCompressionMem` (`C_REP.cpp:84`), which reproduces the
+/// encoder's own hash sizing rather than reading a field.
+fn rep_compression_mem(p: &crate::method::RepParams) -> u64 {
+    // `roundup_to_power_of (mymin(SmallestLen,MinMatchLen)/2, 2)`.
+    let l = roundup_pow2(p.smallest_len.min(p.min_match_len) / 2);
+    // `sqrtb(n, 2)`: `for (result=1; (n /= 4) != 0; result *= 2)`. Not a square
+    // root -- it is 2^floor(log4(n)), and it is 1 for n < 4 rather than 0.
+    let k = {
+        let mut n = l.saturating_mul(2);
+        let mut result = 1u64;
+        loop {
+            n /= 4;
+            if n == 0 {
+                break;
+            }
+            result *= 2;
+        }
+        result
+    };
+    // `CalcHashSize` (C_REP.cpp:78).
+    let hash_size = match p.hash_size_log {
+        0 => u64::from(roundup_pow2(p.block_size / 3 * 2)) / k.max(16),
+        bits => 1u64 << bits.min(63),
+    };
+    u64::from(p.block_size) + hash_size * 4
+}
+
+/// The 4x4 memory shape (`C_4x4.cpp:590`/`:598`), shared by both directions
+/// because the C's two functions differ only in which inner figure they take.
+fn fourx4_mem(p: &crate::fourx4::FourX4Params, inner: u64) -> u64 {
+    let t = match p.num_threads {
+        0 => MEMORY_FORMULA_THREADS,
+        n => u64::from(n),
+    };
+    let d = get_dictionary(&p.inner);
+    let bs = match (p.block_size, d) {
+        (0, 0) => 8 * MB,
+        (0, d) => u64::from(d),
+        (bs, _) => u64::from(bs),
+    };
+    t * inner + (t + 2) * 2 * bs
 }
 
 /// The match finder's memory multiplier (`C_LZMA.cpp`), shared by the getter
@@ -727,16 +884,91 @@ pub fn set_compression_mem(m: &mut Method, mem: u64) -> bool {
             }
             true
         }
-        Method::Tornado(_)
-        | Method::Rep(_)
-        | Method::Lzp(_)
-        | Method::Grzip(_)
-        | Method::Lz4(_)
-        | Method::Zstd(_)
-        | Method::FourX4(_)
-        | Method::Encryption(_)
-        | Method::Exe
-        | Method::Unsupported(_) => false,
+        // `mem = max(mem, 2mb)`, then `avail = mem > 8mb ? mem-8mb : mem`
+        // divided by the multiplier, floored at 4 KB (C_LZMA2.cpp:85).
+        Method::Lzma2(p) => {
+            let mem = mem.max(2 * MB);
+            let base = 8 * MB;
+            let avail = match mem > base {
+                true => mem - base,
+                false => mem,
+            };
+            let d = avail / lzma2_mf_multiplier(p.match_finder);
+            p.dictionary_size = d.max(4 * 1024).min(u64::from(u32::MAX)) as u32;
+            true
+        }
+        // `if (mem>0) hashsize = 1<<lb(mem/3), buffer = mem-hashsize`
+        // (C_Tornado.h:37). The comma operator matters: the hash is computed
+        // first and the buffer gets what is left, so the two are never set from
+        // the same figure.
+        Method::Tornado(p) => {
+            if mem > 0 {
+                let mem = mem.min(u64::from(u32::MAX));
+                let hashsize = 1u64 << lb((mem / 3).min(u64::from(u32::MAX)) as u32);
+                p.hashsize = hashsize.min(u64::from(u32::MAX)) as u32;
+                p.buffer = mem.saturating_sub(hashsize) as u32;
+            }
+            true
+        }
+        // `if (mem>0) BlockSize = 1<<lb(mem/7*6)` (C_REP.h:38). Note `/7*6`,
+        // integer division first -- not `*6/7`.
+        Method::Rep(p) => {
+            if mem > 0 {
+                let target = (mem / 7 * 6).min(u64::from(u32::MAX)).max(1) as u32;
+                p.block_size = 1u32 << lb(target);
+            }
+            true
+        }
+        // `SetDecompressionMem` IS `SetCompressionMem` here (C_LZP.h:44), which
+        // is why the existing helper serves both.
+        Method::Lzp(p) => {
+            set_lzp_mem(p, mem);
+            true
+        }
+        // `SetBlockSize (mem/9/GetCompressionThreads())` (C_GRZip.h:60) -- the
+        // decompression half divides by 5 instead.
+        Method::Grzip(p) => {
+            let bs = (mem / 9 / MEMORY_FORMULA_THREADS).min(u64::from(u32::MAX)) as u32;
+            if bs > 0 {
+                p.block_size = bs.min(GRZ_MAX_BLOCK_SIZE);
+                p.hash_size_log = p.hash_size_log.min(1 + lb(p.block_size.saturating_sub(1)));
+            }
+            true
+        }
+        // `C_LZ4.cpp:109`: the state comes off the top, the rest is split
+        // between the in and out buffers, and the result is clamped to
+        // 64 KB..256 MB. Below `state + 2kb` the split is skipped entirely and
+        // the floor is taken directly.
+        Method::Lz4(p) => {
+            let state = lz4_state_size(p.compressor);
+            let avail = match mem > state + 2 * KB {
+                true => (mem - state) / 2,
+                false => 64 * KB,
+            };
+            p.block_size = avail.clamp(64 * KB, 256 * MB) as u32;
+            true
+        }
+        // `C_Zstd.cpp:70` -- zstd has no dictionary knob, so the memory request
+        // is mapped onto the window log, and only when one was asked for.
+        Method::Zstd(p) => {
+            if mem > 0 {
+                let mut wl = 10u32;
+                while wl < 27 && (1u64 << wl) * 4 < mem {
+                    wl += 1;
+                }
+                p.window_log = wl;
+            }
+            true
+        }
+        // `(void)mem;` -- 4x4's setter is deliberately empty (C_4x4.cpp:607),
+        // so a 4x4 chain reports a figure and then declines to shrink. Left as
+        // the C leaves it: the alternative is to invent a policy the reference
+        // does not have, and `-lc` would then write different bytes.
+        Method::FourX4(_) => true,
+        // Both are empty bodies (C_BCJ.h:28, C_Encryption.h:48).
+        Method::Exe | Method::Encryption(_) => true,
+        // Unparsed, so unadjustable.
+        Method::Unsupported(_) => false,
     }
 }
 
@@ -759,3 +991,154 @@ pub fn limit_compression_mem(chain: &mut [Method], mem: u64) {
 pub fn compression_mem_is_known(chain: &[Method]) -> bool {
     chain.iter().all(|m| get_compression_mem(m).is_some())
 }
+
+/// The methods for which an explicit `-lc` still writes different bytes from
+/// the reference, and so must be refused rather than served.
+///
+/// **The memory formulas are not the problem.** Measured against a reference
+/// built from `9a127e6`, this port and the reference now agree on the method
+/// string at every `-lc` level for both of these — `-mgrzip -lc4m` gives
+/// `grzip:466033b:m1:l32:h15` on both sides, `-mtor -lc4m` gives
+/// `tor:1181kb:h1mb` on both. The archives still differ, with the *same* string
+/// stored.
+///
+/// What differs is upstream of the method: `compressionLimitMemoryUsage`
+/// (`Compression.hs:217`) is `genericLimitMemoryUsage . map limitCompressionMem`,
+/// and that second pass splices a `"tempfile"` stage into the chain once the
+/// accumulated figure passes `limit * 1.05`. It changes how the data is fed to
+/// the codec, not what the codec is. LZMA is unaffected — `-mlzma -lc4m` is
+/// byte-identical — because it buffers the whole block either way; Tornado and
+/// GRZip parse what they are handed, so their output follows the chunking.
+///
+/// Only the TOP level is examined, and that is deliberate rather than lazy:
+/// `-m4x4:tor -lc16m` is byte-identical to the reference, so a Tornado reached
+/// through 4x4 does not trip this. `-m4` and `-m9` do trip it, because their
+/// per-filetype chains carry `tor` and `grzip` at the top level — and they were
+/// refused before this too, when the refusal was "no formula for tor".
+///
+/// Everything else that used to be refused for want of a formula — REP, LZP,
+/// LZ4, Zstd, 4x4, `exe`, encryption — is now served and gated on byte
+/// identity.
+pub fn lc_divergent(chain: &[Method]) -> Option<&'static str> {
+    chain.iter().find_map(|m| match *m {
+        Method::Tornado(_) => Some("tor"),
+        Method::Grzip(_) => Some("grzip"),
+        Method::Storing
+        | Method::Fake
+        | Method::Crc
+        | Method::Lzma(_)
+        | Method::Lzma2(_)
+        | Method::Ppmd(_)
+        | Method::Rep(_)
+        | Method::Exe
+        | Method::Dict(_)
+        | Method::Lzp(_)
+        | Method::Delta(_)
+        | Method::Dispack(_)
+        | Method::Tta(_)
+        | Method::Mm(_)
+        | Method::Zstd(_)
+        | Method::Lz4(_)
+        | Method::Bsc(_)
+        | Method::FourX4(_)
+        | Method::Encryption(_)
+        | Method::Unsupported(_) => None,
+    })
+}
+
+#[cfg(test)]
+mod lzma2_and_lc_tests {
+    use super::*;
+    use crate::method::Method;
+
+    fn m(s: &str) -> Method {
+        Method::parse(s).expect("parses")
+    }
+
+    /// The two figures the C computes from `dictionarySize`, which decide what
+    /// `-lc`/`-ld` write into an archive.
+    #[test]
+    fn lzma2_memory_matches_the_c() {
+        // `dict * divisor + 8mb`, divisor 6 at the default HT4.
+        assert_eq!(get_compression_mem(&m("lzma2:1m")), Some(MB * 6 + 8 * MB));
+        // BT2 charges 11 here where LZMA charges 10 -- the one place the two
+        // multiplier tables differ.
+        assert_eq!(get_compression_mem(&m("lzma2:1m:BT2")), Some(MB * 11 + 8 * MB));
+        assert_eq!(get_compression_mem(&m("lzma:1m:BT2")), Some(MB * 10 + 6 * MB));
+        // `dictionarySize + 2mb`.
+        assert_eq!(get_decompression_mem(&m("lzma2:1m")), MB + 2 * MB);
+    }
+
+    /// `SetCompressionMem`: 8 MB comes off the top, the rest is divided by the
+    /// match finder's multiplier.
+    #[test]
+    fn lzma2_set_compression_mem_subtracts_the_base_first() {
+        let mut a = m("lzma2");
+        assert!(set_compression_mem(&mut a, 32 * MB));
+        assert_eq!(get_dictionary(&a), ((32 - 8) * MB / 6) as u32);
+        // Below the 8 MB base the subtraction is SKIPPED rather than clamped --
+        // `avail = mem > base ? mem-base : mem` -- and `mem` has already been
+        // raised to 2 MB. So the smallest dictionary this can produce is
+        // 2 MB / 6, and the C's 4 KB floor below it is unreachable from here.
+        // Asserting the floor instead would have been asserting dead code.
+        let mut b = m("lzma2");
+        assert!(set_compression_mem(&mut b, 1024));
+        assert_eq!(get_dictionary(&b), (2 * MB / 6) as u32);
+    }
+
+    /// Every method DArc can parse now answers `Some`. Before this, seven did
+    /// not, and an explicit `-lc` over any of them was refused outright.
+    #[test]
+    fn every_parsable_method_has_a_compression_formula() {
+        for s in [
+            "storing", "lzma", "lzma2", "ppmd", "tor", "rep", "grzip", "exe", "dict", "lzp",
+            "delta", "dispack", "tta", "mm", "zstd", "lz4", "bsc", "4x4:tor",
+        ] {
+            assert!(
+                get_compression_mem(&m(s)).is_some(),
+                "{s} has no compression-memory formula"
+            );
+        }
+        // The one that must stay None: nothing can be computed from a name this
+        // port cannot parse.
+        assert_eq!(get_compression_mem(&Method::Unsupported("nope".into())), None);
+    }
+
+    /// The figures the reference was measured to produce. `-mgrzip -lc4m`
+    /// writes `grzip:466033b`, and 466033 is 4194304/9 exactly -- a divisor of
+    /// 9, NOT of 9 times the processor count.
+    #[test]
+    fn grzip_memory_formula_does_not_read_the_processor_count() {
+        let mut g = m("grzip");
+        assert!(set_compression_mem(&mut g, 4 * MB));
+        assert_eq!(get_dictionary(&g), 4 * MB as u32 / 9);
+        // The getter is the same constant the other way round.
+        assert_eq!(get_compression_mem(&m("grzip:1m")), Some(MB * 9));
+    }
+
+    /// `1<<lb(mem/7*6)`, integer division first. `*6/7` would give 3 670 016
+    /// here and round to the same power of two, so the test uses a value where
+    /// the two orders differ in the exponent.
+    #[test]
+    fn rep_set_compression_mem_is_a_power_of_two() {
+        let mut r = m("rep");
+        assert!(set_compression_mem(&mut r, 10 * MB));
+        assert_eq!(get_dictionary(&r), 8 * MB as u32);
+    }
+
+    /// `-lc` is refused for exactly two methods, and only at the top level.
+    #[test]
+    fn lc_is_refused_for_tor_and_grzip_only() {
+        let chain = |s: &str| {
+            Method::parse_chain(&s.split('+').map(str::to_string).collect::<Vec<_>>()).unwrap()
+        };
+        assert_eq!(lc_divergent(&chain("tor")), Some("tor"));
+        assert_eq!(lc_divergent(&chain("rep+tor:16mb")), Some("tor"));
+        assert_eq!(lc_divergent(&chain("grzip")), Some("grzip"));
+        // Reached through 4x4, which IS byte-identical under -lc.
+        assert_eq!(lc_divergent(&chain("4x4:tor")), None);
+        assert_eq!(lc_divergent(&chain("lzma2")), None);
+        assert_eq!(lc_divergent(&chain("rep+exe+lzma:1m")), None);
+    }
+}
+

--- a/rust/darc-arc/src/memlimit.rs
+++ b/rust/darc-arc/src/memlimit.rs
@@ -679,6 +679,13 @@ pub fn parse_mem_with_percents(memory: u64, s: &str) -> Option<u64> {
 /// it as "do not touch", which is exactly what the port did before `-lc`
 /// existed and so cannot change an archive that used to be written.
 pub fn get_compression_mem(m: &Method) -> Option<u64> {
+    get_compression_mem_with(m, MEMORY_FORMULA_THREADS)
+}
+
+/// `GetCompressionMem` with the thread count supplied, because the archiver
+/// asks this same question at two moments and is entitled to two different
+/// answers. See [`MEMORY_FORMULA_THREADS`] and [`real_compressor`].
+pub fn get_compression_mem_with(m: &Method, threads: u64) -> Option<u64> {
     match m {
         // No compression, no memory.
         Method::Storing | Method::Fake | Method::Crc => Some(0),
@@ -724,7 +731,7 @@ pub fn get_compression_mem(m: &Method) -> Option<u64> {
         // the thread count, which makes it machine-dependent -- true of the
         // reference too, and the reason `golden/manifest.txt` admits no grzip
         // case rather than a reason to refuse the formula.
-        Method::Grzip(p) => Some(u64::from(p.block_size) * 9 * MEMORY_FORMULA_THREADS),
+        Method::Grzip(p) => Some(u64::from(p.block_size) * 9 * threads),
         // `BlockSize*2 + sizeof(state)` (C_LZ4.cpp:104).
         Method::Lz4(p) => Some(u64::from(p.block_size) * 2 + lz4_state_size(p.compressor)),
         // The C asks the library through `darc_rs_zstd_sizeof_cctx`
@@ -745,7 +752,7 @@ pub fn get_compression_mem(m: &Method) -> Option<u64> {
         // `t * inner + (t+2) * 2 * bs` (C_4x4.cpp:590), the same shape as the
         // decompression half. An inner method with no figure has none itself.
         Method::FourX4(p) => {
-            get_compression_mem(&p.inner).map(|inner| fourx4_mem(p, inner))
+            get_compression_mem_with(&p.inner, threads).map(|inner| fourx4_mem(p, inner, threads))
         }
         // `LARGE_BUFFER_SIZE` (C_BCJ.h:24).
         Method::Exe => Some(LARGE_BUFFER_SIZE),
@@ -808,9 +815,9 @@ fn rep_compression_mem(p: &crate::method::RepParams) -> u64 {
 
 /// The 4x4 memory shape (`C_4x4.cpp:590`/`:598`), shared by both directions
 /// because the C's two functions differ only in which inner figure they take.
-fn fourx4_mem(p: &crate::fourx4::FourX4Params, inner: u64) -> u64 {
+fn fourx4_mem(p: &crate::fourx4::FourX4Params, inner: u64, threads: u64) -> u64 {
     let t = match p.num_threads {
-        0 => MEMORY_FORMULA_THREADS,
+        0 => threads,
         n => u64::from(n),
     };
     let d = get_dictionary(&p.inner);
@@ -838,6 +845,11 @@ fn lzma_mf_multiplier(mf: u32) -> u64 {
 /// `SetCompressionMem`. Returns false when the method has no implementation
 /// here, leaving it untouched.
 pub fn set_compression_mem(m: &mut Method, mem: u64) -> bool {
+    set_compression_mem_with(m, MEMORY_FORMULA_THREADS, mem)
+}
+
+/// `SetCompressionMem` with the thread count supplied, for the same reason.
+pub fn set_compression_mem_with(m: &mut Method, threads: u64, mem: u64) -> bool {
     match m {
         Method::Storing | Method::Fake | Method::Crc => true,
         Method::Lzma(p) => {
@@ -928,7 +940,7 @@ pub fn set_compression_mem(m: &mut Method, mem: u64) -> bool {
         // `SetBlockSize (mem/9/GetCompressionThreads())` (C_GRZip.h:60) -- the
         // decompression half divides by 5 instead.
         Method::Grzip(p) => {
-            let bs = (mem / 9 / MEMORY_FORMULA_THREADS).min(u64::from(u32::MAX)) as u32;
+            let bs = (mem / 9 / threads).min(u64::from(u32::MAX)) as u32;
             if bs > 0 {
                 p.block_size = bs.min(GRZ_MAX_BLOCK_SIZE);
                 p.hash_size_log = p.hash_size_log.min(1 + lb(p.block_size.saturating_sub(1)));
@@ -987,63 +999,58 @@ pub fn limit_compression_mem(chain: &mut [Method], mem: u64) {
     }
 }
 
+/// `limit_compressor` (`Options.hs:143`) — the chain a DATA_BLOCK is actually
+/// compressed with, which is **not** the chain stored in its header.
+///
+/// `ArcvProcessRead.hs:117-134` is explicit about this:
+///
+/// ```haskell
+///   compressor = orig_compressor .$ limitDictionary (roundMemUp (totalBytes + ...))
+///   real_compressor <- limit_compressor command compressor
+///   writeBlock pipe DATA_BLOCK compressor real_compressor copy_solid_block
+/// ```
+///
+/// `-lc` is therefore applied **twice**, and the two passes see different
+/// chains. The first runs when the command line is parsed and produces what is
+/// STORED. The second runs per block, *after* the dictionary has been fitted to
+/// the data, and produces what is USED. `Options.hs:140` says so in as many
+/// words: "the compressor actually used differs from the one recorded in the
+/// block header".
+///
+/// The second pass also sees a different thread count. `setup_command` has run
+/// by the time a block is compressed, so `GetCompressionThreads()` is the
+/// processor count here where it was 1 at parse time — which is why GRZip, and
+/// only GRZip, shrinks by a factor of the core count in this pass.
+///
+/// Control blocks do not get this: `writeControlBlock` passes the same chain
+/// twice (`ArcvProcessRead.hs:273`).
+pub fn real_compressor(chain: &str, climit: u64) -> String {
+    // `if memory_limit == aUNLIMITED_MEMORY then return compressor`.
+    if climit == u64::MAX {
+        return chain.to_string();
+    }
+    let names: Vec<String> = chain.split('+').map(str::to_string).collect();
+    let mut methods = match Method::parse_chain(&names) {
+        Some(ms) => ms,
+        // Unparsable here means unwritable downstream, which is where it is
+        // reported. Returning the chain unchanged keeps that the only error.
+        None => return chain.to_string(),
+    };
+    let threads = compression_threads();
+    for m in methods.iter_mut() {
+        match get_compression_mem_with(m, threads) {
+            Some(have) if have > climit => {
+                set_compression_mem_with(m, threads, climit);
+            }
+            _ => {}
+        }
+    }
+    methods.iter().map(crate::canonize::show).collect::<Vec<_>>().join("+")
+}
+
 /// Does every method in the chain have a compression-memory formula here?
 pub fn compression_mem_is_known(chain: &[Method]) -> bool {
     chain.iter().all(|m| get_compression_mem(m).is_some())
-}
-
-/// The methods for which an explicit `-lc` still writes different bytes from
-/// the reference, and so must be refused rather than served.
-///
-/// **The memory formulas are not the problem.** Measured against a reference
-/// built from `9a127e6`, this port and the reference now agree on the method
-/// string at every `-lc` level for both of these — `-mgrzip -lc4m` gives
-/// `grzip:466033b:m1:l32:h15` on both sides, `-mtor -lc4m` gives
-/// `tor:1181kb:h1mb` on both. The archives still differ, with the *same* string
-/// stored.
-///
-/// What differs is upstream of the method: `compressionLimitMemoryUsage`
-/// (`Compression.hs:217`) is `genericLimitMemoryUsage . map limitCompressionMem`,
-/// and that second pass splices a `"tempfile"` stage into the chain once the
-/// accumulated figure passes `limit * 1.05`. It changes how the data is fed to
-/// the codec, not what the codec is. LZMA is unaffected — `-mlzma -lc4m` is
-/// byte-identical — because it buffers the whole block either way; Tornado and
-/// GRZip parse what they are handed, so their output follows the chunking.
-///
-/// Only the TOP level is examined, and that is deliberate rather than lazy:
-/// `-m4x4:tor -lc16m` is byte-identical to the reference, so a Tornado reached
-/// through 4x4 does not trip this. `-m4` and `-m9` do trip it, because their
-/// per-filetype chains carry `tor` and `grzip` at the top level — and they were
-/// refused before this too, when the refusal was "no formula for tor".
-///
-/// Everything else that used to be refused for want of a formula — REP, LZP,
-/// LZ4, Zstd, 4x4, `exe`, encryption — is now served and gated on byte
-/// identity.
-pub fn lc_divergent(chain: &[Method]) -> Option<&'static str> {
-    chain.iter().find_map(|m| match *m {
-        Method::Tornado(_) => Some("tor"),
-        Method::Grzip(_) => Some("grzip"),
-        Method::Storing
-        | Method::Fake
-        | Method::Crc
-        | Method::Lzma(_)
-        | Method::Lzma2(_)
-        | Method::Ppmd(_)
-        | Method::Rep(_)
-        | Method::Exe
-        | Method::Dict(_)
-        | Method::Lzp(_)
-        | Method::Delta(_)
-        | Method::Dispack(_)
-        | Method::Tta(_)
-        | Method::Mm(_)
-        | Method::Zstd(_)
-        | Method::Lz4(_)
-        | Method::Bsc(_)
-        | Method::FourX4(_)
-        | Method::Encryption(_)
-        | Method::Unsupported(_) => None,
-    })
 }
 
 #[cfg(test)]
@@ -1116,6 +1123,26 @@ mod lzma2_and_lc_tests {
         assert_eq!(get_compression_mem(&m("grzip:1m")), Some(MB * 9));
     }
 
+    /// The stored chain and the compressing chain are NOT the same under `-lc`.
+    ///
+    /// This is the bug that hid behind agreeing method strings: the port stored
+    /// `grzip:1181kb` correctly and then compressed with it, where the
+    /// reference compresses with `grzip:233016b`. Reading the archive's method
+    /// string proved nothing, because that string is the STORED one.
+    #[test]
+    fn real_compressor_differs_from_the_stored_chain() {
+        set_compression_threads(8);
+        // 1209344 * 9 * 8 = 87 072 768, over a 16 MB limit, so it re-limits to
+        // 16777216/9/8.
+        assert_eq!(real_compressor("grzip:1181kb:m1:l32:h15", 16 * MB), "grzip:233016b:m1:l32:h15");
+        // Under a limit it already fits, the chain is returned untouched.
+        assert_eq!(real_compressor("grzip:1181kb:m1:l32:h15", 512 * MB), "grzip:1181kb:m1:l32:h15");
+        // `-lc-` is unlimited and must not even parse-and-reprint, or a method
+        // this port cannot canonicalise would be rewritten behind the user.
+        assert_eq!(real_compressor("anything:at:all", u64::MAX), "anything:at:all");
+        set_compression_threads(0);
+    }
+
     /// `1<<lb(mem/7*6)`, integer division first. `*6/7` would give 3 670 016
     /// here and round to the same power of two, so the test uses a value where
     /// the two orders differ in the exponent.
@@ -1126,19 +1153,5 @@ mod lzma2_and_lc_tests {
         assert_eq!(get_dictionary(&r), 8 * MB as u32);
     }
 
-    /// `-lc` is refused for exactly two methods, and only at the top level.
-    #[test]
-    fn lc_is_refused_for_tor_and_grzip_only() {
-        let chain = |s: &str| {
-            Method::parse_chain(&s.split('+').map(str::to_string).collect::<Vec<_>>()).unwrap()
-        };
-        assert_eq!(lc_divergent(&chain("tor")), Some("tor"));
-        assert_eq!(lc_divergent(&chain("rep+tor:16mb")), Some("tor"));
-        assert_eq!(lc_divergent(&chain("grzip")), Some("grzip"));
-        // Reached through 4x4, which IS byte-identical under -lc.
-        assert_eq!(lc_divergent(&chain("4x4:tor")), None);
-        assert_eq!(lc_divergent(&chain("lzma2")), None);
-        assert_eq!(lc_divergent(&chain("rep+exe+lzma:1m")), None);
-    }
 }
 

--- a/rust/darc-arc/src/method.rs
+++ b/rust/darc-arc/src/method.rs
@@ -239,6 +239,43 @@ pub struct MmParams {
     pub extra: i32,
 }
 
+/// `lzma2:...` (`C_LZMA2.cpp:118`).
+///
+/// The same knobs as [`LzmaParams`] minus `hash_size`: `LZMA2_METHOD` has no
+/// `h` parameter, so `lzma2:h4mb` is a rejected string where `lzma:h4mb` is not.
+/// Kept as its own struct rather than reusing `LzmaParams` for exactly that
+/// reason — a shared struct would carry a field the format cannot express, and
+/// the printer would have to remember never to print it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Lzma2Params {
+    pub dictionary_size: u32,
+    pub algorithm: u32,
+    pub num_fast_bytes: u32,
+    pub match_finder: u32,
+    pub match_finder_cycles: u32,
+    pub pos_state_bits: u32,
+    pub lit_context_bits: u32,
+    pub lit_pos_bits: u32,
+}
+
+impl Default for Lzma2Params {
+    /// `LZMA2_METHOD::LZMA2_METHOD()` (`C_LZMA2.cpp:40`) — field for field the
+    /// same values as LZMA's constructor, which is why a bare `lzma2` and a bare
+    /// `lzma` differ only in the container.
+    fn default() -> Self {
+        Lzma2Params {
+            dictionary_size: 64 * 1024 * 1024,
+            algorithm: 1,
+            num_fast_bytes: 32,
+            match_finder: MF_HT4,
+            match_finder_cycles: 0,
+            pos_state_bits: 2,
+            lit_context_bits: 3,
+            lit_pos_bits: 0,
+        }
+    }
+}
+
 /// `bsc:...` (`C_BSC.cpp:218`).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct BscParams {
@@ -312,6 +349,9 @@ pub enum Method {
     /// CRC32s recorded, but the data is still not stored.
     Crc,
     Lzma(LzmaParams),
+    /// `lzma2` — the same LZMA coder inside the chunked LZMA2 container, which
+    /// is a different wire format and so a different method, not a parameter.
+    Lzma2(Lzma2Params),
     Ppmd(PpmdParams),
     /// Tornado. The decoder reads everything it needs from the stream header;
     /// the parameters here exist so the method string can be printed back.
@@ -371,6 +411,7 @@ impl Method {
             "fake" => Some(Method::Fake),
             "crc" => Some(Method::Crc),
             "lzma" => parse_lzma(params.into_iter()).map(Method::Lzma),
+            "lzma2" => parse_lzma2(&params).map(Method::Lzma2),
             "ppmd" => parse_ppmd(&params).map(Method::Ppmd),
             "tor" => parse_tornado(&params).map(Method::Tornado),
             "rep" => parse_rep(&params).map(Method::Rep),
@@ -1241,6 +1282,114 @@ fn parse_lzma<'a, I: Iterator<Item = &'a str>>(params: I) -> Option<LzmaParams> 
     Some(p)
 }
 
+/// `parse_LZMA2` (`C_LZMA2.cpp:118`).
+///
+/// Deliberately a separate walk from [`parse_lzma`] rather than a shared one,
+/// because the two grammars differ in three places and every difference is a
+/// string one side accepts and the other rejects:
+///
+/// * no `h` — LZMA2 has no hash-size parameter;
+/// * `mf=NAME` only. `start_from2(param, "mf=")` is the whole test, so the bare
+///   `mfBT4` spelling `parse_LZMA` also takes is an error here;
+/// * a bare match-finder name (`BT4`) is still accepted, before either.
+fn parse_lzma2(params: &[&str]) -> Option<Lzma2Params> {
+    let mut p = Lzma2Params::default();
+    for param in params {
+        match *param {
+            "max" | "normal" => {
+                p.algorithm = 1;
+                continue;
+            }
+            "fast" | "fastest" => {
+                p.algorithm = 0;
+                continue;
+            }
+            // The end marker is always written, so asking for it is a no-op.
+            "eos" => continue,
+            _ => {}
+        }
+        match find_match_finder(param) {
+            Some(mf) => {
+                p.match_finder = mf;
+                continue;
+            }
+            None => {}
+        }
+        match param.strip_prefix("mf=") {
+            // `if (mf < 0) { error=1; break; }` -- an unknown name after `mf=`
+            // rejects the whole string rather than falling through to the
+            // switch, which would read the 'm' as the start of `mc`.
+            Some(rest) => {
+                p.match_finder = find_match_finder(rest)?;
+                continue;
+            }
+            None => {}
+        }
+        let two = param.get(..2).unwrap_or("");
+        let handled = match two {
+            "pb" => {
+                p.pos_state_bits = parse_int(&param[2..])?;
+                true
+            }
+            "lc" => {
+                p.lit_context_bits = parse_int(&param[2..])?;
+                true
+            }
+            "lp" => {
+                p.lit_pos_bits = parse_int(&param[2..])?;
+                true
+            }
+            "fb" => {
+                p.num_fast_bytes = parse_int(&param[2..])?;
+                true
+            }
+            "mc" => {
+                p.match_finder_cycles = parse_int(&param[2..])?;
+                true
+            }
+            _ => false,
+        };
+        if handled {
+            continue;
+        }
+        match param.chars().next() {
+            Some('d') => {
+                p.dictionary_size = parse_mem(&param[1..])?;
+                continue;
+            }
+            Some('a') => {
+                p.algorithm = parse_int(&param[1..])?;
+                continue;
+            }
+            // As in `parse_lzma`: a leading digit is a dictionary size only
+            // when a b/k/m/g suffix follows the digits, and a fast-byte count
+            // otherwise. A `d`-less `64m` therefore sets the dictionary, while
+            // a bare `64` sets fb.
+            Some(c) if c.is_ascii_digit() => {
+                let digits = param.chars().take_while(char::is_ascii_digit).count();
+                match param[digits..].chars().next() {
+                    Some('b') | Some('k') | Some('m') | Some('g') => match parse_mem(param) {
+                        Some(m) => {
+                            p.dictionary_size = m;
+                            continue;
+                        }
+                        // `error = 0` -- the C clears it and tries fb.
+                        None => {}
+                    },
+                    Some(_) | None => {}
+                }
+                p.num_fast_bytes = parse_int(param)?;
+                continue;
+            }
+            // Anything else, including a `p`/`l`/`f`/`m` whose second letter did
+            // not match above: the C's switch `break`s, the digit test fails on
+            // a non-digit, and `error = 1`.
+            Some(_) | None => return None,
+        }
+    }
+    Some(p)
+}
+
 /// `GetBlockSize` (`Compression.h:341`) — how much data the method processes at
 /// one time, and `0` for the ones that stream.
 ///
@@ -1270,6 +1419,9 @@ pub fn block_size(m: &Method) -> u64 {
         | Method::Zstd(_)
         | Method::Storing
         | Method::Lzma(_)
+        // `{return 0;}` (C_LZMA2.h:28). LZMA2 does chunk its input internally,
+        // but it never asks the archiver for a boundary.
+        | Method::Lzma2(_)
         | Method::Ppmd(_)
         | Method::Tornado(_)
         | Method::Rep(_)
@@ -1595,5 +1747,106 @@ mod tests {
             }
             other => panic!("{other:?}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod lzma2_tests {
+    use super::{Lzma2Params, Method};
+
+    fn p(s: &str) -> Lzma2Params {
+        match Method::parse(s) {
+            Some(Method::Lzma2(p)) => p,
+            other => panic!("{s} parsed as {other:?}"),
+        }
+    }
+
+    /// A bare `lzma2` is the constructor's values, and those are format: they
+    /// are what every `-mlzma2` block is written with.
+    #[test]
+    fn bare_lzma2_is_the_constructor_defaults() {
+        let d = Lzma2Params::default();
+        assert_eq!(Method::parse("lzma2"), Some(Method::Lzma2(d)));
+        assert_eq!(d.dictionary_size, 64 * 1024 * 1024);
+        assert_eq!(d.num_fast_bytes, 32);
+        assert_eq!(d.match_finder, 4);
+        assert_eq!(d.pos_state_bits, 2);
+        assert_eq!(d.lit_context_bits, 3);
+    }
+
+    /// The digit rule: a memory suffix makes it a dictionary, its absence makes
+    /// it a fast-byte count. Getting this backwards silently rewrites the
+    /// dictionary of every `-mlzma2:64` archive.
+    #[test]
+    fn a_leading_digit_is_a_dictionary_only_with_a_unit() {
+        assert_eq!(p("lzma2:1m").dictionary_size, 1024 * 1024);
+        assert_eq!(p("lzma2:1m").num_fast_bytes, 32);
+        assert_eq!(p("lzma2:64").num_fast_bytes, 64);
+        assert_eq!(p("lzma2:64").dictionary_size, 64 * 1024 * 1024);
+        assert_eq!(p("lzma2:d64k").dictionary_size, 64 * 1024);
+    }
+
+    /// Where the grammar differs from LZMA's, and each difference is a string
+    /// one accepts and the other rejects.
+    #[test]
+    fn lzma2_grammar_is_not_lzmas() {
+        // No `h`: LZMA takes a hash size, LZMA2 has no such field.
+        assert!(Method::parse("lzma:h4m").is_some());
+        assert_eq!(Method::parse("lzma2:h4m"), None);
+        // `mf=NAME` only -- `start_from2(param,"mf=")` is the whole test.
+        assert_eq!(p("lzma2:mf=BT4").match_finder, 2);
+        assert_eq!(Method::parse("lzma2:mfBT4"), None);
+        // A bare match-finder name is still taken, before either.
+        assert_eq!(p("lzma2:BT2").match_finder, 0);
+        assert_eq!(p("lzma2:hc4").match_finder, 3);
+        // An unknown name after `mf=` rejects the whole string rather than
+        // falling through to reading the 'm' as `mc`.
+        assert_eq!(Method::parse("lzma2:mf=nope"), None);
+    }
+
+    #[test]
+    fn lzma2_named_parameters() {
+        assert_eq!(p("lzma2:a0").algorithm, 0);
+        assert_eq!(p("lzma2:fast").algorithm, 0);
+        assert_eq!(p("lzma2:fastest").algorithm, 0);
+        assert_eq!(p("lzma2:max").algorithm, 1);
+        assert_eq!(p("lzma2:normal").algorithm, 1);
+        assert_eq!(p("lzma2:fb128").num_fast_bytes, 128);
+        assert_eq!(p("lzma2:mc48").match_finder_cycles, 48);
+        assert_eq!(p("lzma2:pb1").pos_state_bits, 1);
+        assert_eq!(p("lzma2:lc0").lit_context_bits, 0);
+        assert_eq!(p("lzma2:lp1").lit_pos_bits, 1);
+        // "eos" is accepted and ignored: the end marker is always written.
+        assert_eq!(Method::parse("lzma2:eos"), Method::parse("lzma2"));
+        // A `p`, `l`, `f` or `m` whose second letter is not one of the known
+        // pairs is an error, not a silently ignored parameter.
+        assert_eq!(Method::parse("lzma2:px1"), None);
+        assert_eq!(Method::parse("lzma2:zz"), None);
+    }
+
+    /// Parse then print must round-trip, because the printed string is what
+    /// goes into the archive and what a later read parses back.
+    #[test]
+    fn lzma2_round_trips_through_the_printer() {
+        for s in [
+            "lzma2",
+            "lzma2:1mb",
+            "lzma2:64kb:a0",
+            "lzma2:1mb:fb128",
+            "lzma2:1mb:mf=BT4",
+            "lzma2:1mb:mc48",
+            "lzma2:1mb:pb1:lc1:lp1",
+        ] {
+            let first = crate::canonize::show(&Method::parse(s).expect(s));
+            let again = crate::canonize::show(&Method::parse(&first).expect(&first));
+            assert_eq!(first, again, "{s} did not round-trip");
+        }
+        // The canonical spelling of the defaults, which is what a bare -mlzma2
+        // stores.
+        assert_eq!(crate::canonize::show(&Method::parse("lzma2").unwrap()), "lzma2:64mb");
+        assert_eq!(
+            crate::canonize::show(&Method::parse("lzma2:1m:BT4:fb64").unwrap()),
+            "lzma2:1mb:fb64:mf=BT4"
+        );
     }
 }

--- a/rust/darc-arc/src/writer.rs
+++ b/rust/darc-arc/src/writer.rs
@@ -370,7 +370,11 @@ impl Writer {
         compressor: Vec<String>,
         files: usize,
     ) -> Result<ArchiveBlock, crate::decompress::Error> {
-        self.write_compressed_data(body, compressor, files)
+        // The two chains are the same here, which is what the reference does
+        // for every block that is not a DATA_BLOCK: `writeControlBlock` passes
+        // its compressor twice (`ArcvProcessRead.hs:273`).
+        let real = compressor.clone();
+        self.write_compressed_data(body, compressor, real, files)
     }
 
     /// A data block whose bytes are COMPRESSED with `compressor`.
@@ -381,12 +385,19 @@ impl Writer {
         &mut self,
         body: &[u8],
         compressor: Vec<String>,
+        real_compressor: Vec<String>,
         files: usize,
     ) -> Result<ArchiveBlock, crate::decompress::Error> {
         let (real_suffix, stored_suffix) = self
             .encryption_for(BlockType::Data)
             .map_err(|e| crate::decompress::Error::BadMethod(e.to_string()))?;
-        let mut real = compressor.clone();
+        // Two chains, and the split is the reference's: `compressor` is written
+        // into the block header, `real_compressor` is what compresses the bytes
+        // (`ArcvProcessRead.hs:134`). Encryption already worked this way for
+        // its own reason -- the stored form carries salt and check code, the
+        // real one carries the key -- so this is the same shape widened, not a
+        // new concept.
+        let mut real = real_compressor;
         real.extend(real_suffix);
         let mut compressor = compressor;
         compressor.extend(stored_suffix);


### PR DESCRIPTION
Closes the two items left on the table after the port finished. Three commits: lzma2, the `-lc` memory formulas, and then the reason `-lc` still diverged.

## `-mlzma2` (was unreadable *and* unwritable)

No `"lzma2"` arm in the parser and no `Lzma2` variant, so an lzma2 archive listed fine and then failed to extract. Same shape as the mm/tta/bsc/lz4/zstd gap and the same fix: variant, parser, canonize, encode/decode dispatch.

The grammar is deliberately **not** shared with LZMA's — LZMA2 has no `h` parameter and takes `mf=NAME` only, so `lzma2:h4m` and `lzma2:mfBT4` are rejected where the LZMA spellings parse.

Gated against a reference built from `9a127e6`: 23/23 method strings byte-identical; 20/20 cross-extractions (reference archives read by the port **and** port archives read by the reference — the half a write-side matrix cannot see); and `-mt1` vs `-mt8` writing *different* archives on both sides, which proves the thread count is plumbed rather than merely accepted.

## `-lc`: the formulas were the easy half

All seven missing `GetCompressionMem`/`SetCompressionMem` are ported (Tornado, REP, LZP, GRZip, LZ4, Zstd, 4x4) plus `exe` and encryption. The only `None` left is a method the port cannot parse at all.

**That was not enough, and the way it failed is the interesting part.** With every formula right, the port and the reference agreed on the stored method string at every `-lc` level — `-mgrzip -lc4m` stores `grzip:466033b` on both sides — and the archives still differed. Comparing method strings would have called this green.

The cause, from `ArcvProcessRead.hs:117-134`:

```haskell
compressor      = orig .$ limitDictionary (roundMemUp (totalBytes + totalBytes/100 + 512))
real_compressor <- limit_compressor command compressor
writeBlock pipe DATA_BLOCK compressor real_compressor copy_solid_block
```

**`-lc` is applied three times, to three different things, and the port did one:**

1. at parse time, to the chain **stored** in the block header;
2. to the **solid-block grouping** — a shrunk block method moves where blocks end, so `-mgrzip -lc2m` writes two data blocks where `-lc4m` writes one;
3. per block, after the dictionary is fitted, to produce the chain that actually **compresses**.

So the port stored `grzip:1181kb` correctly and compressed with it, where the reference compresses with `grzip:233016b`. `Options.hs:140` says it outright: *"the compressor actually used differs from the one recorded in the block header."*

Pass 3 also sees a **different thread count** from pass 1 — `setup_command` has run by block time, so `GetCompressionThreads()` is the processor count there and 1 at parse time. Same C function, two answers, and GRZip's formula multiplies by it. The getters/setters now take the count as a parameter so neither moment can borrow the other's. Reading the processor count at parse time was a live bug: `-lc`/`-ld` on grzip and 4x4 shrank by a machine-dependent factor, so two hosts wrote different archives from one command line.

`write_compressed_data` now takes both chains — the shape encryption already used (stored form carries salt and check code, real form carries the key), widened rather than invented.

**A `tempfile` mechanism I initially blamed turns out to have no effect on the bytes at all.** Tornado matches at every level while the reference uses `tempfile+tor:6mb` and the port uses plain `tor:6mb`. Two threshold models were fitted and each explained one codec and mispredicted the other. What ended it was asking the reference instead of modelling it: `-di'$'` prints `"Using " ++ real_compressor` per block (`ArcvProcessRead.hs:170`), showing the real chain and the block split in one run. Both lessons are recorded in `docs/testing.md`.

Nothing is refused under `-lc` any more except a method the port cannot parse.

## Verification

| gate | result |
|---|---|
| 10 methods × 8 `-lc` levels (128m→1m) | 80/80 byte-identical |
| 12 presets × 6 levels, incl. `-m4`/`-m9` (previously refused) | 72/72 byte-identical |
| lzma2 matrix vs reference | 34/34 identical, 26 distinct archives |
| lzma2 cross-extraction | 20/20, shown to fail on a flipped byte |
| `cargo nextest run --profile ci` | 664 passed |
| `arc-golden-check.sh` | 65 recorded, 0 differing |
| `Tests/run-tests.sh` | 24/0/0 |
| create / solid / copy / extract / crypt vs reference | 0 differing |
| `if let` / `let _` greps, clippy | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)