### PR TITLE
-ma, the last refused option; and the lint gates reduced to totality

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -687,99 +687,33 @@ jobs:
     - name: cargo clippy
       working-directory: rust
       run: cargo clippy --all-targets || true
-    # Totality gate, across the WHOLE Rust workspace -- darc-codecs and
-    # darc-crypto both. An exhaustive `match` with every arm named is preferred
-    # over `if let`, so a branch carrying archive or crypto behaviour has to be
-    # written down and cannot be silently absent -- that is the shape of the
-    # Tornado presets 7-11 bug (#102) and of the lz4hc `Strategy` fall-through
-    # this gate's own PR fixed.
+    # Totality gate, across the WHOLE Rust workspace. An enum matched with a
+    # `_ =>` arm silently absorbs variants added later, which is the shape of
+    # the Tornado presets 7-11 bug (#102) and of the lz4hc `Strategy`
+    # fall-through this gate's own PR fixed. Every arm has to be written down.
     #
-    # darc-crypto had zero `if let` when the gate was widened, so this costs
-    # nothing today and is purely about keeping it that way.
+    # This is now the ONLY lint rule the workspace enforces. Two greps used to
+    # sit here too -- one banning `if let`, one banning `let _` -- on the theory
+    # that an exhaustive `match` says more than either spelling. They are gone
+    # at the owner's direction: the totality guarantee comes from
+    # `wildcard_enum_match_arm`, not from the shape of a single-branch
+    # conditional, and the greps cost more in contortion than they bought.
     #
-    # This is a grep because clippy cannot express it. There is no lint that bans
-    # `if let`; the whole related family (`single_match`, `single_match_else`,
-    # `manual_let_else`, `option_if_let_else`) points from `match` TOWARDS
-    # `if let`, and `single_match` is warn-by-default, which is why the crate root
-    # allows it. Totality is `deny(clippy::wildcard_enum_match_arm)` -- no `_ =>`,
-    # so every arm is named -- plus this gate.
-    #
-    # `while let` and `let ... else` are deliberately NOT covered: the first is a
-    # loop's termination condition, and the second must diverge in its `else`, so
-    # both already write down what happens in the other case.
-    - name: no `if let` in the Rust workspace
-      run: |
-        set -uo pipefail
-        # -F for a literal match; the pattern must not be read as a regex.
-        # --exclude-dir=target keeps build artefacts and vendored crate sources
-        # out: `rust/target` contains third-party code this rule does not govern.
-        # The two -v filters drop comment lines: `//` after the file:line prefix,
-        # and `//!` module docs (the rule is documented in prose in lib.rs).
-        # Single quotes throughout -- backticks inside double quotes would be
-        # command substitution, and "if let" is not a command.
-        hits=$(grep -rnF 'if let ' rust --include='*.rs' --exclude-dir=target \
-                 | grep -Ev ':[0-9]+: *//' | grep -v '//!' || true)
-        if [ -n "$hits" ]; then
-          echo '::error::this workspace uses an exhaustive match, not if let. Offenders:'
-          echo "$hits"
-          exit 1
-        fi
-        echo 'no if let anywhere under rust/ (excluding target)'
-
-    # A `let` binding whose name is `_` or starts with `_` throws a value away
-    # without saying so. It reads as a binding, so the eye slides over it, and
-    # `let _ =` additionally silences `unused_must_use` -- the lint that exists
-    # to catch exactly this.
-    #
-    # It cost a real bug: the directory reader computed `tag == TAG_END` and
-    # discarded the comparison, paying for a check and throwing the answer away,
-    # so a malformed terminator read as valid.
-    #
-    # `drop(expr)` is the replacement. Same semantics, and it says "discarded on
-    # purpose" in a way a reader cannot mistake for a forgotten binding.
-    #
-    # SCOPE: `let` bindings only. Underscore-prefixed FUNCTION PARAMETERS are a
-    # different thing and are not touched -- `darc_lzma_decompress` takes nine
-    # arguments and uses four, because the other five are the C ABI it must
-    # keep. Closure parameters and `let (_a, b) = ...` destructuring are also out
-    # of scope.
-    #
-    # KNOWN COST: `let _guard = mutex.lock()` is the idiomatic way to hold an
-    # RAII guard alive, and `let _ = ...` would drop it immediately instead.
-    # Nothing in this workspace does that today. If something needs to, bind a
-    # real name and `drop(guard)` at the end of the scope, which says when the
-    # guard is released instead of leaving it to a `}`.
-    #
-    # HONEST LIMIT: this is a grep. A discard still re-spells as `expr.ok();` or
-    # `match expr { _ => {} }`. It cannot be a totality guarantee the way the
-    # `if let` rule is. What it guarantees is that the forms which LOOK like a
-    # binding and are not cannot come back. The lint step below is what catches
-    # the underlying hazard -- discarding a Result, an Option, or anything
-    # #[must_use] -- whatever it is spelled.
-    - name: no discarding `let` bindings in the Rust workspace
-      run: |
-        set -uo pipefail
-        # `let _` and `let _name`, with any spacing. `while let Some(..)` does
-        # not match: that is `let Some`, not `let _`.
-        hits=$(grep -rnE '\blet +_' rust --include='*.rs' --exclude-dir=target \
-                 | grep -Ev ':[0-9]+: *//' | grep -v '//!' || true)
-        if [ -n "$hits" ]; then
-          echo '::error::use drop(expr) to discard a value, not let _ / let _name. Offenders:'
-          echo "$hits"
-          exit 1
-        fi
-        echo 'no discarding let bindings anywhere under rust/ (excluding target)'
-
-    - name: discarding a must_use value is denied, however it is spelled
+    # Passed on the command line rather than left to the crate roots, which is
+    # stronger: `#![deny(...)]` binds only the crates carrying it, and only when
+    # clippy runs -- `cargo build` never sees it.
+    - name: exhaustive matches, workspace-wide
       run: |
         set -uo pipefail
         cd rust
