### PR TITLE
difftest: five extraction cases for the Windows traversal names

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -156,7 +156,7 @@ Note that `compile-ghc-probe` writes objects into the shared `/tmp/out/`, so run
 
 ### What runs without a reference: `arc-golden-check.sh`
 
-113 cases. It is the only archive-format gate CI runs, and the only one that
+118 cases. It is the only archive-format gate CI runs, and the only one that
 will still be meaningful in a year.
 
 Since compatibility stopped being the bar (`CLAUDE.md`), it holds three kinds,
@@ -166,7 +166,7 @@ tagged in column 3 of the manifest:
 |---|---|---|
 | `ref` (or absent) | 105 | byte-identical to `9a127e6`. A move is a regression. |
 | `port` | 1 | the port deliberately writes different bytes. Column 4 is what the *reference* writes. |
-| `refuse` | 7 | the input must be rejected: non-zero exit under 128, no archive. |
+| `refuse` | 12 | the input must be rejected, or an extraction name neutralised. |
 
 Recording the reference's hash **beside** ours on a `port` line is what makes a
 silently reverted divergence detectable — otherwise the gate catches "it
@@ -174,9 +174,24 @@ changed" but not "it changed back". `refuse` distinguishes `crashed` (died on a
 signal) from `refused`, because the reference *aborts* on `-mlzma:lc300` and
 collapsing those two would have passed on the crashing build.
 
