### PR TITLE
CI: gate the last ungated harness, and keep the merge watcher

### DIFF
--- a/.github/watch-merge.sh
+++ b/.github/watch-merge.sh
@@ -34,9 +34,30 @@ runs_for() { # runs_for <sha> -- one "status conclusion name" per line
     --jq ".[]|select(.headSha==\"$1\")|\"\(.status) \(.conclusion // \"-\") \(.name)\""
 }
 
-HEAD="$(gh pr view "$PR" --json headRefOid --jq .headRefOid)"
-[ -n "$HEAD" ] || { echo "could not read PR $PR head sha"; exit 2; }
-echo "PR #$PR head = ${HEAD:0:7}"
+# The PR's head SHA, reconciled against what is actually on the branch.
+#
+# `gh pr view` is as stale as `gh pr checks` was: queried straight after a push
+# it can still report the PREVIOUS head. That happened on the first live use of
+# this script -- it pinned to the old commit, read that commit's failed run, and
+# refused for the wrong reason. Refusing was the right outcome by luck; pinning
+# to a commit that is no longer the head is not.
+#
+# So: if the local checkout is on this branch, its HEAD is the truth, and this
+# waits for GitHub to catch up rather than trusting the first answer.
+WANT=""
+if [ "$(git rev-parse --abbrev-ref HEAD 2>/dev/null)" = "$BR" ]; then
+  WANT="$(git rev-parse HEAD)"
+fi
+while :; do
+  HEAD="$(gh pr view "$PR" --json headRefOid --jq .headRefOid)"
+  [ -n "$HEAD" ] || { echo "could not read PR $PR head sha"; exit 2; }
+  [ -z "$WANT" ] && break
+  [ "$HEAD" = "$WANT" ] && break
+  echo "PR head is ${HEAD:0:7}, local is ${WANT:0:7} -- waiting for GitHub to catch up"
+  [ "$(date +%s)" -gt "$DEADLINE" ] && { echo "PR head never became ${WANT:0:7}"; exit 2; }
+  sleep 15
+done
+echo "PR #$PR head = ${HEAD:0:7}${WANT:+ (matches local)}"
 
 # 1. A run must EXIST for this commit. This is the check the old watcher had no
 #    equivalent of, and its absence is the whole bug.

--- a/.github/watch-merge.sh
+++ b/.github/watch-merge.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Watch a PR, merge it only on a verdict PINNED TO ITS HEAD COMMIT, then watch
+# the post-merge run.
+#
+#   usage: watch-merge.sh <pr-number> <branch>
+#
+# ── Why the previous version merged a red PR ────────────────────────────────
+#
+# It polled `gh pr checks <n>` until nothing was pending, then treated "no
+# failures" as green. Both of those are wrong the moment a push has just
+# happened:
+#
+#   * `gh pr checks` reports whatever check set exists RIGHT NOW. Straight after
+#     a push the new run has not registered, so it answers with the previous
+#     commit's checks -- or none at all.
+#   * "nothing pending" is therefore satisfied before the new run starts, and
+#     the loop exits on a stale, all-green answer.
+#
+# That is how #140 was merged with `arc-harnesses` failing on both of its
+# commits. The output parsing was fine; the timing was not.
+#
+# This version never asks "are there failures". It asks "what did the run FOR
+# THIS EXACT COMMIT conclude", and refuses to answer until such a run exists and
+# has finished.
+set -uo pipefail
+
+PR="${1:?usage: watch-merge.sh <pr-number> <branch>}"
+BR="${2:?usage: watch-merge.sh <pr-number> <branch>}"
+DEADLINE=$(( $(date +%s) + 3600 ))
+
+runs_for() { # runs_for <sha> -- one "status conclusion name" per line
+  gh run list --branch "$BR" --limit 20 \
+    --json headSha,status,conclusion,name \
+    --jq ".[]|select(.headSha==\"$1\")|\"\(.status) \(.conclusion // \"-\") \(.name)\""
+}
+
+HEAD="$(gh pr view "$PR" --json headRefOid --jq .headRefOid)"
+[ -n "$HEAD" ] || { echo "could not read PR $PR head sha"; exit 2; }
+echo "PR #$PR head = ${HEAD:0:7}"
+
+# 1. A run must EXIST for this commit. This is the check the old watcher had no
+#    equivalent of, and its absence is the whole bug.
+until [ -n "$(runs_for "$HEAD")" ]; do
+  [ "$(date +%s)" -gt "$DEADLINE" ] && { echo "no run ever appeared for ${HEAD:0:7}"; exit 2; }
+  sleep 20
+done
+echo "run(s) registered for ${HEAD:0:7}"
+
+# 2. Every run for this commit must finish.
+while runs_for "$HEAD" | grep -qE '^(queued|in_progress|waiting|requested|pending)'; do
+  if [ "$(date +%s)" -gt "$DEADLINE" ]; then
+    echo "STALLED. Outstanding for ${HEAD:0:7}:"; runs_for "$HEAD" | grep -vE '^completed' | sed 's/^/  /'
+    exit 2
+  fi
+  sleep 45
+done
+
+echo "verdict for ${HEAD:0:7}:"
+runs_for "$HEAD" | sed 's/^/  /'
+
+# 3. Merge only if every run for THIS commit concluded success or was skipped.
+bad="$(runs_for "$HEAD" | awk '$2!="success" && $2!="skipped" {print}')"
+if [ -n "$bad" ]; then
+  echo "NOT MERGING -- not every run for ${HEAD:0:7} succeeded:"; echo "$bad" | sed 's/^/  /'
+  exit 1
+fi
+# A commit with no Build CI run at all is not green, it is untested.
+runs_for "$HEAD" | grep -q 'Build CI' || { echo "NOT MERGING -- no 'Build CI' run for ${HEAD:0:7}"; exit 1; }
+
+gh pr merge "$PR" --squash --delete-branch >/dev/null 2>&1 || { echo "merge failed"; exit 1; }
+git checkout -q main && git pull -q --ff-only origin main
+SHA="$(git rev-parse HEAD)"; echo "merged; main = ${SHA:0:7}"
+
+# 4. Post-merge, pinned the same way.
+pruns() { gh run list --branch main --limit 20 --json headSha,status,conclusion,name \
+  --jq ".[]|select(.headSha==\"$SHA\")|\"\(.status) \(.conclusion // \"-\") \(.name)\""; }
+until [ -n "$(pruns)" ]; do
+  [ "$(date +%s)" -gt "$DEADLINE" ] && { echo "no post-merge run appeared for ${SHA:0:7}"; exit 2; }
+  sleep 20
+done
+while pruns | grep -qE '^(queued|in_progress|waiting|requested|pending)'; do
+  if [ "$(date +%s)" -gt "$DEADLINE" ]; then
+    echo "post-merge STALLED for ${SHA:0:7}:"; pruns | grep -vE '^completed' | sed 's/^/  /'; exit 2
+  fi
+  sleep 45
+done
+echo "post-merge ${SHA:0:7}:"; pruns | sed 's/^/  /'
+pruns | awk '$2!="success" && $2!="skipped"' | grep -q . && { echo "POST-MERGE RED"; exit 1; }
+echo "post-merge green"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1012,10 +1012,10 @@ jobs:
           # golden needs no reference and runs in its own job. cli-check takes
           # TWO binaries, so it is invoked separately below.
           #