-        # let_underscore_must_use fires on `let _ = <must_use expr>` and
-        # drop_non_drop on `drop()` of a value with no destructor -- together
-        # they cover the re-spellings the grep above cannot see.
+        # unused_must_use stays. Ignoring a Result with NO binding at all is a
+        # different mistake from discarding one on purpose, and the language
+        # already warns about it. `clippy::let_underscore_must_use` is NOT
+        # denied any more -- that is the lint that would have kept `let _ = ...`
+        # banned by another name.
         cargo clippy --workspace --all-targets \
-          -- -D clippy::let_underscore_must_use -D unused_must_use
-        echo 'no must_use value is discarded anywhere in the workspace'
+          -- -D clippy::wildcard_enum_match_arm -D unused_must_use
+        echo 'every enum match names its arms'
 
   # ── Rust codec ports ────────────────────────────────────────────────────────
   # Two things are checked, and they are not the same thing:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,8 +119,9 @@ before adding or changing a corpus.
   `Compression/Tornado/Tornado.cpp` (`C_Tornado.cpp` `#include`s it).
 - **Link order matters to GNU ld and not to macOS ld**, so a broken link passes
   locally and fails every Linux and mingw job. See `docs/rust-workspace.md`.
-- **CI enforces lint gates no `cargo build` will show you**, including greps for
-  `if let` and `let _` anywhere under `rust/` — tests included. See
+- **CI enforces one lint gate no `cargo build` will show you**: every enum
+  `match` must name its arms (`wildcard_enum_match_arm`), workspace-wide,
+  tests included. `if let` and `let _` are allowed. See
   `docs/rust-workspace.md`.
 - **The C is no longer on the archiver's path at all.** It is reached only by
   `Unarc/`, the SFX modules and the difftest oracles, which is why the ASan job

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,9 +24,9 @@ that touches archive bytes.**
 scores 24/0/0, the same as the reference. `mm`, `tta`, `bsc`, `lz4`, `zstd` and
 `lzma2` had no `Method` variant until recently, which made archives using them
 unreadable as well as unwritable; the `-m` VALUE grammar (`-mt`, `-ms`, `-md`,
-`-ma`, `-mc`, `-mm`) was read as method NAMES. Both are fixed and gated. What
-is still refused rather than implemented: `-mm`/`-ma`/`-mc` change the chain
-and are rejected outright, and `-lc-`/`-ld-` are not accepted at all.
+`-ma`, `-mc`, `-mm`) was read as method NAMES. Both are fixed and gated, and
+every `-m` knob now does what the reference does. `-lc-`/`-ld-` are still not
+accepted at all.
 
 **`-mt` is archive-visible through LZMA2 and nothing else.** Above one block
 thread the encoder abandons the solid block and splits the input, so

