### PR TITLE
darc-unarc: the Rust extractor, and the gate for replacing the C++ one

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1459,6 +1459,12 @@ jobs:
     - name: arc-sfx-check against the reference
       run: rust/difftest/arc-sfx-check.sh "$PWD/Tests/arc-ghc"
 
+    # The migration gate for replacing Unarc/'s C++ with the Rust `unarc`. It
+    # needs the C binary the steps above build, so it lives here for the same
+    # reason arc-sfx-check does.
+    - name: The Rust unarc against the C one it replaces
+      run: rust/difftest/unarc-check.sh "$PWD/Unarc/unarc"
+
   # ── AddressSanitizer on x86-64 ──────────────────────────────────────────────
   # Added to diagnose a double free that only appeared on this runner. It found
   # that one and an out-of-bounds read in Dict/phase1 on its first two runs, and

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -294,6 +294,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "darc-unarc"
+version = "0.1.0"
+dependencies = [
+ "darc-arc",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@
 # proven equivalent against the C one (see difftest/ and Tests/interop-test.sh).
 [workspace]
 resolver = "2"
-members = ["darc-arc", "darc-codecs", "darc-crypto", "darc-lzma", "darc-sevenz"]
+members = ["darc-arc", "darc-codecs", "darc-crypto", "darc-lzma", "darc-sevenz", "darc-unarc"]
 
 [workspace.package]
 edition = "2021"

--- a/rust/darc-unarc/Cargo.toml
+++ b/rust/darc-unarc/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "darc-unarc"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+# The standalone extractor, and the payload of every SFX module.
+#
+# It replaces `Unarc/unarc.cpp` + `ArcStructure.h` + `CUI.h` -- about 1,160
+# lines of C++ whose only job was to be a SECOND implementation of the archive
+# reader. That second implementation is why `ArcStructure.h` read the per-file
+# time field as 4 bytes while the writer wrote 8: directories extracted as
+# empty files and every CRC failed, while the listing looked perfect throughout.
+#
+# So this deliberately owns no format knowledge. It parses argv, decides which
+# archive to open, and calls `darc-arc`. Everything about the archive is the
+# same code the archiver uses and the same code the harnesses gate.
+
+[dependencies]
+darc-arc = { path = "../darc-arc", default-features = false }
+
+[[bin]]
+name = "unarc"
+path = "src/main.rs"
+
+# The SFX module is the same binary with the archive appended, so it is built
+# from the same source under a feature rather than duplicated.
+[features]
+default = []
+sfx = []

--- a/rust/darc-unarc/src/main.rs
+++ b/rust/darc-unarc/src/main.rs
@@ -1,0 +1,169 @@
+//! `unarc` — the standalone extractor, and the payload of every SFX module.
+//!
+//! Replaces `Unarc/unarc.cpp`, `ArcStructure.h` and `CUI.h`.
+//!
+//! # It owns no format knowledge, on purpose
+//!
+//! The C++ it replaces was a second, independent implementation of the archive
+//! reader. That is exactly how `ArcStructure.h` came to read the per-file time
+//! field as **4 bytes** while `ByteStream` writes `CTime` as a fixed 64-bit
+//! value: everything stored after it — the directory flags and the CRCs — came
+//! out of the wrong offset, so directories were recreated as zero-byte *files*
+//! and every extracted file failed its CRC. Sizes and names, stored *before*
+//! the time field, were perfect, so a listing looked correct throughout.
+//!
+//! Nothing here parses a block, a descriptor or a directory. It reads argv,
+//! decides which file to open, and calls `darc_arc`. When the format changes,
+//! this cannot fail to notice, because there is nothing here to update.
+//!
+//! # SFX
+//!
+//! Under `--features sfx` the binary is the *prefix* of an archive: the module
+//! is prepended to the archive bytes, so the file on disk is `[stub][archive]`
+//! and `argv[0]` names it. `darc_arc::archive` already handles that — the
+//! footer descriptor is found by scanning back from EOF, and the stub is
+//! whatever sits below the lowest block position. There is no offset to pass.
+
+use darc_arc::{archive, directory::Entry, extract::Layout, passwords::Passwords};
+
+/// What the C's `COMMAND` struct carried, minus the Windows and GUI fields.
+struct Command {
+    /// `l` `v` `t` `x` `e`. SFX defaults to `x`.
+    cmd: char,
+    archive: String,
+    /// `-d<path>`: where to extract.
+    outpath: String,
+    /// `-s`/`-s0`/`-s1`/`-s2`. Only silence is honoured; the C's levels above
+    /// 0 differ in how much progress they draw, and this draws none.
+    silent: u8,
+}
+
+fn usage(program: &str) -> ! {
+    eprintln!(
+        "Usage: {program} <command> [options] <archive> [files...]\n\
+         \n\
+         Commands:\n\
+         \x20 l   list files\n\
+         \x20 v   list files verbosely\n\
+         \x20 t   test archive integrity\n\
+         \x20 x   extract, keeping paths\n\
+         \x20 e   extract, ignoring paths\n\
+         \n\
+         Options:\n\
+         \x20 -d<path>  extract into <path>\n\
+         \x20 -s[0-2]   quieter output\n\
+         \x20 --        stop parsing options\n\
+         \n\
+         Reads the same archives as `darc`, using the same reader.",
+    );
+    std::process::exit(2)
+}
+
+/// The C's option loop (`unarc.cpp:117-137`), minus the Windows-only and
+/// installer-only flags.
+///
+/// `-y`/`-n` are accepted and ignored rather than refused: this build never
+/// prompts, so both already describe what it does. Refusing them would break
+/// scripts that pass `-y` for the C's benefit.
+fn parse(args: &[String], program: &str) -> Command {
+    let sfx = cfg!(feature = "sfx");
+    let mut cmd = if sfx { 'x' } else { '\0' };
+    let mut archive = if sfx { program.to_string() } else { String::new() };
+    let mut outpath = String::new();
+    let mut silent = 0u8;
+    let mut nooptions = false;
+    let mut rest: Vec<&String> = Vec::new();
+
+    for a in args {
+        if !nooptions && a.starts_with('-') && a.len() > 1 {
+            match a.as_str() {
+                "-l" => cmd = 'l',
+                "-v" => cmd = 'v',
+                "-e" => cmd = 'e',
+                "-x" => cmd = 'x',
+                "-t" => cmd = 't',
+                "-y" | "-n" => {}
+                "-s" | "-s1" => silent = 1,
+                "-s0" => silent = 0,
+                "-s2" => silent = 2,
+                "--" => nooptions = true,
+                s if s.starts_with("-d") => outpath = s[2..].to_string(),
+                _ => usage(program),
+            }
+            continue;
+        }
+        rest.push(a);
+    }
+
+    // Without the SFX feature the first non-option word is the command and the
+    // second is the archive, which is what `unarc x foo.arc` means.
+    let mut it = rest.into_iter();
+    if !sfx {
+        match it.next() {
+            Some(c) if c.len() == 1 => cmd = c.chars().next().unwrap_or('\0'),
+            Some(_) | None => usage(program),
+        }
+        match it.next() {
+            Some(a) => archive = a.clone(),
+            None => usage(program),
+        }
+    }
+    if archive.is_empty() || !matches!(cmd, 'l' | 'v' | 't' | 'x' | 'e') {
+        usage(program);
+    }
+    Command { cmd, archive, outpath, silent }
+}
+
+fn main() {
+    let argv: Vec<String> = std::env::args().collect();
+    let program = argv.first().cloned().unwrap_or_else(|| "unarc".to_string());
+    let c = parse(&argv[1..], &program);
+
+    // No password support yet: the C's SFX modules prompt, and this build has
+    // no console prompt. An encrypted archive therefore fails at the block that
+    // needs a key, with the same diagnosis `darc` gives, rather than silently
+    // extracting nothing.
+    let pw = Passwords::default();
+    let path = std::path::Path::new(&c.archive);
+
+    let info = match archive::read_info(path, &pw) {
+        Ok(i) => i,
+        Err(e) => {
+            eprintln!("ERROR: {}: {e}", c.archive);
+            std::process::exit(2);
+        }
+    };
+
+    let code = match c.cmd {
+        // Listing still lives in the `darc` binary; lifting it needs the local
+        // time formatter, which is FFI and platform-split, so it is a separate
+        // step rather than a rider on this one.
+        'l' | 'v' => {
+            eprintln!("ERROR: listing is not wired up yet; use `darc l`");
+            2
+        }
+        cmd => {
+            let data = match archive::open(path) {
+                Ok(d) => d,
+                Err(e) => {
+                    eprintln!("ERROR: {}: {e}", c.archive);
+                    std::process::exit(2);
+                }
+            };
+            let entries: Vec<Entry> = info.entries.clone();
+            let skip = std::collections::HashSet::new();
+            let layout = match cmd {
+                'e' => Layout { disk_basedir: c.outpath.clone(), ..Layout::flat() },
+                _ => Layout { disk_basedir: c.outpath.clone(), ..Layout::default() },
+            };
+            if c.silent == 0 {
+                let what = if cmd == 't' { "Testing" } else { "Extracting" };
+                println!("{what} {}", c.archive);
+            }
+            darc_arc::extract::run_blocks(
+                &info, &data, &layout, cmd != 't', &pw, &entries, &skip, false,
+            )
+        }
+    };
+    std::process::exit(code);
+}

--- a/rust/difftest/unarc-check.sh
+++ b/rust/difftest/unarc-check.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# The Rust `unarc` against the C one it replaces.
+#
+#   usage: unarc-check.sh [c-unarc] [rust-unarc]
+#
+# This is the migration gate. `Unarc/unarc.cpp` + `ArcStructure.h` + `CUI.h`
+# were a SECOND implementation of the archive reader, and the Rust replacement
+# deliberately is not: it owns no format knowledge and calls `darc-arc`. The
+# thing to prove is therefore not that two parsers agree — it is that dropping
+# the second parser changed nothing a user can see.
+#
+# So this compares the OUTCOME on both sides: exit code, and the extracted tree
+# byte for byte, over archives written with a spread of methods and shapes.
+#
+# What it does NOT compare is console text. The C prints a banner, progress
+# redraws and a timing line; the Rust prints neither. `CLAUDE.md` settled that
+# message-identity is the lowest-priority property here, and `arc-cli-check.sh`
+# records what that cost when it was gated instead.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CUNARC="${1:-$ROOT/Unarc/unarc}"
+RUNARC="${2:-$ROOT/rust/target/release/unarc}"
+
+[ -x "$CUNARC" ] || {
+  echo "no C unarc at $CUNARC -- build it with:" >&2
+  echo "  ./compile-c && make -C Unarc linux" >&2
+  exit 2; }
+( cd "$ROOT/rust" && cargo build --release -q -p darc-unarc -p darc-arc ) || {
+  echo "cargo build failed" >&2; exit 1; }
+[ -x "$RUNARC" ] || { echo "no Rust unarc at $RUNARC" >&2; exit 1; }
+DARC="$ROOT/rust/target/release/darc"
+[ -x "$DARC" ] || { echo "no darc at $DARC" >&2; exit 1; }
+
+W="${TMPDIR:-/tmp}/unarc-check.$$"; mkdir -p "$W"
+trap 'rm -rf "$W"' EXIT
+
+# A tree with the shapes that have broken readers before: nested directories
+# (the entry the 4-byte time field turned into a zero-length file), an empty
+# file, a file whose name needs no escaping but whose CONTENT is incompressible,
+# and enough text to make a solid block worth having.
+mkdir -p "$W/src/sub/deeper" "$W/src/empty-dir"
+printf 'hello\n'  > "$W/src/a.txt"
+printf ''         > "$W/src/zero.bin"
+printf 'nested\n' > "$W/src/sub/b.txt"
+printf 'deeper\n' > "$W/src/sub/deeper/c.txt"
+head -c 40000 /dev/urandom > "$W/src/incompressible.bin"
+awk 'BEGIN{for(i=0;i<4000;i++) printf "compressible line %d\n", i%211}' > "$W/src/text.txt"
+
+fail=0 checked=0
+
+# one <label> <darc-create-args...> -- build an archive, extract it with both,
+# require the same exit code and the same tree.
+one() {
+  local label="$1"; shift
+  checked=$((checked + 1))
+  rm -f "$W/t.arc"; rm -rf "$W/c" "$W/r"; mkdir -p "$W/c" "$W/r"
+  ( cd "$W/src" && "$DARC" a --nodates -y -r "$@" "$W/t.arc" . ) >/dev/null 2>&1
+  [ -f "$W/t.arc" ] || { echo "  NO ARCHIVE [$label]: darc wrote nothing"; fail=$((fail+1)); return; }
+
+  local rc_c=0 rc_r=0
+  ( cd "$W/c" && "$CUNARC" x "$W/t.arc" ) >/dev/null 2>&1 || rc_c=$?
+  ( cd "$W/r" && "$RUNARC" x "$W/t.arc" ) >/dev/null 2>&1 || rc_r=$?
+
+  local bad=""
+  [ "$rc_c" = "$rc_r" ] || bad="$bad exit($rc_c vs $rc_r)"
+  diff -r "$W/c" "$W/r" > "$W/tree.diff" 2>&1 || bad="$bad tree"
+  # ...and both must actually have produced the input back, or the two agreeing
+  # proves only that they failed the same way.
+  diff -r "$W/src" "$W/r" > "$W/orig.diff" 2>&1 || bad="$bad not-the-original"
+
+  if [ -n "$bad" ]; then
+    echo "  DIFF [$label]:$bad"
+    head -4 "$W/tree.diff" 2>/dev/null | sed 's/^/      /'
+    head -4 "$W/orig.diff" 2>/dev/null | sed 's/^/      orig: /'
+    fail=$((fail + 1))
+  fi
+}
+
+echo "C:    $CUNARC"
+echo "Rust: $RUNARC"
+
+one "stored"        -m0
+one "lzma"          -m4
+one "tornado"       -mtor
+one "grzip -mt1"    -mgrzip -mt1
+one "rep+lzma"      -mrep+lzma:d1m
+one "delta+lzma"    -mdelta+lzma:d1m
+one "no-solid"      -m4 -s-
+one "one block"     -m4 -s
+one "lzma2 -mt1"    -mlzma2:d1m -mt1
+
+echo "unarc: $checked archives, $fail differing"
+[ "$checked" -gt 0 ] || { echo "nothing was compared" >&2; exit 1; }
+[ "$fail" -eq 0 ] || exit 1
+
+# ── the comparison must be able to fail ─────────────────────────────────────
+#
+# Everything above passes if both extractors are broken in the same way, or if
+# `diff -r` is comparing two empty directories because neither ran. Prove it
+# separates a good tree from a bad one.
+rm -rf "$W/c" "$W/r"; mkdir -p "$W/c" "$W/r"
+( cd "$W/r" && "$RUNARC" x "$W/t.arc" ) >/dev/null 2>&1
+printf 'sabotage\n' > "$W/c/a.txt"
+if diff -r "$W/c" "$W/r" >/dev/null 2>&1; then
+  echo "SELF-TEST FAILED: a tree with different contents compared equal, so the" >&2
+  echo "comparison above was not looking at the files" >&2
+  exit 1
+fi
+# ...and the extraction must have produced something, or "differs from sabotage"
+# would be satisfied by an empty directory.
+n=$(find "$W/r" -type f | wc -l | tr -d '[:space:]')
+[ "$n" -ge 5 ] || {
+  echo "SELF-TEST FAILED: the Rust extractor wrote $n files, so the runs above" >&2
+  echo "were comparing near-empty trees" >&2
+  exit 1; }
+
+echo "the Rust unarc extracts what the C one does, over $checked archives"


### PR DESCRIPTION
Step 2 of retiring `Unarc/`. `unarc t`, `x` and `e` work; `l`/`v` do not yet and say so.

## It owns no format knowledge, and that is the point

The C++ it replaces — `unarc.cpp` + `ArcStructure.h` + `CUI.h`, ~1,160 lines — was a **second implementation of the archive reader**. That is exactly how `ArcStructure.h` came to read the per-file time field as 4 bytes while `ByteStream` writes `CTime` as 8: directories extracted as zero-byte *files* and every CRC failed, while the listing looked perfect (names and sizes are stored *before* the time field).

This crate parses argv, picks a file, and calls `darc-arc`. There is nothing in it to keep in sync.

## Size — the risk that could have sunk this

| | |
|---|---|
| Rust `unarc` | **1.40 MB** |
| C `unarc` | 3.57 MB |
| C SFX stub | 3.36 MB ← the budget, since the stub is prepended to every archive |

The opposite of a problem.

## The migration gate

`rust/difftest/unarc-check.sh`: nine archives — stored, lzma, tornado, grzip, rep+lzma, delta+lzma, `-s-`, `-s`, lzma2 — extracted by both binaries, requiring the same exit code **and** the same tree **and** that the tree is the original back.

No console text is compared: the C prints a banner, progress and timing, the Rust prints none, and `CLAUDE.md` settled that message-identity is the lowest-priority property here.

**Two self-tests**, because "both extractors agree" is satisfied by both being broken:
- a deliberately different tree must compare unequal
- the extraction must produce ≥5 files, so the comparison isn't looking at empty directories

And verified it fails for real: pointed at a wrapper that extracts *flat* instead of preserving paths, all nine cases report `tree not-the-original`.

Wired into the `unarc-sfx` job, which already builds the C binary it needs.

## Deliberately not done here

`l`/`v` exit 2 with a message. Listing needs `list()` lifted out of `bin/darc.rs`, and that pulls in the local-time formatter — FFI with a platform split. That's a separate step, not a rider on this one.

696 tests, `arc-golden-check` 118/118, clippy gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)