### PR TITLE
rep: bound the two allocations that come out of the stream

### DIFF
--- a/rust/darc-arc/src/decompress.rs
+++ b/rust/darc-arc/src/decompress.rs
@@ -77,7 +77,9 @@ fn undo(method: &Method, src: &[u8], hint: usize) -> Result<Vec<u8>, Error> {
         Method::Tornado(_) => {
             drive("tor", src, hint, darc_codecs::tornado::decode::decompress)
         }
-        Method::Rep(_) => drive("rep", src, hint, darc_codecs::rep::decompress),
+        Method::Rep(p) => {
+            drive("rep", src, hint, |io| darc_codecs::rep::decompress(io, p.block_size))
+        }
         Method::Grzip(_) => drive("grzip", src, hint, darc_codecs::grzip::stream::decompress),
         // The BCJ filter runs in the decode direction here.
         Method::Exe => drive("exe", src, hint, |io| {

--- a/rust/darc-codecs/src/rep.rs
+++ b/rust/darc-codecs/src/rep.rs
@@ -50,23 +50,36 @@ fn i32_at(buf: &[u8], off: usize) -> i32 {
     i32::from_le_bytes([buf[off], buf[off + 1], buf[off + 2], buf[off + 3]])
 }
 
-/// Decode a REP stream. Signature-compatible with `rep_decompress`; the tuning
-/// parameters are not needed on the decode side (the block size that matters is
-/// stored in the stream), so they are accepted and ignored, as the C does.
-pub fn decompress(io: &Io) -> c_int {
-    match run(io) {
+/// Decode a REP stream.
+///
+/// `declared_block_size` is the block size from the METHOD STRING, and it is
+/// the only trustworthy bound available here: everything else this function
+/// reads comes out of the stream. It used to be accepted and dropped on the
+/// floor, on the reasoning that "the block size that matters is stored in the
+/// stream" -- true for decoding, and exactly why the stored one cannot also be
+/// its own sanity check.
+///
+/// `dict` and `lzp` have always threaded theirs through for this reason; rep
+/// was simply missed when [`crate::ffi::archive_sized_buffer`] was introduced.
+pub fn decompress(io: &Io, declared_block_size: u32) -> c_int {
+    match run(io, declared_block_size) {
         Ok(()) => OK,
         Err(e) => e,
     }
 }
 
-fn run(io: &Io) -> Result<(), c_int> {
-    // The real dictionary size is the first word of the stream.
-    let block_size = read_u32(io)? as usize;
-    if block_size == 0 {
+fn run(io: &Io, declared_block_size: u32) -> Result<(), c_int> {
+    // The real dictionary size is the first word of the stream -- so it is
+    // attacker-controlled, and `vec![0u8; n]` is infallible. A stream claiming
+    // a 4 GiB dictionary used to get one attempted: harmless where the OS hands
+    // back lazy zero pages, an abort through `handle_alloc_error` under strict
+    // overcommit, a cgroup limit, or a 32-bit target.
+    let stream_block_size = read_u32(io)? as usize;
+    if stream_block_size == 0 {
         return Err(BAD);
     }
-    let mut data = vec![0u8; block_size];
+    let mut data = crate::ffi::archive_sized_buffer(stream_block_size, declared_block_size)?;
+    let block_size = data.len();
     let mut pos: usize = 0; // current write index into `data` (the circular buffer)
 
     loop {
@@ -80,7 +93,10 @@ fn run(io: &Io) -> Result<(), c_int> {
         }
         let compr_size = compr_size as usize;
 
-        let mut buf = vec![0u8; compr_size];
+        // Bounded for the same reason, against the same figure: the encoder
+        // compresses `block_size` bytes at a time, so a compressed block far
+        // past it is corrupt input rather than a big block.
+        let mut buf = crate::ffi::archive_sized_buffer(compr_size, declared_block_size)?;
         read_exact(io, &mut buf)?;
 
         // Header: num, then lens[num], offsets[num], datalens[num+1]. num sizes
@@ -163,7 +179,7 @@ fn run(io: &Io) -> Result<(), c_int> {
 #[allow(clippy::too_many_arguments)]
 pub fn decompress_full(
     io: &Io,
-    _block_size: u32,
+    block_size: u32,
     _min_compression: c_int,
     _min_match_len: c_int,
     _barrier: c_int,
@@ -172,7 +188,7 @@ pub fn decompress_full(
     _amplifier: c_int,
 ) -> c_int {
     drop(NOMEM); // allocation-failure code, kept for parity with the C
-    decompress(io)
+    decompress(io, block_size)
 }
 
 // ---------------------------------------------------------------------------

--- a/rust/darc-codecs/tests/rep.rs
+++ b/rust/darc-codecs/tests/rep.rs
@@ -25,7 +25,7 @@ unsafe extern "C" fn cb(what: *const c_char, buf: *mut c_void, size: c_int, aux:
 fn decompress(stream: &[u8]) -> c_int {
     let mut mem = Mem { input: stream.to_vec(), pos: 0, out: Vec::new() };
     let io = unsafe { Io::new(Some(cb), &mut mem as *mut Mem as *mut c_void) }.unwrap();
-    rep::decompress(&io)
+    rep::decompress(&io, 64 * 1024 * 1024)
 }
 fn le(v: u32) -> [u8; 4] { v.to_le_bytes() }
 
@@ -111,8 +111,44 @@ fn encode_decode_round_trips() {
         let packed = compress(input);
         let mut mem = Mem { input: packed, pos: 0, out: Vec::new() };
         let io = unsafe { Io::new(Some(cb), &mut mem as *mut Mem as *mut c_void) }.unwrap();
-        let rc = rep::decompress(&io);
+        let rc = rep::decompress(&io, 64 * 1024 * 1024);
         assert!(rc >= 0, "case {i}: decompress returned {rc}");
         assert_eq!(mem.out, *input, "case {i}: round-trip mismatch ({} bytes)", input.len());
     }
+}
+
+/// The dictionary size is the first word of the stream, so it is
+/// attacker-controlled, and `vec![0u8; n]` is infallible: a stream claiming a
+/// 4 GiB dictionary used to get one attempted. That is harmless where the OS
+/// hands back lazy zero pages -- measured at 1.85 MB max RSS on macOS, which is
+/// why it never showed up as a crash -- and an abort through
+/// `handle_alloc_error` under strict overcommit, a cgroup limit, or a 32-bit
+/// target.
+///
+/// `dict` and `lzp` were already bounded this way; rep was missed when
+/// `archive_sized_buffer` was introduced.
+#[test]
+fn an_absurd_dictionary_size_is_refused_rather_than_allocated() {
+    let eof = le(0);
+    for declared in [u32::MAX, 1 << 31, (64 * 1024 * 1024) + (1 << 20) + 2048] {
+        let mut s = le(declared).to_vec();
+        s.extend_from_slice(&eof);
+        assert!(
+            decompress(&s) < 0,
+            "a stream declaring a {declared}-byte dictionary must be refused",
+        );
+    }
+    // ...and the bound must not reject a legitimate one. 64 MiB is the method's
+    // own default and what the difftest driver passes.
+    let mut ok = le(64 * 1024 * 1024).to_vec();
+    ok.extend_from_slice(&eof);
+    assert_eq!(decompress(&ok), 0, "a 64 MiB dictionary is legitimate");
+}
+
+/// The per-block compressed size is bounded against the same figure.
+#[test]
+fn an_absurd_compressed_block_size_is_refused() {
+    let mut s = le(1 << 16).to_vec();   // a small, legitimate dictionary
+    s.extend_from_slice(&le(1 << 30));  // ...then a 1 GiB "compressed block"
+    assert!(decompress(&s) < 0, "a compressed block far past the dictionary must be refused");
 }


### PR DESCRIPTION
The codec-layer sweep's one finding.

`darc-codecs/src/ffi.rs` has `archive_sized_buffer` for exactly this, and its doc states the rule: `vec!` is infallible, so **a corrupt archive must produce a diagnosis rather than a fault**. `delta`, `dict` and `lzp` use it. `rep` was missed, and it has two such allocations:

```rust
let block_size = read_u32(io)? as usize;   // the DICTIONARY SIZE, from the stream
let mut data = vec![0u8; block_size];      // up to 4 GiB, unguarded
...
let compr_size = read_u32(io)? as i32;     // bounded below (>= 8), never above
let mut buf = vec![0u8; compr_size];       // up to 2 GiB
```

### The bound was available and thrown away

`decompress_full` already received the **method string's** block size — as `_block_size`. And `darc-arc` matched `Method::Rep(_)` while `Method::Dict(p)` and `Method::Lzp(p)` *directly beside it* thread `p.block_size` through. Both now pass it.

That distinction is the whole point: the stream's own dictionary size cannot sanity-check itself. The method string's is the one figure here that didn't come out of the bytes under test.

### Measured, not asserted — and the measurement is why this isn't filed as a crash

| | result |
|---|---|
| 4 GiB declared dictionary, before | rc=0 in <1s, **1.85 MB** max RSS (vs 1.84 MB normal) |
| 4 GiB declared dictionary, after | rc=4 `BAD_COMPRESSED_DATA` |
| 2 GiB declared dictionary, after | rc=4 |
| legitimate 64 MiB, after | rc=0 |

macOS hands back lazy zero pages, so nothing is committed and nothing aborts — which is why this never surfaced as a crash. The exposure is real but **platform-dependent**: strict overcommit on Linux, a cgroup limit, or a 32-bit target turn it into `handle_alloc_error`.

### Gated

- `rep-check` **13/13 byte-identical** to the C
- `arc-golden-check` **118/118 unchanged**
- 692 tests, clippy gate clean
- Two new tests, **sabotage-verified**: reverting the guard to `vec![0u8; stream_block_size]` fails `an_absurd_dictionary_size_is_refused_rather_than_allocated`

### Also swept, found already sound

- **Crypto** — `apply_in_place` checks IV length before `Ctr::new`/`Cfb::new` assert, with a test whose comment names the threat
- **SREP** — `datasize`/`origsize1`/`statsize` bounded by `MAX_BLOCK`
- **DisPack** — `in_size`/`out_size` bounded by `block_size`
- **`Hash::Unverified(u8)`** — 255 max
- The unconditional asserts from #133 are all on encoder-side invariants, **not reachable from archive bytes**
- 60 distinct random inputs to the rep decoder: 60 clean, 0 hangs, 0 signal deaths

🤖 Generated with [Claude Code](https://claude.com/claude-code)