--- a/README.md
+++ b/README.md
@@ -323,7 +323,6 @@ Options that take a parameter use `-<opt><value>` or `--<option>=<value>`.
 |       | `--queue`         | Serialize operations across multiple concurrent DArc processes |
 | `-ioff` | `--shutdown`    | Shut the computer down when the operation completes |
 |       | `--pause-before-exit` | Pause just before closing the program window |
-|       | `--arc-32bit-legacy` | Read archives produced by 32-bit FreeArc/Arc.exe |
 |       | `--nodata`        | Don't store file data in the archive (directory only) |
 |       | `--crconly`       | Save and check CRCs, but don't store file data |
 

--- a/docs/rust-workspace.md
+++ b/docs/rust-workspace.md
@@ -33,9 +33,12 @@ Both instances are worth recognising:
 
 **Lint gates CI enforces**, so match them or the build goes red:
 
-* **No `if let` anywhere under `rust/`** — a CI grep, because no clippy lint
-  expresses it (the whole related family pushes the other way). Totality is
-  `deny(clippy::wildcard_enum_match_arm)` plus that grep, so every arm is named.
+* **Every enum `match` names its arms** — `wildcard_enum_match_arm`, denied on
+  the clippy command line so it binds the whole workspace and not just the
+  crates carrying the attribute. This is the only style rule CI enforces.
+  `if let` and `let _` were also banned, by grep; both bans were dropped at the
+  owner's direction, because totality comes from forbidding `_ =>` and not from
+  the shape of a single-branch conditional.
 * `deny(clippy::unwrap_used, clippy::expect_used)` outside tests.
 * `overflow-checks = true` in the release profile, so unchecked arithmetic
   *traps* rather than wrapping.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -8,9 +8,9 @@ Load this before changing a codec or writing a harness. The short version: the R
 thorough one, and it is the gate.** Do not confuse the two — a change to
 `Arc*.hs` is covered by nothing but your own round-trip.
 
-## `rust/difftest` — 53 differential harnesses
+## `rust/difftest` — 55 differential harnesses
 
-35 are codec-level and 18 are the CLI-level `arc-*-check.sh` described further
+35 are codec-level and 20 are the CLI-level `arc-*-check.sh` described further
 down. Each `<codec>-check.sh` builds the C original **from a pinned revision**
 (`DARC_C_REF_SHA` in `c-reference.sh`, currently `5c2c6ce`) alongside the Rust port
 and requires identical bytes. The C is taken from git history rather than the
@@ -18,7 +18,7 @@ working tree so the oracle survives the C being deleted and cannot drift.
 
 ```bash
 rust/difftest/lzma-decode-check.sh     # exit 0 or the port diverged
-cd rust && cargo nextest run --profile ci   # 648 unit tests
+cd rust && cargo nextest run --profile ci   # 687 unit tests
 ```
 
 Two properties every harness here is expected to have, learned the hard way:
@@ -89,9 +89,9 @@ Note that `compile-ghc-probe` writes objects into the shared `/tmp/out/`, so run
 
 ### What runs without a reference: `arc-golden-check.sh`
 
-65 cases, one SHA-256 each, recorded from `Tests/arc-ghc` while all
-19 harnesses were green. It is the only archive-format gate CI runs, and the
-only one that will still be meaningful in a year.
+93 cases, one SHA-256 each, recorded from `Tests/arc-ghc`. It is the only
+archive-format gate CI runs, and the only one that will still be meaningful in
+a year.
 
 Two rules:
 
@@ -101,16 +101,19 @@ Two rules:
 - **New cases must be machine-independent**, which the differential harnesses
   never had to be — they ran two binaries on one host, so anything host-varying
   cancelled. That means `--nodates`, explicitly parameterised chains rather than