+Five of the refusals are **extraction** cases, and they check the result rather
+than the verdict: everything that lands must land inside the destination, under
+a name that is not itself an escape. Refusing is only one acceptable answer —
+`strip_root` *sanitises* a rooted name instead, so `\evil.txt` becomes
+`evil.txt`, which is better than refusing because the data survives. An
+expectation of "refused" would have failed the port for doing the right thing.
+
+They are buildable end-to-end because `\` is an ordinary Unix filename
+character: `..\..\evil.txt` is a legal file here, is archived under that exact
+name, and becomes a path only when opened on Windows. On Unix that means the
+case cannot demonstrate the escape itself, only that the dangerous name never
+survives to disk — the escape is what `extract.rs`'s unit tests cover.
+
 The self-test is running the whole thing against `Tests/arc-ghc`: it must fail,
 with RECONVERGED on the `port` case, ACCEPTED on `lc259` and the dictionary
-overflow, and CRASHED on `lc300`/`lp300` — while all 105 `ref` cases pass.
+overflow, CRASHED on `lc300`/`lp300`, and UNSAFE NAME on all five extraction
+cases — while all 105 `ref` cases pass. Ten failures, and the reference earns
+every one of them.
 
 Rules:
 

--- a/rust/difftest/arc-golden-check.sh
+++ b/rust/difftest/arc-golden-check.sh
@@ -328,6 +328,79 @@ run_refuse() {
   printf '%s  %s\n' "$outcome" "$id" >> "$results"
 }
 
+# run_extract_refuse <case-id> <stored-name> -- a name that must not be written
+# on EXTRACTION.
+#
+# I claimed these were unbuildable from the CLI, on the reasoning that a
+# traversal name could not be created on disk. That was wrong: `\` is an
+# ordinary filename character on Unix, so `..\..\evil.txt` is a perfectly legal
+# file here, gets archived under that exact name, and becomes a path only when
+# the archive is opened on Windows. Which is the whole point -- the danger lives
+# in the archive, not in the machine that made it, and that is why
+# `extract::is_safe` refuses these on every platform rather than under
+# `cfg!(windows)`.
+#
+# `/` cannot appear in a Unix filename, so the classic `../evil` and absolute
+# `/etc/passwd` forms are NOT expressible this way. They stay unit-tested in
+# `extract.rs`; everything here is a backslash form.
+#
+# The assertion is NOT "was it refused". Refusing is only one of two acceptable
+# answers, and the port gives the other one for three of these five: `strip_root`
+# SANITISES a rooted name rather than rejecting it, so `\evil.txt` lands as
+# `evil.txt` and `d:\evil.txt` as `evil.txt`. That is correct and better than
+# refusing -- the data is preserved and it lands inside the destination -- and an
+# expectation of "refused" would have failed the port for doing the right thing.
+# It nearly did; the first draft of this recorded those three as a failure.
+#
+# What is checked instead is the property that actually matters: **everything
+# that lands, lands inside the destination, under a name that is not itself an
+# escape.** That is `is_safe` applied to the RESULT rather than to the input,
+# which is the thing a Windows box would act on.
+#
+# One honest limit: on Unix none of these names is a traversal at all, so this
+# cannot demonstrate the escape itself -- only that the dangerous name never
+# survives to disk. The escape is what `extract.rs`'s unit tests cover.
+run_extract_refuse() {
+  local id="$1" name="$2"
+  local tree="$W/xt"
+  rm -rf "$tree"; mkdir -p "$tree"
+  printf 'pwned\n' > "$tree/$name" 2>/dev/null || {
+    printf '%s  %s\n' "unbuildable" "$id" >> "$results"; return; }
+  rm -f "$W/g.arc"
+  ( cd "$tree" && "$BIN" a --nodates -y -m0 "$W/g.arc" . ) >/dev/null 2>&1
+  [ -f "$W/g.arc" ] || { printf '%s  %s\n' "no-archive" "$id" >> "$results"; return; }
+  # The destination sits inside a box, so anything written outside it is visible
+  # rather than scattered through $W.
+  local box="$W/xbox"; rm -rf "$box"; mkdir -p "$box/dest"
+  local rc=0
+  ( cd "$box/dest" && "$BIN" x -y "$W/g.arc" ) >/dev/null 2>&1 || rc=$?
+  local outcome=contained
+  if [ -n "$(find "$box" -mindepth 1 -maxdepth 1 ! -name dest 2>/dev/null)" ]; then
+    outcome=escaped
+  elif [ "$rc" -ge 128 ]; then
+    outcome=crashed
+  else
+    # Every landed path, judged by the same rules extract::is_safe applies.
+    local f rel
+    while IFS= read -r f; do
+      rel="${f#"$box/dest/"}"
+      case "$rel" in
+        /*|\\*) outcome=unsafe-name; break ;;
+        [A-Za-z]:*) outcome=unsafe-name; break ;;
+        *..*)
+          # Only a whole `..` COMPONENT is an escape; `a..b` is an ordinary name.
+          case "$(printf '%s' "$rel" | tr '\\' '/')" in
+            ../*|*/../*|*/..) outcome=unsafe-name; break ;;
+            ..) outcome=unsafe-name; break ;;
+            *) ;;
+          esac ;;
+        *) ;;
+      esac
+    done < <(find "$box/dest" -type f 2>/dev/null)
+  fi
+  printf '%s  %s\n' "$outcome" "$id" >> "$results"
+}
+
 A="$W/g.arc"
 
 # ── stored: the format itself, with no codec in the way ─────────────────────
@@ -545,6 +618,17 @@ run_refuse lzma-pb5      a --nodates -y -mlzma:pb5 "$A" .
 run_refuse lzma2-lc9     a --nodates -y -mlzma2:lc9 "$A" .
 run_refuse lzma-dict-overflow a --nodates -y -mlzma:d5000000000 "$A" .
 
+# ── extraction: a stored name that must never become a path ─────────────────
+#
+# Every one of these is a legal Unix filename and a path on Windows. Before
+# #136 `is_safe` split on '/' alone, so none of them had a component equal to
+# ".." and `Path::join` wrote them wherever they pointed.
+run_extract_refuse x-dotdot-backslash   '..\..\evil.txt'
+run_extract_refuse x-mixed-separators   'sub\..\..\evil.txt'
+run_extract_refuse x-leading-backslash  '\evil.txt'
+run_extract_refuse x-drive-letter       'd:\evil.txt'
+run_extract_refuse x-unc-path           '\\server\share'
+
 sort -o "$results" "$results"
 
 if [ "$record" = 1 ]; then
@@ -649,7 +733,15 @@ while read -r want id kind refbytes why; do
     refuse)
       n_refuse=$((n_refuse + 1))
       case "$got" in
-        refused) ;;
+        refused|contained) ;;
+        escaped)
+          echo "  ESCAPED [$id]: a file was written OUTSIDE the destination"
+          echo "      $why"
+          fail=$((fail + 1)) ;;
+        unsafe-name)
+          echo "  UNSAFE NAME [$id]: a name that is a path escape survived to disk"
+          echo "      $why"
+          fail=$((fail + 1)) ;;
         accepted)
           echo "  ACCEPTED [$id]: an input that must be refused produced an archive"
           echo "      $why"

--- a/rust/difftest/golden/manifest.txt
+++ b/rust/difftest/golden/manifest.txt
@@ -131,3 +131,8 @@ refused  lzma-lp300            refuse  crashed   As lzma-lc300, via lp (#136).
 refused  lzma-pb5              refuse  refused   pb above LZMA_PB_MAX. Both refuse.
 refused  lzma2-lc9             refuse  refused   The lzma2 parser must bound lc as the lzma one does; it did not until #136.
 refused  lzma-dict-overflow    refuse  accepted  d5000000000 overflows u32. parse_int wrapped it to 705032704 and the reference still does, giving a header that names a dictionary nobody asked for (#136).
+contained  x-dotdot-backslash   refuse  unsafe-name  ..\..\evil.txt is a legal Unix filename and a traversal on Windows. is_safe split on / alone before #136, so it had no ".." component and Path::join wrote it outside the destination.
+contained  x-mixed-separators   refuse  unsafe-name  sub\..\..\evil.txt -- the same escape reached through a name that also contains a legitimate component (#136).
+contained  x-leading-backslash  refuse  unsafe-name  \evil.txt is absolute from the drive root on Windows. The port sanitises it to evil.txt inside the destination; the reference writes it verbatim (#136).
+contained  x-drive-letter       refuse  unsafe-name  d:\evil.txt -- strip_root's doc always claimed it removed d:\ while the code trimmed only /, leaving \evil.txt (#136).
+contained  x-unc-path           refuse  unsafe-name  \\server\share names another host on Windows. Sanitised to server\share inside the destination (#136).


### PR DESCRIPTION
I said an archive-level case for the traversal names couldn't be built, because a `..\` name couldn't be created on disk. **That's false on Unix** — `\` is an ordinary filename character. `..\..\evil.txt` is a perfectly legal file here, gets archived under that exact name, and becomes a *path* only when the archive is opened on Windows.

Which is exactly the point: the danger lives in the **archive**, not in the machine that made it. That's why `extract::is_safe` refuses these on every platform rather than under `cfg!(windows)`.

### The five cases

`..\..\evil.txt`, `sub\..\..\evil.txt`, `\evil.txt`, `d:\evil.txt`, `\\server\share`.

`/` can't appear in a Unix filename, so `../evil` and `/etc/passwd` aren't expressible this way — they stay unit-tested in `extract.rs`.

### The assertion is not "was it refused"

Getting this wrong nearly failed the port for doing the right thing. Refusing is only *one* of two acceptable answers, and `strip_root` gives the other for three of the five — it **sanitises** a rooted name rather than rejecting it:

| stored | lands as | |
|---|---|---|
| `..\..\evil.txt` | *(refused)* | has a `..` component |
| `\evil.txt` | `evil.txt` | rooted → root stripped |
| `d:\evil.txt` | `evil.txt` | drive stripped |
| `\\server\share` | `server\share` | leading separators stripped |

All inside the destination, data preserved. My first draft of the runner expected `refused` and reported those three as failures.

What's checked instead is the property that matters: **everything that lands, lands inside the destination under a name that is not itself an escape** — `is_safe` applied to the *result*, which is what a Windows box would act on. New outcomes `escaped` and `unsafe-name`; `contained` passes.

**Honest limit, stated at the site:** on Unix none of these names is a traversal, so the case can't demonstrate the escape — only that the dangerous name never survives to disk.

### Measured both ways

- **Port:** `contained` on all five.
- **Reference:** `unsafe-name` on all five — the vulnerability, present in `9a127e6` too.

### Gate

`arc-golden-check` is now **118 cases** (105 reference, 1 divergent, 12 refusal), 0 failing.

Against `Tests/arc-ghc` it fails **ten** — RECONVERGED, two ACCEPTED, two CRASHED, five UNSAFE NAME — while all 105 `ref` cases still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)