### PR TITLE
Codecs: every debug_assert becomes an unconditional assert

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -931,12 +931,15 @@ jobs:
         # the window never slid and a broken window passed 88/88.
         rust/difftest/lzma-gap-check.sh
 
-  # Debug profile, on purpose. Every other codec job builds --release, where
-  # `debug_assert!` compiles to nothing -- so the crate's 19 assertions are dead
-  # in the only configuration otherwise tested. The Tornado presets 7-11
-  # divergence was exactly that: a guard firing into the void. Removing the fix
-  # makes this job report 80 panics naming the cause; the release harnesses
-  # needed differential tracing to find the same thing.
+  # Debug profile, on purpose. Every other codec job builds --release, and this
+  # is the only place `-C overflow-checks` is on -- so an `as` cast that wraps
+  # (there are ~2250 the compiler can prove might) panics here and nowhere else.
+  #
+  # It was written for `debug_assert!`, which release compiled to nothing: the
+  # Tornado presets 7-11 divergence was exactly that, a guard firing into the
+  # void. There are no `debug_assert!`s left -- all 22 became unconditional
+  # `assert!`s -- so that half of the job's remit now belongs to every harness.
+  # Overflow checks are what is still tested only here.
   rust-codecs-debug-assert:
     runs-on: ubuntu-latest
     steps:

--- a/rust/darc-arc/src/writer.rs
+++ b/rust/darc-arc/src/writer.rs
@@ -549,7 +549,7 @@ impl Writer {
         // block first to learn that position.
         let bodies = crate::recovery::build(&g, &protected, 0);
         let r0 = crate::recovery::block(rr_pos, &bodies.sectors);
-        debug_assert_eq!(bodies.sectors.len() as u64, sectors_len);
+        assert_eq!(bodies.sectors.len() as u64, sectors_len);
         self.out.extend_from_slice(&bodies.sectors);
         self.out.extend_from_slice(&descriptor(&r0));
 

--- a/rust/darc-codecs/src/bcj.rs
+++ b/rust/darc-codecs/src/bcj.rs
@@ -108,7 +108,7 @@ fn test86_ms_byte(b: u8) -> bool {
 /// and a panic here, so the shift is done with `checked_shl` and asserted
 /// instead of trusting the reasoning.
 fn shift_mask(prev_mask: u32, prev_pos_t: usize) -> u32 {
-    debug_assert!((1..=3).contains(&prev_pos_t), "prevPosT out of range: {prev_pos_t}");
+    assert!((1..=3).contains(&prev_pos_t), "prevPosT out of range: {prev_pos_t}");
     let shift = prev_pos_t.wrapping_sub(1) as u32;
     prev_mask.checked_shl(shift).unwrap_or(0) & 0x7
 }

--- a/rust/darc-codecs/src/delta.rs
+++ b/rust/darc-codecs/src/delta.rs
@@ -263,10 +263,12 @@ fn read_i16(buf: &[u8], at: isize) -> i16 {
     // the block by the loop guards; if one were not, the C original would be
     // reading uninitialised memory from its own BigAlloc block and would not be
     // reproducible either.
-    debug_assert!(at >= 0 && (at as usize) + 2 <= buf.len(), "i16 read outside the block");
-    if at < 0 || (at as usize) + 2 > buf.len() {
-        return 0;
-    }
+    //
+    // `assert!`, not `debug_assert!`: an out-of-range read here means the loop
+    // guards are wrong, and returning 0 for it would let a mis-transcribed guard
+    // produce a plausible-looking but different stream in exactly the build that
+    // ships. There is deliberately no fallback below.
+    assert!(at >= 0 && (at as usize) + 2 <= buf.len(), "i16 read outside the block");
     i16::from_le_bytes([buf[at as usize], buf[at as usize + 1]])
 }
 

--- a/rust/darc-codecs/src/ffi.rs
+++ b/rust/darc-codecs/src/ffi.rs
@@ -53,7 +53,7 @@ impl Io {
     }
 
     fn call(&self, what: &[u8], buf: *mut c_void, size: c_int) -> c_int {
-        debug_assert_eq!(what.last(), Some(&0), "`what` must be NUL-terminated");
+        assert_eq!(what.last(), Some(&0), "`what` must be NUL-terminated");
         unsafe { (self.callback)(what.as_ptr() as *const c_char, buf, size, self.auxdata) }
     }
 
@@ -126,9 +126,11 @@ impl Io {
 /// The callback takes an `int` length; anything past `c_int::MAX` cannot be
 /// expressed. Rust's `as` truncates every bit as silently as C's implicit
 /// conversion -- that is how 16 GB became 0 in GetPhysicalMemory -- so the one
-/// place a length crosses into an `int` is explicit and asserts in debug.
+/// place a length crosses into an `int` is explicit and asserts unconditionally.
+/// The `min` below is therefore unreachable, and kept only so the cast is still
+/// provably lossless when read on its own.
 fn clamp_len(n: usize) -> c_int {
-    debug_assert!(n <= c_int::MAX as usize, "buffer longer than c_int can express");
+    assert!(n <= c_int::MAX as usize, "buffer longer than c_int can express");
     core::cmp::min(n, c_int::MAX as usize) as c_int
 }
 

--- a/rust/darc-codecs/src/lz4hc.rs
+++ b/rust/darc-codecs/src/lz4hc.rs
@@ -289,7 +289,7 @@ impl HashChain {
 
         while match_index >= lowest_match_index && nb_attempts > 0 {
             nb_attempts -= 1;
-            debug_assert!(match_index < ip_index);
+            assert!(match_index < ip_index);
             let m = (match_index - BASE) as i32;
 
             // Speculative pre-filter (lz4hc.c:933): if the two bytes at the end
@@ -329,7 +329,7 @@ impl HashChain {
             // it finds a better jump, so a long match costs far fewer probes
             // than one step per byte. Only the optimal parser enables this.
             if chain_swap && match_length == longest {
-                debug_assert_eq!(look_back_length, 0); // search forward only
+                assert_eq!(look_back_length, 0); // search forward only
                 if match_index + longest as u32 <= ip_index {
                     const K_TRIGGER: i32 = 4;
                     let mut distance_to_next_match = 1u32;
@@ -471,8 +471,8 @@ fn encode_sequence(
     match_length: i32,
     offset: i32,
 ) -> bool {
-    debug_assert!(match_length >= MINMATCH);
-    debug_assert!(offset > 0 && offset as u32 <= DISTANCE_MAX);
+    assert!(match_length >= MINMATCH);
+    assert!(offset > 0 && offset as u32 <= DISTANCE_MAX);
 
     let lit_len = (*ip - *anchor) as usize;
 
@@ -580,7 +580,7 @@ fn literals_price(litlen: i32) -> i32 {
 /// offset, the literal run, and any extra match-length bytes.
 #[inline]
 fn sequence_price(litlen: i32, mlen: i32) -> i32 {
-    debug_assert!(mlen >= MINMATCH);
+    assert!(mlen >= MINMATCH);
     let mut price = 1 + 2; // token + 16-bit offset
     price += literals_price(litlen);
     if mlen >= ML_MASK + MINMATCH {

--- a/rust/darc-codecs/src/lzp.rs
+++ b/rust/darc-codecs/src/lzp.rs
@@ -30,10 +30,10 @@ fn ror(x: u32, y: i32) -> u32 {
 /// `lzpC(p)` -- the 32-bit word ending at `at`, i.e. bytes [at-4, at).
 #[inline]
 fn lzp_c(b: &[u8], at: usize) -> u32 {
-    debug_assert!(at >= 4 && at <= b.len(), "lzpC out of range");
-    if at < 4 || at > b.len() {
-        return 0;
-    }
+    // `assert!`, not `debug_assert!`: the callers' bounds are the invariant, and a
+    // 0 returned for an out-of-range window would silently change the hash rather
+    // than name the broken caller.
+    assert!(at >= 4 && at <= b.len(), "lzpC out of range");
     u32::from_le_bytes([b[at - 4], b[at - 3], b[at - 2], b[at - 1]])
 }
 

--- a/rust/darc-codecs/src/srep/hash_table.rs
+++ b/rust/darc-codecs/src/srep/hash_table.rs
@@ -204,7 +204,7 @@ pub const DIGEST_LEN: usize = 20;
 /// bit. The C reaches this through `__builtin_clzll`; `n == 0` is undefined
 /// there and never occurs, since every caller has already forced `n >= 2`.
 pub fn lb(n: u64) -> u32 {
-    debug_assert!(n > 0, "lb(0) is undefined in the C too");
+    assert!(n > 0, "lb(0) is undefined in the C too");
     63 - n.leading_zeros()
 }
 

--- a/rust/darc-codecs/src/tornado/matchfinder.rs
+++ b/rust/darc-codecs/src/tornado/matchfinder.rs
@@ -42,7 +42,7 @@ const MB: usize = 1024 * 1024;
 /// `lb` (Common.h:507) -- floor of the binary logarithm. Undefined for 0 there;
 /// the callers all pass a positive size.
 fn lb(n: u32) -> u32 {
-    debug_assert!(n > 0, "lb(0) is undefined in the C too");
+    assert!(n > 0, "lb(0) is undefined in the C too");
     31 - n.leading_zeros()
 }
 

--- a/rust/darc-codecs/src/tornado/out_stream.rs
+++ b/rust/darc-codecs/src/tornado/out_stream.rs
@@ -86,14 +86,18 @@ impl<'a> OutputByteStream<'a> {
 
     #[inline]
     fn room(&mut self, n: usize) -> bool {
-        if self.output + n > self.buf.len() {
-            // Unreachable with the C's sizing: at most `pad` bytes are written
-            // between flushes and the buffer holds chunk+pad+512+4096. Report it
-            // rather than panicking across the ABI if the arithmetic ever slips.
-            debug_assert!(false, "Tornado output buffer overflow");
-            self.err = Some(crate::ffi::FREEARC_ERRCODE_GENERAL);
-            return false;
-        }
+        // Unreachable with the C's sizing: at most `pad` bytes are written between
+        // flushes and the buffer holds chunk+pad+512+4096.
+        //
+        // `assert!`, not a `debug_assert!` beside an error return: the error return
+        // was the release behaviour and it silently truncated the stream where the
+        // debug build would have named the bug. Panicking is safe across the ABI --
+        // every entry point goes through `ffi::guard`, whose `catch_unwind` turns
+        // this back into FREEARC_ERRCODE_GENERAL for the C caller.
+        assert!(
+            self.output + n <= self.buf.len(),
+            "Tornado output buffer overflow"
+        );
         true
     }
 
@@ -211,7 +215,7 @@ impl<'a> OutputBitStream<'a> {
     /// the target's shift instruction happens to do.
     #[inline]
     pub fn putbits(&mut self, n: i32, x: u32) {
-        debug_assert!((0..=32).contains(&n), "putbits width {n} out of range");
+        assert!((0..=32).contains(&n), "putbits width {n} out of range");
         self.bitbuf |= (x as u64) << self.bitcount;
         self.bitcount += n;
         if self.bitcount >= 64 {

--- a/rust/darc-codecs/src/tornado/tables.rs
+++ b/rust/darc-codecs/src/tornado/tables.rs
@@ -345,7 +345,7 @@ pub fn check_for_data_table(
     bufend: usize,
     last_checked: &mut LastChecked,
 ) -> Option<FoundTable> {
-    debug_assert!(n < MAX_TABLE_ROW);
+    assert!(n < MAX_TABLE_ROW);
     if p < 2 {
         return None;
     }

--- a/rust/darc-crypto/src/ffi.rs
+++ b/rust/darc-crypto/src/ffi.rs
@@ -41,7 +41,7 @@ impl Io {
     }
 
     fn call(&self, what: &[u8], buf: *mut c_void, size: c_int) -> c_int {
-        debug_assert_eq!(what.last(), Some(&0), "`what` must be NUL-terminated");
+        assert_eq!(what.last(), Some(&0), "`what` must be NUL-terminated");
         unsafe { (self.callback)(what.as_ptr() as *const c_char, buf, size, self.auxdata) }
     }
 
@@ -63,6 +63,6 @@ impl Io {
 }
 
 fn clamp_len(n: usize) -> c_int {
-    debug_assert!(n <= c_int::MAX as usize, "buffer longer than c_int can express");
+    assert!(n <= c_int::MAX as usize, "buffer longer than c_int can express");
     n as c_int
 }

--- a/rust/darc-lzma/src/lzma2_enc.rs
+++ b/rust/darc-lzma/src/lzma2_enc.rs
@@ -745,17 +745,16 @@ impl Lzma2Enc {
             };
             res?;
 
-            // Lzma2Enc.c:626-627. A debug assertion for the message, and the C's own
-            // runtime check so that release builds refuse rather than emit a stream
-            // whose chunk lengths do not add up to the input.
-            debug_assert_eq!(
+            // Lzma2Enc.c:626-627. Unconditional, not `debug_assert_eq!`: emitting a
+            // stream whose chunk lengths do not add up to the input is a corrupt
+            // archive, and it must not be possible to build a configuration that
+            // does it quietly. The C's runtime check that stood beside this is gone
+            // with the debug assertion -- there is only one behaviour now.
+            assert_eq!(
                 st.src_pos, limited.processed,
                 "block consumed {} bytes but the limited stream delivered {}",
                 st.src_pos, limited.processed
             );
-            if st.src_pos != limited.processed {
-                return Err(Lzma2Error::Fail);
-            }
 
             // Lzma2Enc.c:629. With SOLID this always holds -- the limit is the "no
             // limit" sentinel, so the only way the inner loop ended is end-of-input.
@@ -1137,7 +1136,7 @@ fn encode_subblock(
     // so an incompressible prefix followed by compressible data emits mode 2 for the
     // first LZMA chunk. `a_copy_chunk_before_the_first_lzma_chunk_produces_mode_two`
     // is that case, and the independent differential harness observes it too.
-    debug_assert_ne!(mode, 1, "mode 1 requires needInitState without needInitProp");
+    assert_ne!(mode, 1, "mode 1 requires needInitState without needInitProp");
 
     chunk.clear();
     chunk.push(CONTROL_LZMA | (mode << 5) | (((u >> 16) & 0x1F) as u8));
@@ -1148,7 +1147,7 @@ fn encode_subblock(
     if st.need_init_prop {
         chunk.push(st.props_byte);
     }
-    debug_assert_eq!(chunk.len(), lz_header_size);
+    assert_eq!(chunk.len(), lz_header_size);
 
     st.need_init_prop = false;
     st.need_init_state = false;

--- a/rust/darc-lzma/src/rangecoder.rs
+++ b/rust/darc-lzma/src/rangecoder.rs
@@ -281,7 +281,7 @@ impl<'a> RangeEncoder<'a> {
     /// `RangeEnc_EncodeDirectBits` (inlined at `LzmaEnc.c:2133`): encode the top
     /// `num_bits` of `value` with no probability model, MSB first.
     pub fn encode_direct_bits(&mut self, value: u32, num_bits: u32) {
-        debug_assert!(num_bits > 0);
+        assert!(num_bits > 0);
         let mut n = num_bits;
         loop {
             self.range >>= 1;

--- a/rust/difftest/debug-assert-check.sh
+++ b/rust/difftest/debug-assert-check.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
-# Run the codecs with debug assertions ENABLED, which no other harness does.
+# Run the codecs with OVERFLOW CHECKS enabled, which no other harness does.
 #
 # ## Why this exists
 #
-# The crate carries 19 `debug_assert!`s. Every other harness builds
-# `--release`, where `debug_assert!` compiles to nothing -- so all 19 are dead
-# in the only configuration that is ever tested. That is not hypothetical: the
-# Tornado presets 7-11 divergence fixed alongside this file was precisely a
-# guard firing into the void. `MatchFinder`'s default `update_hash1` is
+# It was written for `debug_assert!`. The crate carried 19 of them, every other
+# harness builds `--release` where `debug_assert!` compiles to nothing, and so
+# all 19 were dead in the only configuration ever tested. That was not
+# hypothetical: the Tornado presets 7-11 divergence fixed alongside this file
+# was precisely a guard firing into the void. `MatchFinder`'s default
+# `update_hash1` was
 #
 #     fn update_hash1(&mut self, buf: &[u8], p: usize) {
 #         let _ = (buf, p);
@@ -17,21 +18,29 @@
 # `Hash3` defined `update_hash1` only inherently, so `CombineMF` -- which holds
 # its auxiliary finder as `Box<dyn MatchFinder>` -- reached that default. In
 # release it silently did nothing and the encoder diverged from the C thousands
-# of positions later. One debug run would have named the problem immediately.
+# of positions later.
+#
+# **There are no `debug_assert!`s left.** Every one became an `assert!`, so the
+# assertions now fire in the builds that ship and every other harness exercises
+# them. What is still debug-only, and still tested nowhere else, is `-C
+# overflow-checks`: an `as`-free arithmetic wrap that release computes silently
+# panics here. With ~2400 `as` casts in the crate that is a live class of bug,
+# so this file keeps its job with a narrower remit -- and the liveness probe
+# below had to change with it, since the assertion messages it used to look for
+# are in the release artifact too now.
 #
 # ## What this checks, and what it does NOT
 #
 # This is not a differential test. It does not compare against the C at all --
 # the other harnesses do that, and doing it here would only duplicate them more
-# slowly. What it does is drive the codec through a debug build and fail if any
-# assertion fires or the process dies. The signal is a panic, not a byte
-# mismatch.
+# slowly. What it does is drive the codec through a debug build and fail if an
+# assertion or an overflow check fires, or the process dies. The signal is a
+# panic, not a byte mismatch.
 #
-# Tornado is the whole scope today: 9 of the 19 assertions live under
-# `src/tornado/` (matchfinder 4, out_stream 2, lz77_enc 2, tables 1), and every
-# preset reaches a different match finder and entropy back-end. Extending to
-# another codec is mechanical -- add its `*_ref.cpp` pair to `CODECS` below with
-# the arguments its driver expects.
+# Tornado is the whole scope today: its four match finders and two entropy
+# back-ends are the densest arithmetic in the crate, and every preset reaches a
+# different combination. Extending to another codec is mechanical -- add its
+# `*_ref.cpp` pair to `CODECS` below with the arguments its driver expects.
 set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 . "$ROOT/rust/difftest/c-reference.sh"
@@ -40,7 +49,7 @@ CFLAGS_C="$(darc_codec_cflags Tornado)" || exit 1
 W="${TMPDIR:-/tmp}/debug-assert.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
-# The point of the whole file: NO --release. Debug assertions on.
+# The point of the whole file: NO --release. Overflow checks on.
 #
 # Note this writes target/debug, a different directory from the release
 # staticlib every other harness uses, so running this cannot disturb them and
@@ -51,20 +60,23 @@ trap 'rm -rf "$W"' EXIT
 LIB="$ROOT/rust/target/debug/libdarc_codecs.a"
 [ -f "$LIB" ] || { echo "no debug staticlib at $LIB" >&2; exit 1; }
 
-# Prove the build really has assertions compiled in. Without this the harness
-# would pass vacuously on a release artifact, which is the exact failure mode it
-# exists to prevent.
+# Prove the build really has overflow checks compiled in. Without this the
+# harness would pass vacuously on a release artifact, which is the exact failure
+# mode it exists to prevent.
+#
 # grep -c, not grep -q: `set -o pipefail` is on and `grep -q` exits at the first
 # match, SIGPIPEing `strings` and failing the pipeline even on success. That bug
 # was fixed in 4x4-check.sh earlier the same day and then written again here.
 #
-# The message checked is from ffi.rs's clamp_len, not the update_hash1 default:
-# now that Hash3 overrides that method, nothing may reach the default body, and
-# a message the optimiser is free to drop is a poor liveness probe.
-asserts=$(strings -a "$LIB" 2>/dev/null | grep -c 'buffer longer than c_int can express')
-[ "${asserts:-0}" -ge 1 ] || {
-  echo "the debug staticlib does not contain the assertion messages -- assertions are" >&2
-  echo "compiled out, so this run would prove nothing." >&2
+# The probe is rustc's own overflow panic message, which exists ONLY when
+# `-C overflow-checks` is on. It deliberately is not an assertion message any
+# more: every assertion in this crate is now unconditional, so an assertion
+# string is present in a release artifact too and would prove nothing about the
+# profile this file needs.
+checks=$(strings -a "$LIB" 2>/dev/null | grep -c 'attempt to .* with overflow')
+[ "${checks:-0}" -ge 1 ] || {
+  echo "the debug staticlib carries no overflow-check panic messages -- overflow" >&2
+  echo "checks are compiled out, so this run would prove nothing." >&2
   exit 1; }
 
 cc() { local out="$1"; shift

--- a/rust/difftest/debug-assert-check.sh
+++ b/rust/difftest/debug-assert-check.sh
@@ -3,9 +3,9 @@
 #
 # ## Why this exists
 #
-# It was written for `debug_assert!`. The crate carried 19 of them, every other
-# harness builds `--release` where `debug_assert!` compiles to nothing, and so
-# all 19 were dead in the only configuration ever tested. That was not
+# It was written for `debug_assert!`. The workspace carried 22 of them, every
+# other harness builds `--release` where `debug_assert!` compiles to nothing, and
+# so all 22 were dead in the only configuration ever tested. That was not
 # hypothetical: the Tornado presets 7-11 divergence fixed alongside this file
 # was precisely a guard firing into the void. `MatchFinder`'s default
 # `update_hash1` was


### PR DESCRIPTION
Zero `debug_assert!`s remain in the workspace. 22 sites became `assert!`, so an invalid operation panics in the profile that ships rather than in the profile nothing builds.

The origin is the Tornado presets 7-11 divergence: a `debug_assert!(false, …)` in a trait default, dead in release, that let the encoder diverge from the C thousands of positions later. That fix removed the default; this removes the class.

### The five that mattered

Five sites stood beside a release fallback that existed *because* the assertion was debug-only. Those fallbacks are the hazard — each turns a broken invariant into plausible-looking output:

| site | old release behaviour |
|---|---|
| `delta::read_i16` | returned 0 for a read outside the block |
| `lzp::lzp_c` | returned 0 for an out-of-range window |
| `lzma2_enc` | returned `Lzma2Error::Fail` for chunk lengths that don't add up |
| `tornado::OutStream::room` | set an error code and truncated the stream |

All gone. One behaviour now, and it is the loud one.

Panicking is safe across the ABI: every codec entry point goes through `ffi::guard`, whose `catch_unwind` returns `FREEARC_ERRCODE_GENERAL` — the C caller gets what the fallbacks used to hand it, without the silence.

### `debug-assert-check.sh`

Its liveness probe grepped the debug staticlib for an assertion message, and that message is in the release artifact now — the probe would have passed on any profile. It greps rustc's overflow-panic string instead, which exists only under `-C overflow-checks`. The header says what the file is still for: overflow checks over ~3000 `as` casts that release wraps in silence.

### Gated

- byte-identical to the C: tornado (decode + 28 encode presets), lz4hc 312/312, lzp, bcj 1340/1340, lzma2, srep, dispack, grzip, mm, tta, dict, rep
- `debug-assert-check.sh`: 320 clean runs on the new probe
- `arc-golden-check.sh`: **105 cases, 0 differing**
- 687 tests, clippy exhaustive-match gate clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)