-  presets, `-rr` in absolute bytes, and **no `grzip` and no `4x4`**: those two
-  are the only methods whose memory formulas read the processor count
-  (`memlimit.rs:288`), so they are the only two that could bake the recording
-  machine into a hash.
+  presets, and `-rr` in absolute bytes. `grzip`, `4x4` and `lzma2` are allowed
+  only with an explicit `-mtN`: their output depends on the thread count, so
+  pinning it is what keeps the recording machine out of the hash.
+- **A limit that never binds tests nothing.** Half the cases now run on a ~12 MB
+  tree, because `limitDictionary` fits every chain to the DATA size first — on
+  the original 200 KB tree no `-lc`/`-ld`/`-md` figure was ever reached, and
+  four format bugs lived behind that.
 
 It earned its place on its first run by finding three divergences nothing else
 had: filespec group ordering, the missing `isVeryFastCompressor` clause in the
 sort-order decision, and `addBlockSizeCrit` having been ported and never called.
 
-### What the port cannot do
+### What the port can and cannot do
 
 `Tests/run-tests.sh` scores 24 passed / 0 failed / 0 skipped — the same as the
 reference. The six methods that had no `Method` variant (`mm`, `tta`, `bsc`,
@@ -130,10 +133,16 @@ nothing trips it now. It matches on the binary's own "cannot write yet" wording,
 so the next unimplemented method gets listed rather than silently failing — and
 a case that fails for any *other* reason is still a failure.
 
-Still refused rather than implemented: `-mm` (multimedia mode), `-ma`
-(autodetect level) and `-mc` (disable an algorithm) each change the chain, so
-they are rejected outright rather than ignored, on the same rule the HONOURED
-option list follows. `-lc-`/`-ld-` are not accepted at all.
+Every `-m` knob is implemented: `-mm`, `-mc`, `-md`, `-ms`, `-mt` and `-ma`.
+`-lc-`/`-ld-` are still not accepted at all.
+
+`-ma` is the one worth reading the harness for. It selects between the TWO
+paths of `splitFileTypes`, and the port had implemented neither clause of
+`quick_and_dirty` -- it used `chains.len() > 1`, which agreed everywhere
+reachable only because the cases that separate them need `-ma`, and `-ma` was
+refused. On the quick path the blocks are ordered by their CHAIN STRING
+(`merge_by_type`), not by type index and not by first appearance; both of those
+were tried and both wrote valid archives that were not the reference's.
 
 `-lc` is served for every method, and getting there is the cautionary tale in
 this file.

--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -1048,21 +1048,9 @@ fn add(
                 .build_global(),
         );
     }
-    // The knobs this port does not implement are REFUSED, not ignored: acting
-    // on part of a -m spec and dropping the rest writes an archive that is not
-    // what was asked for, which is the same rule the HONOURED list applies.
-    let mut unimplemented: Vec<String> = Vec::new();
-    if mopts.autodetect != "--" {
-        unimplemented.push(format!("-ma{}", mopts.autodetect));
-    }
-    if !unimplemented.is_empty() {
-        eprintln!(
-            "ERROR: this port does not implement {} yet, and ignoring it would \
-             write an archive that is not what you asked for",
-            unimplemented.join(", ")
-        );
-        return 2;
-    }
+    // Every -m knob is implemented now: -mm, -mc, -md, -ms, -mt and -ma all
+    // do what the reference does. The refusal list that stood here is gone
+    // with the last of them.
     // `(mainMethod ||| aDEFAULT_COMPRESSOR) ++ userMethods` (Cmdline.hs:334):
     // the per-type suffixes are appended to the main method, and the whole
     // string is what decode_method expands.
@@ -1867,10 +1855,43 @@ fn add(
         }
     }
 
