### PR TITLE
darc-arc: lift the extraction loop into the library

### DIFF
--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -14,32 +14,6 @@ use darc_arc::{archive, crc, decompress, directory::Entry, extract::Layout, opti
 use rayon::prelude::*;
 use std::io::Write;
 
-fn show3(n: u64) -> String {
-    let s = n.to_string();
-    let mut out = String::with_capacity(s.len() + s.len() / 3);
-    let b = s.as_bytes();
-    for (i, c) in b.iter().enumerate() {
-        if i > 0 && (b.len() - i) % 3 == 0 {
-            out.push('.');
-        }
-        out.push(*c as char);
-    }
-    out
-}
-
-/// `ratio3` (`UIBase.hs:159`) — integer arithmetic, which truncates where a
-/// rounding formatter would not.
-fn ratio3(count: u64, total: u64) -> String {
-    if total == 0 {
-        return "0.0".to_string();
-    }
-    let scaled = (count.saturating_mul(1000) / total).to_string();
-    match scaled.len() {
-        1 => format!("0.{scaled}"),
-        n => format!("{}.{}", &scaled[..n - 1], &scaled[n - 1..]),
-    }
-}
-
 /// The command list, and enough of the option surface to be usable.
 ///
 /// Printed for `--help`/`-h`/`-?`/`help` and, minus the options, when there are
@@ -692,7 +666,7 @@ fn main() {
                 }
                 false => std::collections::HashSet::new(),
             };
-            run_blocks(&info, &data, &layout, extracting, &pw, &selected, &skip, parsed.flag("keepbroken"))
+            darc_arc::extract::run_blocks(&info, &data, &layout, extracting, &pw, &selected, &skip, parsed.flag("keepbroken"))
         }
         // One function: every one of these is `runArchiveAdd` with a different
         // archive filter and a different source of files (Arc.hs:122-131).