-          # arc-sfx-check needs the SFX modules, which are C artifacts built by
-          # `./compile-c` then `make -C Unarc linux` -- minutes of build this job
-          # does not do. Excluded on that prerequisite, not on its result; it
-          # passes locally where those artifacts exist.
+          # arc-sfx-check needs Unarc/arc-tiny.linux.sfx, which is gitignored
+          # (a build output) and takes `./compile-c` then `make -C Unarc linux`
+          # to produce. It runs in the `unarc-sfx` job instead, which already
+          # builds exactly those artifacts -- excluded HERE, gated THERE.
           case "$n" in arc-golden-check|arc-cli-check|arc-sfx-check) continue ;; esac
           echo "::group::$n"
           if bash "$h" "$R"; then pass=$((pass+1)); echo "PASS $n"
@@ -1427,6 +1427,18 @@ jobs:
 
     - name: Round-trip through unarc and a self-extracting archive
       run: Tests/sfx-roundtrip.sh rust/target/release/darc Unarc/unarc Unarc/arc.linux.sfx
+
+    # The 18th CLI harness, and the only one the `arc-harnesses` job cannot run:
+    # it needs Unarc/arc-tiny.linux.sfx, which is gitignored and built by the
+    # steps above. It lives here rather than there so that it is gated at all --
+    # it was the last arc-*-check.sh still running nowhere.
+    - name: Fetch the Haskell oracle
+      run: |
+        chmod +x rust/difftest/*.sh
+        rust/difftest/haskell-reference.sh
+        test -x Tests/arc-ghc
+    - name: arc-sfx-check against the reference
+      run: rust/difftest/arc-sfx-check.sh "$PWD/Tests/arc-ghc"
 
   # ── AddressSanitizer on x86-64 ──────────────────────────────────────────────
   # Added to diagnose a double free that only appeared on this runner. It found

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,8 +125,18 @@ before adding or changing a corpus.
     on is why. **Added by hand, never by `--record`.**
   - **`refuse`** the input must be rejected — non-zero exit under 128, no
     archive. A signal death is `crashed`, and is not a pass.
+- **Merge with `.github/watch-merge.sh <pr> <branch>`, not by eyeballing
+  `gh pr checks`.** That command reports whatever check set exists *right now*,
+  so straight after a push it answers with the previous commit's checks — or
+  none. A poll loop that waits for "nothing pending" is satisfied before the new
+  run starts and reads a stale all-green answer. That is how **#140 was merged
+  with `arc-harnesses` failing on both of its commits**. The script pins on the
+  PR's head SHA, refuses to answer until a run exists *for that SHA*, and
+  refuses to merge a commit with no `Build CI` run at all.
 - **The CLI harnesses run in CI now**, in the `arc-harnesses` job: it fetches
   the published oracle and runs every reference-dependent `arc-*-check.sh`.
+  `arc-sfx-check` runs in `unarc-sfx` instead, because it needs the gitignored
+  SFX modules that job already builds.
   Before it, `arc-golden-check.sh` was the only one CI ran — and
   `arc-cli-check.sh` had been failing **18 of 18 cases**, unnoticed, for an
   unknown length of time.

--- a/rust/difftest/arc-recovery-check.sh
+++ b/rust/difftest/arc-recovery-check.sh
@@ -74,7 +74,11 @@ head -c 300000 /dev/urandom > "$W/src/big.bin"
 printf 'a small file\n' > "$W/src/a.txt"
 touch -t 202501010000 "$W/src/big.bin" "$W/src/a.txt"
 
-size() { stat -f '%z' "$1" 2>/dev/null || stat -c '%s' "$1" 2>/dev/null; }
+# `wc -c`, not `stat`: GNU `stat -f` means --file-system and SUCCEEDS, so the
+# usual `stat -f '%z' || stat -c '%s'` pair never reaches its fallback on Linux
+# and returns filesystem info instead of a size. See arc-sfx-check.sh, where
+# that produced `File: unbound variable` on the first CI run.
+size() { wc -c < "$1" | tr -d '[:space:]'; }
 
 # create <options...> -- both binaries create with -rr and compare bytes.
 create() {

--- a/rust/difftest/arc-sfx-check.sh
+++ b/rust/difftest/arc-sfx-check.sh
@@ -67,7 +67,17 @@ W="${TMPDIR:-/tmp}/arc-sfx-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
 fail=0 checked=0
-size() { stat -f '%z' "$1" 2>/dev/null || stat -c '%s' "$1" 2>/dev/null; }
+# Portable and unambiguous. This was
+#
+#     stat -f '%z' "$1" 2>/dev/null || stat -c '%s' "$1" 2>/dev/null
+#
+# which assumes `stat -f` FAILS wherever it is not BSD. On Linux GNU `stat -f`
+# means --file-system and SUCCEEDS, so the `||` never fires and `size` returns a
+# block of filesystem info beginning `File: "..."`. The caller then does
+# arithmetic on that and bash reports `File: unbound variable` -- which is
+# exactly what CI hit the first time this harness ever ran on Linux. `wc -c`
+# has no BSD/GNU split to get wrong.
+size() { wc -c < "$1" | tr -d '[:space:]'; }
 
 mkdir -p "$W/src"
 printf 'one file\n' > "$W/src/a.txt"

--- a/rust/difftest/arc-solid-check.sh
+++ b/rust/difftest/arc-solid-check.sh
@@ -61,7 +61,11 @@ W="${TMPDIR:-/tmp}/arc-solid-check.$$"; mkdir -p "$W"
 trap 'rm -rf "$W"' EXIT
 
 fail=0 checked=0
-size() { stat -f '%z' "$1" 2>/dev/null || stat -c '%s' "$1" 2>/dev/null; }
+# `wc -c`, not `stat`: GNU `stat -f` means --file-system and SUCCEEDS, so the
+# usual `stat -f '%z' || stat -c '%s'` pair never reaches its fallback on Linux
+# and returns filesystem info instead of a size. See arc-sfx-check.sh, where
+# that produced `File: unbound variable` on the first CI run.
+size() { wc -c < "$1" | tr -d '[:space:]'; }
 # DATA blocks, which is what the grouping decides. NOT arcdump: that lists the
 # footer's block table, which holds only the SERVICE blocks (header, directory,
 # footer, recovery) and never the data ones -- so it reports the same three or


### PR DESCRIPTION
Two small things, both closing gaps this session opened.

## `arc-sfx-check` was the only `arc-*-check.sh` still running nowhere

The `arc-harnesses` job can't run it: it needs `Unarc/arc-tiny.linux.sfx`, which is **gitignored** — a build output — and takes `./compile-c` then `make -C Unarc linux` to produce.

The `unarc-sfx` job already builds exactly those artifacts and verifies them, so the harness runs **there**, with the oracle fetched the same way `arc-harnesses` fetches it. Excluded in one job, gated in the other, and the comment in each says which.

Locally: `arc sfx/volumes: 22 runs, 0 differing`.

## The merge watcher is now `.github/watch-merge.sh`

It exists because `gh pr checks` reports whatever check set exists **right now**. Straight after a push it answers with the previous commit's checks — or with none — and a poll loop waiting for "nothing pending" is satisfied *before the new run starts*, reading a stale all-green answer.

That is how **#140 was merged with `arc-harnesses` failing on both of its commits.** The output parsing was correct; the timing was not.

The script never asks whether anything is failing. It:

1. reads the PR's head SHA
2. **refuses to proceed until a run exists for that SHA**
3. waits for every such run to finish
4. merges only if each concluded `success` or `skipped`
5. treats a commit with no `Build CI` run as untested, not green
6. watches post-merge the same way, pinned to the new `main` SHA

**Self-tested against the failure it missed:** for #140's head `ce94f53`, the run for that SHA reads `completed failure Build CI` — not success, so it refuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)