-    // splitFileTypes: which files share a block, decided by CONTENT. Only
-    // reached when the level defines more than one chain -- with a single chain
-    // every file is type 0 anyway, and probing would be wasted work.
-    let type_groups: Vec<(usize, Vec<usize>)> = if chains.len() > 1 {
+    // `splitFileTypes` (ArhiveFileList.hs:459) has TWO paths, and which one
+    // runs is `quick_and_dirty`:
+    //
+    //   quick_and_dirty -> partitionList by cfType, the type the groups file
+    //                      assigns. No probing.
+    //   otherwise       -> split by extension and 2 MB, then probe each group.
+    //
+    // This used to be `chains.len() > 1`, which is neither clause. It happened
+    // to agree because the cases where it differs need `-ma`, which was
+    // refused -- so the approximation was unreachable rather than right.
+    let detect = darc_arc::methodtable::detect_level(&mopts.autodetect, &method);
+    let quick = darc_arc::methodtable::quick_and_dirty(detect, &type_names);
+    let type_groups: Vec<(usize, Vec<usize>)> = if chains.len() > 1 && quick {
+        // `cfType` -- the RAW groups-file type mapped to its index in the
+        // compressor list, 0 when the list has no such entry. Not
+        // `default_type`: that substitutes $binary for the detector's benefit,
+        // and there is no detector on this path.
+        let split: Vec<(usize, Vec<usize>)> = file_entries
+            .iter()
+            .enumerate()
+            .map(|(i, e)| {
+                let raw = groups.group_type_name(&e.stored_name);
+                (type_names.iter().position(|t| *t == raw).unwrap_or(0), vec![i])
+            })
+            .collect();
+        // Through `merge_by_type`, the same as the detection path -- which
+        // orders the blocks by their CHAIN STRING, not by type index and not
+        // by first appearance. For -m5 that is dict… < rep… < tta, so the
+        // $text block precedes the default one even though $text is type 2.
+        //
+        // Two hand-rolled orderings were tried here first and both wrote a
+        // different archive: type-index order (which is what `zip [0..]`
+        // looks like it means) failed on the solid case, and first-appearance
+        // order failed on `-s-`, where the sorted list starts with a binary
+        // file. Reusing the function that was already gated is what fixed it.
+        darc_arc::filetype::merge_by_type(&split, |t| chains[t].clone())
+    } else if chains.len() > 1 {
         // getDefaultType: an autodetectable type becomes $binary so the
         // detector decides it, and darc.groups supplies everything else --
         // which is what makes $wav and $bmp reachable at all.

--- a/rust/darc-arc/src/methodtable.rs
+++ b/rust/darc-arc/src/methodtable.rs
@@ -966,3 +966,103 @@ pub fn apply_method_change(mc: &str, decoded: Vec<(String, Vec<String>)>) -> Vec
         })
         .collect()
 }
