### PR TITLE
reference: publish the Linux oracles, and fix the workflow that builds them

### DIFF
--- a/.github/workflows/reference-oracle.yml
+++ b/.github/workflows/reference-oracle.yml
@@ -49,7 +49,11 @@ jobs:
         with:
           # The oracle is built from history, not from the current tree. That
           # is the whole point: it must not drift with the port it checks.
-          ref: 9a127e6
+          # The FULL sha: actions/checkout resolves `ref` as a branch or tag
+          # name first, and an abbreviated one matches neither -- it fails with
+          # "A branch or tag with the name '9a127e6' could not be found".
+          # Only a 40-character sha is treated as a commit.
+          ref: 9a127e6087fb46cab518bc827662d9b1596e8633
           fetch-depth: 0
 
       - name: Confirm the platform key matches this runner

--- a/.github/workflows/reference-oracle.yml
+++ b/.github/workflows/reference-oracle.yml
@@ -6,23 +6,25 @@
 # Rust staticlibs, on every run — so this does it once per platform and
 # `rust/difftest/haskell-reference.sh` fetches the result.
 #
-# Manual only. It publishes to a release and creates a tag, which is not
-# something a push should ever do by accident.
-#
-# ── One release per platform, and why it cannot be otherwise ────────────────
-#
-# This repository has immutable releases: assets are attached at creation and
-# cannot be added later, so every platform needs its own release rather than
-# sharing one. Deleting to recreate is not a way out — deleting a published
-# release BURNS its tag name, and recreating that ref afterwards fails with
-# "Reference update failed".
+# Manual only, and it does not publish: it builds and uploads an artifact.
+# Publishing is a separate step by someone holding a token that may write.
 #
 # ── After a successful run ──────────────────────────────────────────────────
 #
-# The job prints the SHA-256. Put it in `rust/difftest/golden/reference.sha256`
-# against the platform key and commit that, or the resolver will refuse to use
-# the asset — an unpinned platform declines to download rather than trusting
-# whatever arrives.
+#   gh run download <id> -n arc-ghc-<platform>
+#   gh api -X POST repos/OWNER/REPO/git/refs \
+#     -f ref=refs/tags/oracle-9a127e6-<platform> -f sha=<full sha>
+#   gh release create oracle-9a127e6-<platform> --verify-tag --latest=false \
+#     --title ... --notes ... arc-ghc-<platform>
+#
+# ONE RELEASE PER PLATFORM, because this repository has immutable releases:
+# assets are attached at creation and cannot be added later. Deleting to
+# recreate is not a way out either — deleting a published release BURNS its tag
+# name, and recreating that ref fails with "Reference update failed".
+#
+# Then put the printed SHA-256 in `rust/difftest/golden/reference.sha256`
+# against the platform key, or the resolver will refuse to use the asset: an
+# unpinned platform declines to download rather than trusting what arrives.
 name: Reference oracle
 
 on:
@@ -35,8 +37,13 @@ on:
         type: choice
         options: [linux-x86_64, linux-aarch64]
 
-permissions:
-  contents: write
+# No `permissions:` block. The repository sets
+# `default_workflow_permissions: read`, and a workflow cannot elevate above
+# the repository maximum -- a `contents: write` request here is silently
+# inert, and the release call fails with "403: Resource not accessible by
+# integration". So this job BUILDS and uploads an artifact, and publishing is
+# done separately by someone holding a token that may write. A build job that
+# cannot publish is also the more conservative arrangement.
 
 jobs:
   build:
@@ -99,32 +106,28 @@ jobs:
           "$GITHUB_WORKSPACE/Tests/arc-ghc" t t.arc
           echo "the binary runs and round-trips"
 
-      - name: Publish
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Package
+        id: pack
         run: |
           set -euo pipefail
           plat='${{ inputs.platform }}'