@@ -2773,7 +2747,7 @@ fn add(
             (Ok(info), Ok(data)) => {
                 let all: Vec<Entry> = info.entries.clone();
                 let empty = std::collections::HashSet::new();
-                run_blocks(&info, &data, &Layout::default(), false, pw, &all, &empty, false)
+                darc_arc::extract::run_blocks(&info, &data, &Layout::default(), false, pw, &all, &empty, false)
             }
             (Err(e), _) | (_, Err(e)) => {
                 eprintln!("ERROR: {archive_name}: {e}");
@@ -2945,10 +2919,10 @@ fn list(command: &str, info: &archive::ArchiveInfo, entries: &[Entry]) -> i32 {
             println!(
                 "{} {:>15} {:>15} {:>15} {:>7} {}",
                 if b.is_encrypted() { "*" } else { " " },
-                show3(b.pos),
-                show3(b.orig_size),
-                show3(b.comp_size),
-                show3(b.files.unwrap_or(0) as u64),
+                darc_arc::extract::show3(b.pos),
+                darc_arc::extract::show3(b.orig_size),
+                darc_arc::extract::show3(b.comp_size),
+                darc_arc::extract::show3(b.files.unwrap_or(0) as u64),
                 b.compressor.join("+")
             );
         }
@@ -2960,9 +2934,9 @@ fn list(command: &str, info: &archive::ArchiveInfo, entries: &[Entry]) -> i32 {
         let packed: u64 = info.data_blocks.iter().map(|b| b.comp_size).sum();
         println!(
             "{} files, {} bytes, {} compressed",
-            show3(entries.len() as u64),
-            show3(total),
-            show3(packed)
+            darc_arc::extract::show3(entries.len() as u64),
+            darc_arc::extract::show3(total),
+            darc_arc::extract::show3(packed)
         );
         println!("All OK\n");
         return 0;
@@ -3006,7 +2980,7 @@ fn list(command: &str, info: &archive::ArchiveInfo, entries: &[Entry]) -> i32 {
                 e.stored_name
             );
         } else {
-            let size = if e.is_dir { "-dir-".to_string() } else { show3(e.size) };
+            let size = if e.is_dir { "-dir-".to_string() } else { darc_arc::extract::show3(e.size) };
             println!("{} {:>11} {}", format_time(e.time), size, e.stored_name);
         }
         total += e.size;
@@ -3020,9 +2994,9 @@ fn list(command: &str, info: &archive::ArchiveInfo, entries: &[Entry]) -> i32 {
     }
     println!(
         "{} files, {} bytes, {} compressed",
-        show3(entries.len() as u64),
-        show3(total),
-        show3(compressed)
+        darc_arc::extract::show3(entries.len() as u64),
+        darc_arc::extract::show3(total),
+        darc_arc::extract::show3(compressed)
     );
     println!("All OK\n");
     0
@@ -3110,7 +3084,7 @@ fn pretest_archive(mode: i32, path: &std::path::Path, pw: &darc_arc::passwords::
             let all: Vec<Entry> = info.entries.clone();
             let empty = std::collections::HashSet::new();
             let rc =
-                run_blocks(&info, bytes, &Layout::default(), false, pw, &all, &empty, false);
+                darc_arc::extract::run_blocks(&info, bytes, &Layout::default(), false, pw, &all, &empty, false);
             if rc != 0 {
                 eprintln!("ERROR: {}: failed its pretest", path.display());
                 return false;
@@ -3348,213 +3322,6 @@ fn resolve_overwrites(
     skip
 }
 
-fn run_blocks(
-    info: &archive::ArchiveInfo,
-    data: &[u8],
-    layout: &Layout,
-    extracting: bool,
-    pw: &darc_arc::passwords::Passwords,
-    entries: &[Entry],
-    skip: &std::collections::HashSet<String>,
-    keep_broken: bool,
-) -> i32 {
-    // The safety check runs on the archive's contribution alone: the
-    // destination is the user's own and may be absolute.
-    let relative = Layout { disk_basedir: String::new(), ..layout.clone() };
-
-    if extracting && layout.creates_directories() {
-        for e in entries.iter().filter(|e| e.is_dir) {
-            if !darc_arc::extract::is_safe(&relative.disk_name(e)) {
-                eprintln!("ERROR: refusing unsafe path {:?}", e.stored_name);
-                return 2;
-            }
-            match std::fs::create_dir_all(layout.disk_name(e)) {
-                Ok(()) => {}
-                Err(err) => {
-                    eprintln!("ERROR: {}: {err}", e.stored_name);
-                    return 2;
-                }
-            }
-        }
-    }
-
-    let total_bytes: u64 = entries.iter().map(|e| e.size).sum();
-    if !extracting {
-        println!(
-            "Testing {} files, {} bytes.",
-            show3(entries.len() as u64),
-            show3(total_bytes)
-        );
-    }
-
-    let mut per_block: Vec<Vec<&Entry>> = vec![Vec::new(); info.data_blocks.len()];
-    for e in entries {
-        match per_block.get_mut(e.block) {
-            Some(v) => v.push(e),
-            None => {}
-        }
-    }
-
-    // Counted where the write happens, not from `entries`, and atomics rather
-    // than a per-block return so the early exits above stay as they are.
-    use std::sync::atomic;
-    let written_files = atomic::AtomicU64::new(0);
-    let written_bytes = atomic::AtomicU64::new(0);
-
-    let results: Vec<Vec<String>> = per_block
-        .par_iter()
-        .enumerate()
-        .map(|(bi, entries)| {
-            let mut bad = Vec::new();
-            let b = match info.data_blocks.get(bi) {
-                Some(b) => b,
-                None => return bad,
-            };
-            if entries.iter().all(|e| e.is_dir) {
-                return bad;
-            }
-            let start = b.pos as usize;
-            let end = start.saturating_add(b.comp_size as usize);
-            let packed = match data.get(start..end) {
-                Some(s) => s,
-                None => {
-                    bad.push(format!("{} is truncated", b.name()));
-                    return bad;
-                }
-            };
-            // The block's chain may name an encryption method, which carries a
-            // salt but no key until a password has been verified against it.
-            let compressor = match archive::keyed(&b.compressor, b, pw) {
-                Ok(c) => c,
-                Err(e) => {
-                    bad.push(format!("{e}"));
-                    return bad;
-                }
-            };
-            let unpacked =
-                match decompress::decompress_chain(&compressor, packed, b.orig_size as usize) {
-                    Ok(u) => u,
-                    Err(e) => {
-                        bad.push(format!("{}: {e}", b.name()));
-                        return bad;
-                    }
-                };
-            for e in entries {
-                if e.is_dir {
-                    continue;
-                }
-                let from = e.pos_in_block as usize;
-                let to = from.saturating_add(e.size as usize);
-                let bytes = match unpacked.get(from..to) {
-                    Some(x) => x,
-                    None => {
-                        bad.push(format!("{}: runs past the end of its block", e.stored_name));
-                        continue;
-                    }
-                };
-                // `-kb`/`--keepbroken` (ArcExtract.hs:99): a file that failed
-                // its CRC is normally not left on disk. With -kb it is kept,
-                // and the failure is still reported -- keeping the bytes is not
-                // the same as calling them good.
-                let crc_ok = crc::calc(bytes) == e.crc;
-                if !crc_ok {
-                    bad.push(format!("{}: CRC failed", e.stored_name));
-                    if !keep_broken {
-                        continue;
-                    }
-                }
-                if !extracting {
-                    continue;
-                }
-                if !darc_arc::extract::is_safe(&relative.disk_name(e)) {
-                    bad.push(format!("refusing unsafe path {:?}", e.stored_name));
-                    continue;
-                }
-                // `-o-`, or an existing file the user declined to overwrite.
-                // Decided serially before this loop; see resolve_overwrites.
-                if skip.contains(&e.stored_name) {
-                    continue;
-                }
-                let name = layout.disk_name(e);
-                match std::path::Path::new(&name).parent() {
-                    Some(dir) => match std::fs::create_dir_all(dir) {
-                        Ok(()) => {}
-                        Err(err) => {
-                            bad.push(format!("{}: {err}", dir.display()));
-                            continue;
-                        }
-                    },
-                    None => {}
-                }
-                match std::fs::File::create(&name).and_then(|mut f| f.write_all(bytes)) {
-                    // Counted HERE, at the only place a file is actually
-                    // written, rather than from the selected-entry list. See
-                    // the summary below for why that distinction matters.
-                    Ok(()) => {
-                        written_files.fetch_add(1, atomic::Ordering::Relaxed);
-                        written_bytes.fetch_add(bytes.len() as u64, atomic::Ordering::Relaxed);
-                    }
-                    Err(err) => bad.push(format!("{name}: {err}")),
-                }
-            }
-            bad
-        })
-        .collect();
-
-    let mut failures = 0usize;
-    for block in &results {
-        for msg in block {
-            eprintln!("ERROR: {msg}");
-            failures += 1;
-        }
-    }
-
-    if !extracting {
-        // Blocks whose unpacked size is zero are never decompressed, so they
-        // contribute nothing to the packed total.
-        let packed: u64 =
-            info.data_blocks.iter().filter(|b| b.orig_size > 0).map(|b| b.comp_size).sum();
-        println!(
-            "Tested {} files, {} => {} bytes. Ratio {}%",
-            show3(entries.len() as u64),
-            show3(packed),
-            show3(total_bytes),
-            ratio3(packed, total_bytes)
-        );
-    } else {
-        // What was WRITTEN, not what was selected. `entries.len()` counted every
-        // entry the filters picked -- including directories, and including
-        // files that were then refused for an unsafe path, failed their CRC, or
-        // were skipped at an overwrite prompt. So a run that refused its only
-        // entry still printed "Extracted 1 files", directly under the ERROR
-        // saying it had not been.
-        //
-        // **A DELIBERATE DIVERGENCE, and #140 recorded the wrong reason for it.**
-        // That commit claimed the reference prints no summary here, so there was
-        // nothing to match; it does print one, and I had missed it by tailing
-        // output whose progress is drawn with carriage returns. It reads
-        //
-        //     Extracted 226 files, 33.111 => 438.744 bytes. Ratio 7.5%
-        //
-        // on a tree of 218 files and 8 directories -- the same entries-not-files
-        // count this used to have. So the port is right and the reference is
-        // wrong, which is the trade CLAUDE.md asks for, but it IS a divergence
-        // and is marked as one here rather than left looking like a free fix.
-        // `arc-cli-check.sh` holds both builds against the disk and reports the
-        // reference's miscount without failing on it.
-        println!(
-            "Extracted {} files, {} bytes.",
-            show3(written_files.load(atomic::Ordering::Relaxed)),
-            show3(written_bytes.load(atomic::Ordering::Relaxed))
-        );
-    }
-    if failures == 0 {
-        println!("All OK");
-        0
-    } else {
-        2
-    }
-}
 
 /// mtimes are formatted in LOCAL time, as `System.Time`'s `toCalendarTime`
 /// does. Reproduced rather than corrected: matching the reference is the bar.
@@ -4050,7 +3817,7 @@ fn recover(
     let ss = scan.control.sector_size;
     println!(
         "{} recovery sectors ({}) present",
-        show3(scan.control.rec_sectors),
+        darc_arc::extract::show3(scan.control.rec_sectors),
         show_memory(scan.control.rec_sectors * ss)
     );
     if scan.bad.is_empty() {
@@ -4104,8 +3871,8 @@ fn recover(
                 eprintln!(
                     "WARNING: {original_name} has size {} so it can't be used to recover \
                      {archive_name} having size {}",
-                    show3(n),
-                    show3(data.len() as u64)
+                    darc_arc::extract::show3(n),
+                    darc_arc::extract::show3(data.len() as u64)
                 );
                 None
             }
@@ -4129,20 +3896,20 @@ fn recover(
         save_bad_ranges(save_ranges, &lost, &scan.control);
         eprintln!(
             "ERROR: {} unrecoverable errors ({}) found, can't restore anything!",
-            show3(lost.len() as u64),
+            darc_arc::extract::show3(lost.len() as u64),
             show_memory(lost.len() as u64 * ss)
         );
         return 2;
     }
     print!(
         "{} recoverable errors ({}) ",
-        show3(recoverable.len() as u64),
+        darc_arc::extract::show3(recoverable.len() as u64),
         show_memory(recoverable.len() as u64 * ss)
     );
     if !lost.is_empty() {
         print!(
             "and {} unrecoverable errors ({}) ",
-            show3(lost.len() as u64),
+            darc_arc::extract::show3(lost.len() as u64),
             show_memory(lost.len() as u64 * ss)
         );
     }
@@ -4178,7 +3945,7 @@ fn recover(
     if !still_bad.is_empty() {
         eprintln!(
             "WARNING: {} errors ({}) remain unrecovered",
-            show3(still_bad.len() as u64),
+            darc_arc::extract::show3(still_bad.len() as u64),
             show_memory(still_bad.len() as u64 * ss)
         );
     }

--- a/rust/darc-arc/src/extract.rs
+++ b/rust/darc-arc/src/extract.rs
@@ -22,6 +22,8 @@
 //! and writing them in any other order would mean holding more of it.
 
 use crate::directory::Entry;
+use rayon::prelude::*;
+use std::io::Write;
 
 /// How stored names become disk names — the `-ep` and basedir options.
 #[derive(Clone, Debug)]
@@ -265,5 +267,251 @@ mod tests {
         assert!(is_safe("sub/dir/a.txt"));
         assert!(is_safe("..hidden"), "a leading .. in a NAME is not a traversal");
         assert!(is_safe("a..b/c"));
+    }
+}
+
+// ── Shared with the `unarc` front-end ───────────────────────────────────────
+//
+// `run_blocks` and the two formatters below used to live in `bin/darc.rs`.
+// They are here because `unarc` and every SFX module need exactly this work --
+// walk the data blocks, decrypt, decompress, verify each file's CRC, and either
+// report or write it -- and a second copy is how `Unarc/ArcStructure.h` came to
+// read the per-file time field as 4 bytes while the writer wrote 8, so that
+// directories extracted as empty files and every CRC failed.
+//
+// One implementation, two callers. That is the whole reason the C++ reader is
+// being retired rather than ported alongside this one.
+
+/// `showMem3`-style digit grouping: `438744` -> `438.744`.
+pub fn show3(n: u64) -> String {
+    let s = n.to_string();
+    let mut out = String::with_capacity(s.len() + s.len() / 3);
+    let b = s.as_bytes();
+    for (i, c) in b.iter().enumerate() {
+        if i > 0 && (b.len() - i) % 3 == 0 {
+            out.push('.');
+        }
+        out.push(*c as char);
+    }
+    out
+}
+
+/// `ratio3` (`UIBase.hs:159`) — integer arithmetic, which truncates where a
+/// rounding formatter would not.
+pub fn ratio3(count: u64, total: u64) -> String {
+    if total == 0 {
+        return "0.0".to_string();
+    }
+    let scaled = (count.saturating_mul(1000) / total).to_string();
+    match scaled.len() {
+        1 => format!("0.{scaled}"),
+        n => format!("{}.{}", &scaled[..n - 1], &scaled[n - 1..]),
+    }
+}
+pub fn run_blocks(
+    info: &crate::archive::ArchiveInfo,
+    data: &[u8],
+    layout: &Layout,
+    extracting: bool,
+    pw: &crate::passwords::Passwords,
+    entries: &[Entry],
+    skip: &std::collections::HashSet<String>,
+    keep_broken: bool,
+) -> i32 {
+    // The safety check runs on the archive's contribution alone: the
+    // destination is the user's own and may be absolute.
+    let relative = Layout { disk_basedir: String::new(), ..layout.clone() };
+
+    if extracting && layout.creates_directories() {
+        for e in entries.iter().filter(|e| e.is_dir) {
+            if !crate::extract::is_safe(&relative.disk_name(e)) {
+                eprintln!("ERROR: refusing unsafe path {:?}", e.stored_name);
+                return 2;
+            }
+            match std::fs::create_dir_all(layout.disk_name(e)) {
+                Ok(()) => {}
+                Err(err) => {
+                    eprintln!("ERROR: {}: {err}", e.stored_name);
+                    return 2;
+                }
+            }
+        }
+    }
+
+    let total_bytes: u64 = entries.iter().map(|e| e.size).sum();
+    if !extracting {
+        println!(
+            "Testing {} files, {} bytes.",
+            show3(entries.len() as u64),
+            show3(total_bytes)
+        );
+    }
+
+    let mut per_block: Vec<Vec<&Entry>> = vec![Vec::new(); info.data_blocks.len()];
+    for e in entries {
+        match per_block.get_mut(e.block) {
+            Some(v) => v.push(e),
+            None => {}
+        }
+    }
+
+    // Counted where the write happens, not from `entries`, and atomics rather
+    // than a per-block return so the early exits above stay as they are.
+    use std::sync::atomic;
+    let written_files = atomic::AtomicU64::new(0);
+    let written_bytes = atomic::AtomicU64::new(0);
+
+    let results: Vec<Vec<String>> = per_block
+        .par_iter()
+        .enumerate()
+        .map(|(bi, entries)| {
+            let mut bad = Vec::new();
+            let b = match info.data_blocks.get(bi) {
+                Some(b) => b,
+                None => return bad,
+            };
+            if entries.iter().all(|e| e.is_dir) {
+                return bad;
+            }
+            let start = b.pos as usize;
+            let end = start.saturating_add(b.comp_size as usize);
+            let packed = match data.get(start..end) {
+                Some(s) => s,
+                None => {
+                    bad.push(format!("{} is truncated", b.name()));
+                    return bad;
+                }
+            };
+            // The block's chain may name an encryption method, which carries a
+            // salt but no key until a password has been verified against it.
+            let compressor = match crate::archive::keyed(&b.compressor, b, pw) {
+                Ok(c) => c,
+                Err(e) => {
+                    bad.push(format!("{e}"));
+                    return bad;
+                }
+            };
+            let unpacked =
+                match crate::decompress::decompress_chain(&compressor, packed, b.orig_size as usize) {
+                    Ok(u) => u,
+                    Err(e) => {
+                        bad.push(format!("{}: {e}", b.name()));
+                        return bad;
+                    }
+                };
+            for e in entries {
+                if e.is_dir {
+                    continue;
+                }
+                let from = e.pos_in_block as usize;
+                let to = from.saturating_add(e.size as usize);
+                let bytes = match unpacked.get(from..to) {
+                    Some(x) => x,
+                    None => {
+                        bad.push(format!("{}: runs past the end of its block", e.stored_name));
+                        continue;
+                    }
+                };
+                // `-kb`/`--keepbroken` (ArcExtract.hs:99): a file that failed
+                // its CRC is normally not left on disk. With -kb it is kept,
+                // and the failure is still reported -- keeping the bytes is not
+                // the same as calling them good.
+                let crc_ok = crate::crc::calc(bytes) == e.crc;
+                if !crc_ok {
+                    bad.push(format!("{}: CRC failed", e.stored_name));
+                    if !keep_broken {
+                        continue;
+                    }
+                }
+                if !extracting {
+                    continue;
+                }
+                if !crate::extract::is_safe(&relative.disk_name(e)) {
+                    bad.push(format!("refusing unsafe path {:?}", e.stored_name));
+                    continue;
+                }
+                // `-o-`, or an existing file the user declined to overwrite.
+                // Decided serially before this loop; see resolve_overwrites.
+                if skip.contains(&e.stored_name) {
+                    continue;
+                }
+                let name = layout.disk_name(e);
+                match std::path::Path::new(&name).parent() {
+                    Some(dir) => match std::fs::create_dir_all(dir) {
+                        Ok(()) => {}
+                        Err(err) => {
+                            bad.push(format!("{}: {err}", dir.display()));
+                            continue;
+                        }
+                    },
+                    None => {}
+                }
+                match std::fs::File::create(&name).and_then(|mut f| f.write_all(bytes)) {
+                    // Counted HERE, at the only place a file is actually
+                    // written, rather than from the selected-entry list. See
+                    // the summary below for why that distinction matters.
+                    Ok(()) => {
+                        written_files.fetch_add(1, atomic::Ordering::Relaxed);
+                        written_bytes.fetch_add(bytes.len() as u64, atomic::Ordering::Relaxed);
+                    }
+                    Err(err) => bad.push(format!("{name}: {err}")),
+                }
+            }
+            bad
+        })
+        .collect();
+
+    let mut failures = 0usize;
+    for block in &results {
+        for msg in block {
+            eprintln!("ERROR: {msg}");
+            failures += 1;
+        }
+    }
+
+    if !extracting {
+        // Blocks whose unpacked size is zero are never decompressed, so they
+        // contribute nothing to the packed total.
+        let packed: u64 =
+            info.data_blocks.iter().filter(|b| b.orig_size > 0).map(|b| b.comp_size).sum();
+        println!(
+            "Tested {} files, {} => {} bytes. Ratio {}%",
+            show3(entries.len() as u64),
+            show3(packed),
+            show3(total_bytes),
+            ratio3(packed, total_bytes)
+        );
+    } else {
+        // What was WRITTEN, not what was selected. `entries.len()` counted every
+        // entry the filters picked -- including directories, and including
+        // files that were then refused for an unsafe path, failed their CRC, or
+        // were skipped at an overwrite prompt. So a run that refused its only
+        // entry still printed "Extracted 1 files", directly under the ERROR
+        // saying it had not been.
+        //
+        // **A DELIBERATE DIVERGENCE, and #140 recorded the wrong reason for it.**
+        // That commit claimed the reference prints no summary here, so there was
+        // nothing to match; it does print one, and I had missed it by tailing
+        // output whose progress is drawn with carriage returns. It reads
+        //
+        //     Extracted 226 files, 33.111 => 438.744 bytes. Ratio 7.5%
+        //
+        // on a tree of 218 files and 8 directories -- the same entries-not-files
+        // count this used to have. So the port is right and the reference is
+        // wrong, which is the trade CLAUDE.md asks for, but it IS a divergence
+        // and is marked as one here rather than left looking like a free fix.
+        // `arc-cli-check.sh` holds both builds against the disk and reports the
+        // reference's miscount without failing on it.
+        println!(
+            "Extracted {} files, {} bytes.",
+            show3(written_files.load(atomic::Ordering::Relaxed)),
+            show3(written_bytes.load(atomic::Ordering::Relaxed))
+        );
+    }
+    if failures == 0 {
+        println!("All OK");
+        0
+    } else {
+        2
     }
 }


### PR DESCRIPTION
Groundwork for porting `Unarc/`, and useful on its own.

`run_blocks` walks the data blocks, decrypts, decompresses, verifies each file's CRC and either reports or writes it. It lived in `bin/darc.rs`, so it was reachable only by the `darc` binary — and `unarc` and every SFX module need exactly that work.

It moves to `extract.rs`, beside `Layout` and `is_safe`, which it already used. `show3`/`ratio3` come with it, being its output format.

## One implementation, two callers

That's the point, not a convenience. A second copy of this logic is precisely how `Unarc/ArcStructure.h` came to read the per-file time field as **4 bytes** while the writer wrote **8** — so directories extracted as empty files and every CRC failed, while the listing looked perfect.

Per the decision on this port, the C++ reader is being **retired rather than ported alongside** this one, so nothing will diverge from it again.

## Pure refactor — the gates say so

| | |
|---|---|
| tests | 696 |
| `arc-golden-check` | 118 cases, 0 differing |
| `arc-extract-check` | 24 extractions, 0 differing |
| `arc-cli-check` | 24 cases, 0 differing |
| clippy gate | clean |

## Two notes for repeating this kind of move

Deleting the function by line range also ate the closing brace of `ratio3` — the compiler caught it. And the `sed -e 's/\barchive::/…'` meant to rewrite module paths **did nothing at all**, because BSD `sed` has no `\b`. Both surfaced on build, but the second is the kind that passes silently when the pattern happens not to matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)