+
+/// `clevel` (`Cmdline.hs:282`) — the compression LEVEL a `-m` value implies.
+///
+/// Only five shapes yield a digit; everything else is level 4, including a
+/// named method like `-mlzma`. `-mx`/`-max` are 9.
+pub fn compression_level(main_method: &str) -> u32 {
+    let d = |c: char| c.to_digit(10).unwrap_or(4);
+    let b: Vec<char> = main_method.chars().collect();
+    match b.as_slice() {
+        [c] if c.is_ascii_digit() => d(*c),
+        [c, 'p'] if c.is_ascii_digit() => d(*c),
+        [c, 'x'] if c.is_ascii_digit() => d(*c),
+        ['x', c] if c.is_ascii_digit() => d(*c),
+        _ => match main_method {
+            "mx" | "max" => 9,
+            // "default compression level"
+            _ => 4,
+        },
+    }
+}
+
+/// `detect_level` (`ArhiveFileList.hs:473`) — `-ma` if given, else the
+/// compression level.
+pub fn detect_level(autodetect: &str, main_method: &str) -> u32 {
+    match autodetect {
+        "--" => compression_level(main_method),
+        v => v.parse().unwrap_or_else(|_| compression_level(main_method)),
+    }
+}
+
+/// `quick_and_dirty` (`ArhiveFileList.hs:468`) — is content autodetection
+/// worth running at all?
+///
+/// ```haskell
+///   quick_and_dirty = detect_level <= 1
+///                     || not (types `contains_one_of` detectable_types)
+/// ```
+///
+/// Two independent reasons to skip it, and both matter. The first is `-ma`,
+/// which is the whole point of that option. The second is that probing is
+/// pointless when the compressor list has no entry the detector could pick:
+/// `detect_datatype` only ever answers `$text` or `$compressed`, so a list
+/// without either — `-m1`, whose types are `""`, `$exe`, `$wav`, `$bmp` — can
+/// gain nothing from being probed.
+///
+/// When it is true the reference does NOT put everything in one group: it
+/// partitions by `cfType`, the type the groups file assigns. That distinction
+/// is invisible with one type and archive-visible with several.
+pub fn quick_and_dirty(detect_level: u32, type_names: &[String]) -> bool {
+    detect_level <= 1
+        || !type_names.iter().any(|t| {
+            darc_codecs::mmdet::DETECTABLE_TYPES.split_whitespace().any(|d| d == t)
+        })
+}
+
+#[cfg(test)]
+mod autodetect {
+    use super::{compression_level, detect_level, quick_and_dirty};
+
+    /// `-m` values that carry a level, and the ones that do not.
+    #[test]
+    fn the_level_comes_from_the_m_value() {
+        assert_eq!(compression_level("5"), 5);
+        assert_eq!(compression_level("5p"), 5);
+        assert_eq!(compression_level("5x"), 5);
+        assert_eq!(compression_level("x5"), 5);
+        assert_eq!(compression_level("mx"), 9);
+        assert_eq!(compression_level("max"), 9);
+        // A named method has no level, and the reference's default is 4 --
+        // NOT 0, so `-mlzma` autodetects where `-m1` does not.
+        assert_eq!(compression_level("lzma:1m"), 4);
+        assert_eq!(compression_level(""), 4);
+    }
+
+    /// `-ma` overrides the level; absent, it tracks it.
+    #[test]
+    fn ma_overrides_the_level() {
+        assert_eq!(detect_level("--", "9"), 9);
+        assert_eq!(detect_level("--", "1"), 1);
+        assert_eq!(detect_level("0", "9"), 0);
+        assert_eq!(detect_level("2", "1"), 2);
+    }
+
+    /// Either clause alone is enough to skip probing.
+    #[test]
+    fn either_clause_skips_detection() {
+        let with = |v: &[&str]| -> Vec<String> { v.iter().map(|s| s.to_string()).collect() };
+        let detectable = with(&["", "$obj", "$text", "$compressed"]);
+        let not = with(&["", "$exe", "$wav", "$bmp"]);
+        // Level 2+ over a list containing $text: probe.
+        assert!(!quick_and_dirty(2, &detectable));
+        // Level 1 turns it off however rich the list is -- this is `-ma1`.
+        assert!(quick_and_dirty(1, &detectable));
+        assert!(quick_and_dirty(0, &detectable));
+        // A list with nothing detectable in it: probing can gain nothing, at
+        // any level. This is -m1, and it is why -m1 never probes.
+        assert!(quick_and_dirty(9, &not));
+        assert!(quick_and_dirty(4, &with(&[""])));
+    }
+}