-          tag="oracle-9a127e6-$plat"
-          asset="arc-ghc-$plat"
-          cp Tests/arc-ghc "$asset"
-          sum="$(sha256sum "$asset" | cut -d' ' -f1)"
-
-          # Attached at creation: an immutable release takes no later uploads.
-          gh release create "$tag" \
-            --target "$(git rev-parse 9a127e6)" \
-            --title "Haskell reference oracle 9a127e6 ($plat)" \
-            --latest=false \
-            --notes "Prebuilt \`arc-ghc\` for \`$plat\`, built from \`9a127e6\` by the Reference oracle workflow. A test oracle, not a product build. GPLv3-or-later; the corresponding source is commit \`9a127e6\` of this repository. SHA-256 \`$sum\`." \
-            "$asset"
-
+          cp Tests/arc-ghc "arc-ghc-$plat"
+          sum="$(sha256sum "arc-ghc-$plat" | cut -d' ' -f1)"
+          echo "sum=$sum" >> "$GITHUB_OUTPUT"
           {
-            echo "### Reference oracle published"
+            echo "### Reference oracle built"
             echo
-            echo "Add this line to \`rust/difftest/golden/reference.sha256\`,"
-            echo "or the resolver will refuse to use the asset:"
+            echo "Download the artifact, publish it, and put this line in"
+            echo "\`rust/difftest/golden/reference.sha256\`:"
             echo
             echo '```'
             printf '%-18s %s\n' "$plat" "$sum"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: arc-ghc-${{ inputs.platform }}
+          path: arc-ghc-${{ inputs.platform }}
+          if-no-files-found: error
+          retention-days: 7

--- a/rust/difftest/golden/reference.sha256
+++ b/rust/difftest/golden/reference.sha256
@@ -11,3 +11,5 @@
 #
 # platform         sha256
 darwin-arm64       ccf84e7e8a8b4561e0f37d7d9beb1fe2c6854b9d1acbbb3075c0624215af97a7
+linux-x86_64       ac4b1f4a95e89bef3c14a3fa2c6f319cb5413acde44ec01a8ee397535e2b6b78
+linux-aarch64      a35a8546225f068c0e8446a81e5b107d922ff1ff590289d4541ddec89513a445


### PR DESCRIPTION
Follow-up to #131, which left the Linux oracle assets unproduced and the workflow unproven. Both are done: **all three platforms are published and pinned.**

## The open question is answered

**`compile-ghc-probe` builds on a Linux runner** — x86_64 and aarch64, with libncurses, libcurl and the stock gcc/GHC 9.10.3 toolchain. #131 flagged this as untested; it works.

The workflow also proves each binary can create and test an archive before uploading it, so a build that links but cannot run is caught at the source rather than becoming a broken oracle.

## Two fixes were needed

- **`actions/checkout` resolves `ref` as a branch or tag name** before treating it as a commit, so the abbreviated `9a127e6` failed with *"A branch or tag with the name '9a127e6' could not be found"*. It needs the full 40-character SHA.
- **The workflow no longer publishes.** `default_workflow_permissions` is `read` on this repository, and a workflow cannot elevate above the repository maximum — so the `permissions: contents: write` block was silently inert and the release call returned *"403: Resource not accessible by integration"*. Rather than ask for a repo-wide setting change, the job uploads an artifact and publishing happens separately with a token that may write. A build job that cannot publish is the more conservative arrangement anyway.

## Published

| platform | tag |
|---|---|
| `darwin-arm64` | `oracle-9a127e6-darwin-arm64` |
| `linux-x86_64` | `oracle-9a127e6-linux-x86_64` |
| `linux-aarch64` | `oracle-9a127e6-linux-aarch64` |

One release per platform, because immutable releases attach assets at creation and accept none afterwards.

## Verification

Each published asset was **fetched back over its real release URL and hashed**, and all three match the pins committed here.

What that does **not** prove is the Linux binaries working as oracles — they cannot execute on the machine that built this PR. Linux CI is what exercises that, and it is why this is a PR rather than a direct push. If the fetch or the binaries are wrong, the Linux jobs fail here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)