### PR TITLE
arc: say so when -ld cannot be met, instead of quietly missing it

### DIFF
--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -1233,6 +1233,33 @@ fn add(
     // are actually reached are checked below, once the split is known.
     let type_names: Vec<String> = decoded.iter().map(|(t, _)| t.clone()).collect();
     let chains: Vec<String> = decoded.iter().map(|(_, c)| c.join("+")).collect();
+
+    // `-ld` is a promise about the archive, and some of it cannot be kept:
+    // LZMA needs its dictionary PLUS a fixed ~2 MB, so `-ld1m` is unreachable
+    // whatever the dictionary. Say so once, here, where the chains are known and
+    // the code runs a single time -- the per-block fitting below would repeat it
+    // for every block, and the limiter itself returns `()` and cannot speak.
+    //
+    // A warning, not an error: the archive is valid and is the closest thing to
+    // the request that exists. What was wrong was producing it silently.
+    if dlimit != u64::MAX {
+        let mut said: Vec<String> = Vec::new();
+        for chain in &chains {
+            for (m, needs) in darc_arc::memlimit::unmet_decompression_limit(chain, dlimit) {
+                let line = format!(
+                    "WARNING: -ld cannot be met by {m}: it needs {} to decompress, \
+                     against the {} asked for. Using the smallest this method allows.",
+                    darc_arc::canonize::show_mem(needs.min(u64::from(u32::MAX)) as u32),
+                    darc_arc::canonize::show_mem(dlimit.min(u64::from(u32::MAX)) as u32),
+                );
+                if !said.contains(&line) {
+                    eprintln!("{line}");
+                    said.push(line);
+                }
+            }
+        }
+    }
+
     // `parseSolidOption` (Cmdline.hs:757).
     //
     // `-s` has NO command form. The `s…` command is `ch -sfx…`, not `ch -s…`

--- a/rust/darc-arc/src/memlimit.rs
+++ b/rust/darc-arc/src/memlimit.rs
@@ -236,6 +236,37 @@ pub fn fit_to_data(chain: &str, total_bytes: u64) -> Option<String> {
 mod tests {
     use super::*;
 
+    /// `-ld` below LZMA's fixed overhead is unsatisfiable at ANY dictionary
+    /// size, and used to be met with silence.
+    #[test]
+    fn an_unsatisfiable_decompression_limit_is_reported() {
+        // 2 MB of it is fixed decoder overhead, so even a 4 KB dictionary
+        // cannot get under 1 MB. Independent of the data size, which is why
+        // this is worth saying at chain-fitting time.
+        let unmet = unmet_decompression_limit("lzma:d64m", MB);
+        assert_eq!(unmet.len(), 1, "lzma cannot meet -ld1m: {unmet:?}");
+        assert!(unmet[0].0.starts_with("lzma"), "names the method: {:?}", unmet[0].0);
+        assert!(unmet[0].1 > MB, "and what it still needs: {}", unmet[0].1);
+
+        // Above the overhead it IS satisfiable, and must stay quiet.
+        assert!(unmet_decompression_limit("lzma:d64m", 3 * MB).is_empty());
+        assert!(unmet_decompression_limit("lzma:d64m", u64::MAX).is_empty());
+
+        // Methods that need nothing to unpack never complain.
+        assert!(unmet_decompression_limit("storing", 1).is_empty());
+
+        // Only the unsatisfiable LINK is named, not the whole chain.
+        let mixed = unmet_decompression_limit("rep+lzma:d64m", MB);
+        assert!(
+            mixed.iter().all(|(m, _)| m.starts_with("lzma")),
+            "rep can be shrunk to fit; only lzma cannot: {mixed:?}",
+        );
+
+        // A chain that does not parse has a real error coming from elsewhere;
+        // a second complaint here would be noise.
+        assert!(unmet_decompression_limit("nosuchmethod", MB).is_empty());
+    }
+
     /// A decompression limit at or below LZMA's 2 MB overhead used to be
     /// dropped on the floor — the C's `if (mem > 2mb)` skipped the assignment
     /// and left whatever dictionary was already there, so `-ld1m` on a 64 MB
@@ -609,6 +640,38 @@ pub fn limit_decompression_mem(chain: &mut [Method], mem: u64) {
             set_decompression_mem(m, mem);
         }
     }
+}
+
+/// Which links of `chain` STILL need more than `mem` once
+/// [`limit_decompression_mem`] has shrunk them as far as the method allows.
+///
+/// `-ld` is a promise about the archive: "this must open in `mem`". Some of it
+/// cannot be kept. LZMA needs its dictionary *plus a fixed ~2 MB*, so no
+/// dictionary at all satisfies `-ld1m` — the limiter floors the dictionary at
+/// 4 KB and the block still wants about 2 MB. Until this, that gap was silent:
+/// the user asked for 1 MB, got an archive needing 2, and was told nothing.
+///
+/// Reported rather than refused. The archive is valid and is the closest thing
+/// to the request that exists, so failing the run would help nobody; what was
+/// wrong was saying nothing. Returns `(rendered method, bytes it still needs)`
+/// per unsatisfiable link, empty when the limit is met — which is the common
+/// case, so callers pay a parse and nothing else.
+///
+/// An unparseable chain yields no complaints: it has a real error coming from
+/// whatever tries to use it, and a second diagnosis here would only be noise.
+#[must_use]
+pub fn unmet_decompression_limit(chain: &str, mem: u64) -> Vec<(String, u64)> {
+    let names: Vec<String> = chain.split('+').map(str::to_string).collect();
+    let mut methods = match Method::parse_chain(&names) {
+        Some(m) => m,
+        None => return Vec::new(),
+    };
+    limit_decompression_mem(&mut methods, mem);
+    methods
+        .iter()
+        .map(|m| (crate::canonize::show(m), get_decompression_mem(m)))
+        .filter(|(_, needs)| *needs > mem)
+        .collect()
 }
 
 /// The `-ld` default for the ADD command: a flat 1 GB (`Cmdline.hs:300`).


### PR DESCRIPTION
`-ld` is a promise about the archive — *"this must open in N"* — and some of it cannot be kept. LZMA needs its dictionary **plus a fixed ~2 MB**, so no dictionary at all satisfies `-ld1m`: the limiter floors it at 4 KB and the block still wants ~2 MB.

Until now that gap was silent. The user asked for 1 MB, got an archive needing 2, and was told nothing — the last of the "silently does nothing" cases from the repo-wide sweep.

```
$ darc a -mlzma:d64m -ld1m t.arc a.txt
WARNING: -ld cannot be met by lzma:4kb: it needs 2052kb to decompress,
against the 1mb asked for. Using the smallest this method allows.
```

| | |
|---|---|
| `-ld1m` | warns |
| `-ld3m` | silent |
| `-ld1gb` | silent |
| no `-ld` | silent |

The 2 MB is fixed decoder overhead, independent of data size — so this is genuinely unreachable, not a small-input artefact.

## A warning, not an error

The archive is valid and is the closest thing to the request that exists. Failing the run would help nobody; what was wrong was producing it without a word.

## A query, not an error channel

`set_decompression_mem` returns `()`, and threading a result through all seventeen of its arms would be a large change for a small answer — and unnecessary, because `get_decompression_mem` already exists.

`unmet_decompression_limit` limits a *copy* of the chain and then **measures** it, reporting the links still over the line. Checking the result rather than the verdict, the same shape as the extraction cases in #138.

Called once per run, where the chains are known and before the block loop — the per-block fitting would repeat it for every block, and the two existing callers of `limit_decompression_mem` are internal computations with nowhere to speak. Identical lines print once even across several file-type chains.

## Verification

- 696 tests (one new, covering unsatisfiable/satisfiable/no-op/multi-link/unparseable)
- `arc-golden-check` **118/118**
- clippy gate clean
- the warning goes to stderr and isn't a data line, so `arc-cli-check`'s whitelist ignores it

🤖 Generated with [Claude Code](https://claude.com/claude-code)