--- a/rust/darc-arc/src/options.rs
+++ b/rust/darc-arc/src/options.rs
@@ -113,7 +113,6 @@ pub const OPTIONS: &[OptionDef] = &[
     OptionDef { short: "", long: "pause-before-exit", param: Some("PAUSE") },
     OptionDef { short: "v", long: "volume", param: Some("SIZE") },
     OptionDef { short: "", long: "queue", param: None },
-    OptionDef { short: "", long: "arc-32bit-legacy", param: None },
     OptionDef { short: "", long: "cache", param: Some("N") },
     OptionDef { short: "lc", long: "LimitCompMem", param: Some("N") },
     OptionDef { short: "ld", long: "LimitDecompMem", param: Some("N") },

--- a/rust/darc-arc/src/sort.rs
+++ b/rust/darc-arc/src/sort.rs
@@ -587,9 +587,21 @@ impl Groups {
     /// caller passed a hardcoded `$binary`, so the multimedia branch in
     /// `filetype::classify` was dead and `-m9` compressed a WAV with the
     /// general binary chain where the reference used `tta`.
+    /// The RAW type a file's group carries, without the `$binary`
+    /// substitution.
+    ///
+    /// `cfType` (`ArhiveDirectory.hs:408`) uses this one: it maps the group
+    /// straight to a compressor index through `opt_group2type`. Only
+    /// [`Self::default_type`] applies the substitution, and only because
+    /// `getDefaultType` feeds the DETECTOR, which must be free to disagree with
+    /// the filename. Using the substituted name for partitioning would send
+    /// every `$text` file to the binary chain.
+    pub fn group_type_name(&self, stored_name: &str) -> String {
+        self.group_type_names().get(self.group_of(stored_name)).cloned().unwrap_or_default()
+    }
+
     pub fn default_type(&self, stored_name: &str) -> String {
-        let names = self.group_type_names();
-        let typ = names.get(self.group_of(stored_name)).cloned().unwrap_or_default();
+        let typ = self.group_type_name(stored_name);
         match typ.is_empty()
             || darc_codecs::mmdet::DETECTABLE_TYPES.split_whitespace().any(|d| d == typ)
         {

--- a/rust/darc-codecs/src/lib.rs
+++ b/rust/darc-codecs/src/lib.rs
@@ -30,19 +30,19 @@
 //! and denying them would mean touching byte-exact code for cosmetics.
 //! ## Why `single_match` is allowed
 //!
-//! This crate prefers an exhaustive `match` with every case named over `if let`,
-//! so that a branch carrying archive behaviour has to be written down and cannot
-//! be silently absent. `clippy::single_match` is warn-by-default (it is in
-//! `clippy::all`) and pushes the opposite way -- it asked, by name, for
-//! `grzip/block.rs`'s mode dispatch to become
-//! `if let Some(m) = RecMode::from_stream(..)`, which is exactly the form this
-//! crate is moving away from. So it is allowed on purpose, not by oversight.
+//! Totality here is `wildcard_enum_match_arm`: a `_ =>` over an enum silently
+//! absorbs variants added later, so every arm has to be named. That is the one
+//! style rule CI enforces, and it is about the ARMS of a match, not about
+//! choosing `match` over `if let`.
 //!
-//! Note there is no clippy lint that bans `if let`; the whole family of related
-//! lints (`single_match`, `single_match_else`, `manual_let_else`,
-//! `option_if_let_else`) points from `match` towards `if let`. Totality here is
-//! `wildcard_enum_match_arm` (which forbids `_ =>`, so every arm is named) plus
-//! the convention, not a lint.
+//! `if let` and `let _` were both banned once, by CI grep, on the wider theory
+//! that an exhaustive `match` says more than either. Those bans are gone. This
+//! crate is still written mostly in `match` form and there is no need to churn
+//! it, but neither spelling is a build failure now.
+//!
+//! `clippy::single_match` stays allowed all the same: it is warn-by-default and
+//! would fire on a large amount of existing code that reads perfectly well,
+//! which is noise rather than a finding.
 #![deny(clippy::wildcard_enum_match_arm)]
 #![deny(clippy::todo, clippy::unimplemented, clippy::mem_forget)]
 #![deny(unused_must_use)]

--- a/rust/difftest/arc-multimedia-check.sh
+++ b/rust/difftest/arc-multimedia-check.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# `-mm`, `-mc`, and the file-type routing they operate on.
+# `-mm`, `-mc`, `-ma`, and the file-type routing all three operate on.
 #
-# These three are one subject. `-mm` adds or removes the `$wav`/`$bmp` entries
+# These are one subject. `-ma` decides whether file types are probed at all,
+# `-mm` adds or removes the `$wav`/`$bmp` entries
 # of the decoded compressor list, `-mc` removes entries and links from it, and
 # neither means anything unless files actually REACH those entries — which is
 # `getDefaultType`, from the groups file.
@@ -88,6 +89,24 @@ g mc-tta    -m9 -mc-tta
 g mc-rep    -m4 -mc-rep
 g mc-exe    -m4 -mc-exe
 g mc-two    -m4 -mc-rep -mc-exe
+
+# `-ma` -- the autodetection LEVEL. Two behaviours only, either side of
+# `detect_level <= 1`: at 0 or 1 the reference partitions by the type the
+# groups file assigns and probes nothing; at 2 and above it probes contents.
+# `-ma` unset tracks the compression level, so -m1 never probes and -m4 does.
+g ma-off      -m4 -ma-
+g ma-0        -m4 -ma0
+g ma-1        -m4 -ma1
+g ma-2        -m4 -ma2
+g ma-9        -m4 -ma9
+g ma-m2-1     -m2 -ma1
+g ma-m9-0     -m9 -ma0
+g ma-m9-2     -m9 -ma2
+# -s- is the case that caught the ordering: with solid off the sorted list
+# starts with a binary file, so a first-appearance bucket order writes the
+# blocks the wrong way round. merge_by_type sorts by the CHAIN STRING.
+g ma-solid-off -m5 -ma1 -s-
+g ma-s1k      -m4 -ma0 -s1k
 
 echo "arc multimedia: $((pass+fail)) cases, $fail differing"
 u=$(printf '%s\n' "${hashes[@]}" | cut -d' ' -f1 | sort -u | wc -l | tr -d ' ')


### PR DESCRIPTION
Three owner decisions, one commit each.

## 1. `--arc-32bit-legacy` dropped

Removed rather than left refused. It was the one option with no possible oracle: `readIntCompat`, the function that honours it, sits inside `#else` of `#ifndef __MHS__` (`ByteStream.hs:429-442`), so the GHC reference parses the flag and never reads it. Now reports "unknown option", like `--language` and `-ioff` before it.

## 2. Lint gates reduced to totality alone

The `if let` and `let _` greps are gone. **One thing was worth catching before deleting them:** the workspace's `cargo clippy` step is `|| true`, and `#![deny(...)]` binds only the crates carrying it and only under clippy — so deleting the greps alone would have left totality effectively *unenforced* in CI.

So `wildcard_enum_match_arm` is now denied on the clippy **command line**, workspace-wide, which is strictly stronger than the per-crate attributes. Verified 0 errors.

`clippy::let_underscore_must_use` is no longer denied — that lint would have kept `let _ = ...` banned under another name. Plain `unused_must_use` stays: ignoring a `Result` with *no* binding is a different mistake from discarding one on purpose. Existing code is untouched.

## 3. `-ma` — the last refused option

`-ma` sets `detect_level`; unset it tracks the compression level, which `clevel` reads off the `-m` value (a digit for `5`/`5p`/`5x`/`x5`, 9 for `mx`/`max`, 4 for anything else). So `-m1` already implies detection off and `-mlzma` implies it on.

`splitFileTypes` has two paths, chosen by:

```haskell
quick_and_dirty = detect_level <= 1 || not (types `contains_one_of` detectable_types)
```

**The port had implemented neither clause.** It used `chains.len() > 1`, which agreed everywhere reachable only because the cases that separate them need `-ma` — so the approximation was unreachable rather than right.

On the quick path the reference partitions by `cfType`, the **raw** groups-file type. Raw, not `getDefaultType`: that substitutes `$binary` so the *detector* can disagree with the filename, and there is no detector on this path — using the substituted name would send every `$text` file to the binary chain.

### The ordering took three attempts

Worth recording, because the first two produced **valid archives that were not the reference's**:

1. by type index — what `zip [0..] . partitionList` looks like it means. Wrong in solid mode.
2. by first appearance over the sorted list. Right in solid mode, wrong under `-s-`, where the sorted list starts with a binary file.
3. through **`merge_by_type`**, the function the detection path already used, which sorts by the **chain string**: `dict…` < `rep…` < `tta`. Right in both.

Reusing the already-gated function is what fixed it. Nothing but byte comparison would have caught either mistake.

**Every `-m` knob is now implemented** — `-mm`, `-mc`, `-md`, `-ms`, `-mt`, `-ma` — and the refusal list in `darc.rs` is gone with the last of them.

## Verification

| gate | result |
|---|---|
| `-ma` vs reference: levels 0–9, every `-ma` value, `-s-`/`-s1k`/`-se`/`-s2`, with `-mm-` | **31/31 identical** |
| `arc-multimedia-check.sh` (10 `-ma` cases added) | 22/22 |
| `arc-golden-check.sh` | 93/93 |
| `arc-config-check.sh` | 10/10 |
| `Tests/run-tests.sh` | 24/0/0 |
| `cargo nextest run --profile ci` | 687 passed |
| create / solid / copy / extract / filter vs reference | 0 differing |
| totality gate, workspace-wide | clean |

Also corrects drift in `docs/testing.md`: it still described the golden gate as 65 cases banning `grzip`/`4x4`, which #128 changed to 93 with those admissible under an explicit `-mtN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)