### PR TITLE
darc-arc: document the boundary casts that look wrong and are not

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -45,6 +45,34 @@ records the bug already paid for: `n_symbols` typed `u8` overflowed on a
 full-alphabet block. Testing the casts empirically is cheaper and safer than
 converting thousands of them.
 
+### The boundary audit, and why it found nothing
+
+The other half of the cast problem is the casts the harness cannot reach by
+running code: those on the **data path**, where no encoder/decoder symmetry
+argument applies — archive-header fields, allocation sizes, FFI lengths. Clippy
+flags 77 possibly-truncating casts in `darc-arc`, and every one was checked.
+
+**No defects.** Each is one of:
+
+* **Lossless by construction.** `u64 as usize` on the only supported targets
+  (all 64-bit); `(hi * 16 + lo) as u8` where both are `to_digit(16)` nibbles;
+  `orig as u32` in `fourx4.rs`, bounded because the block size upstream is
+  already `u32`.
+* **Guarded before the narrowing.** `bytestream.rs:244` is the model:
+  `if n > remaining as u64 { return Err(ImplausibleLength) }` proves `n` fits a
+  `usize` before casting. `codec_io.rs` rejects `size < 0` on entry, so every
+  later `as c_int` round-trips a value that arrived as one.
+* **A faithful transliteration whose truncation is visible in the reference
+  too**, documented at the site. Two of these look exactly like bugs, and
+  "fixing" either would break byte-identity — see `decompress.rs`'s thread clamp
+  (values above `i32::MAX` wrap negative, matching `9a127e6` at every value
+  tested) and its `lc`/`lp`/`pb` narrowing (`-mlzma:lc259` is byte-identical to
+  the reference; `-mlzma:lc300` aborts in *both* builds).
+
+That last category is the reason this audit was worth doing and the reason a
+mass `try_into()` sweep would not have been: three sites that read as obvious
+defects are conformant, and only the reference could settle it.
+
 **Its failure signal is stderr, never the exit status**, and this is not a
 stylistic choice. Every codec entry point goes through `ffi::guard`, whose
 `catch_unwind` turns a panic into `FREEARC_ERRCODE_GENERAL` — indistinguishable

--- a/rust/darc-arc/src/decompress.rs
+++ b/rust/darc-arc/src/decompress.rs
@@ -309,6 +309,19 @@ pub fn compress_one_with(method: &Method, src: &[u8], all_at_once: bool) -> Resu
             })
         }
         Method::Lzma(p) => {
+            // `lc`/`lp`/`pb` are parsed as `u32` and narrowed here, so a method
+            // string may name a value the encoder never sees. Also conformant,
+            // also verified rather than assumed:
+            //
+            //     -mlzma:lc259  ->  259 as u8 == 3, archive stores "lc259",
+            //                       byte-identical to the reference (54497 B)
+            //     -mlzma:lc300  ->  300 as u8 == 44, and the literal-probability
+            //                       allocation aborts -- rc=134 in BOTH builds
+            //     -mlzma:lc9    ->  rejected by both
+            //
+            // The C narrows the same way through `atoi` into an `int`, so
+            // validating before the cast would reject archives the reference
+            // writes. The abort is the reference's behaviour too.
             let props = darc_lzma::LzmaProps {
                 lc: p.lit_context_bits as u8,
                 lp: p.lit_pos_bits as u8,
@@ -509,6 +522,21 @@ fn do_lzma2(p: &crate::method::Lzma2Params, src: &[u8]) -> Result<Vec<u8>, Error
     // `GetCompressionThreads()` (`C_LZMA2.cpp:71-73`). NOT a tuning knob: above
     // one block thread the encoder splits the input into blocks that each open
     // with a dictionary reset, so this decides the bytes.
+    //
+    // The clamp bound is `u32::MAX` and the cast is to `i32`, which means every
+    // value above `i32::MAX` WRAPS NEGATIVE and the encoder falls back to a
+    // single block thread. That reads like a bug -- the obvious "fix" is to
+    // clamp to `i32::MAX` -- and it is load-bearing. Measured against the
+    // reference on a 3.2 MB input with `-mlzma2:d64k`:
+    //
+    //     -mt2147483647  776354 bytes   (multi-block)
+    //     -mt2147483648  770873 bytes   (single block -- the sign flipped)
+    //     -mt4294967295  770873 bytes
+    //
+    // byte-identical to `9a127e6` at every one of those values. The C narrows
+    // to a signed int and flips in the same place, so clamping to `i32::MAX`
+    // here would make `-mt` above 2^31 write archives the reference does not.
+    // Leave it.
     let threads = crate::memlimit::compression_threads().clamp(1, u64::from(u32::MAX)) as i32;
     props.num_total_threads = threads;
     props.num_block_threads_max = threads;


### PR DESCRIPTION
The other half of the cast problem — the half `debug-assert-check.sh` cannot reach by running code. Casts on the **data path**, where the encoder/decoder symmetry that makes a model-context truncation harmless does not apply: archive-header fields, allocation sizes, FFI lengths.

Clippy flags **77** possibly-truncating casts in `darc-arc`. All 77 checked.

## Result: no defects

Every one is:

- **Lossless by construction** — `u64 as usize` on the only supported targets (all 64-bit); `(hi * 16 + lo) as u8` where both come from `to_digit(16)`; `orig as u32` in `fourx4.rs`, bounded because the block size upstream is already `u32`.
- **Guarded before the narrowing** — `bytestream.rs:244` is the model: `if n > remaining as u64 { return Err(ImplausibleLength) }` proves `n` fits a `usize` before casting. `codec_io.rs` rejects `size < 0` on entry, so every later `as c_int` round-trips a value that arrived as one.
- **A faithful transliteration**, now documented at the site.

## The two that look like bugs

Both verified against `Tests/arc-ghc` built from `9a127e6`, not reasoned about.

**The LZMA2 thread count** clamps to `u32::MAX` then casts to `i32`, so everything above `i32::MAX` wraps negative and falls back to one block thread. On 3.2 MB with `-mlzma2:d64k`:

| `-mt` | bytes | |
|---|---|---|
| 2147483647 | 776354 | multi-block |
| 2147483648 | 770873 | single block — sign flipped |
| 4294967295 | 770873 | |

**Byte-identical to the reference at every value.** Clamping to `i32::MAX` — the obvious fix — would write archives `9a127e6` does not.

**`lc`/`lp`/`pb`** are parsed as `u32` and narrowed to `u8`:

- `-mlzma:lc259` → `259 as u8 == 3`: encodes as lc3 while storing `"lc259"`, byte-identical to the reference (54497 B)
- `-mlzma:lc300` → `300 as u8 == 44`: the literal-probability allocation aborts, **rc=134 in both builds**
- `-mlzma:lc9` → rejected by both

The C narrows the same way through `atoi` into an `int`. Validating before the cast would reject archives the reference writes, and the abort is the reference's behaviour too.

## Why this matters

Three sites that read as obvious defects are conformant, and only the reference could settle it. **I was one edit from "correcting" all three** — which is the argument against the mass `try_into()` sweep, made concrete.

271 `darc-arc` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)