### PR TITLE
arc: `a` on an existing archive adds to it again

### DIFF
--- a/rust/darc-arc/src/bin/darc.rs
+++ b/rust/darc-arc/src/bin/darc.rs
@@ -1652,9 +1652,25 @@ fn add(
     // (Arc.hs:200). The filespecs are archive names, not file patterns.
     let joining = command == "j";
 
-    if (archive_only || joining || update_type != darc_arc::joinlist::UpdateType::Add)
-        && std::path::Path::new(archive_name).exists()
-    {
+    // The input archive is read whenever there IS one. The condition used to
+    // exclude `UpdateType::Add`, and that was simply wrong: `arc a` on an
+    // existing archive ADDS to it. Excluding it meant the old archive was never
+    // read, so `main_list` was empty, and `joinlist::merge`'s "if one of the
+    // lists is empty, return the other" arm returned the disk list alone --
+    // `darc a x.arc b.txt` on an archive holding `a.txt` wrote an archive
+    // holding `b.txt`, silently destroying the rest of it along with the
+    // comment, the lock and any SFX stub.
+    //
+    // Measured against the oracle, same corpus: the reference's `a` onto an
+    // existing archive lists both files, the port's listed one. Nothing else
+    // was wrong -- `merge` already implements Add correctly, taking the disk
+    // file where the names collide and keeping the archive's where they do not.
+    // It was never reached.
+    //
+    // Why it survived: `arc-update-check.sh` exercises `u`, `f` and `--sync`
+    // against an existing archive, and plain `a` only ever against a fresh
+    // name. A case for it is added there.
+    if std::path::Path::new(archive_name).exists() {
         let info = match archive::read_info(std::path::Path::new(archive_name), pw) {
             Ok(i) => i,
             Err(e) => {

--- a/rust/difftest/arc-update-check.sh
+++ b/rust/difftest/arc-update-check.sh
@@ -145,6 +145,46 @@ for m in -m0 -m1 -m4 -m9; do
   done
 done
 
+# Plain `a` onto an EXISTING archive. The loop above covers -u, -f and --sync
+# there; `a` was only ever run against a fresh name, and that gap hid a real
+# defect for as long as it existed: the port skipped reading the input archive
+# whenever the update type was Add, so `darc a x.arc b.txt` wrote an archive
+# holding b.txt alone and destroyed everything x.arc already had -- the files,
+# the comment, the lock and any SFX stub.
+#
+# Two shapes, because they exercise different arms of `merge`: a name the
+# archive does NOT have (it must be kept alongside), and one it does (the disk
+# copy must win, which is what distinguishes `a` from `f`).
+for m in -m0 -m1 -m4; do
+  for shape in add-new replace-existing; do
+    checked=$((checked + 1))
+    build_tree "$W/src"
+    rm -f "$W/ref.arc" "$W/port.arc"
+    ( cd "$W/src" && "$REF" a --nodates -y "$m" "$W/ref.arc" older.txt same.txt ) >/dev/null 2>&1
+    cp "$W/ref.arc" "$W/port.arc"
+    case "$shape" in
+      add-new)          second=newer.txt ;;
+      # Rewritten first, so the disk copy genuinely differs from the archived
+      # one; otherwise "the disk won" and "nothing happened" look the same.
+      replace-existing) second=same.txt; printf 'rewritten on disk\n' > "$W/src/same.txt" ;;
+    esac
+    ( cd "$W/src" && "$REF"  a --nodates -y "$m" "$W/ref.arc"  "$second" ) >/dev/null 2>&1
+    ( cd "$W/src" && "$PORT" a --nodates -y "$m" "$W/port.arc" "$second" ) >/dev/null 2>&1
+
+    if ! cmp -s "$W/ref.arc" "$W/port.arc"; then
+      echo "  DIFF [$m a $shape]: $(wc -c <"$W/ref.arc") vs $(wc -c <"$W/port.arc") bytes"
+      fail=$((fail + 1))
+    fi
+    # Byte equality would also hold if both sides destroyed the archive the
+    # same way, and the reference does not -- but this harness gates the port,
+    # so say what the archive must CONTAIN rather than only that the two agree.
+    if ! saw 'older.txt' "$PORT" l "$W/port.arc"; then
+      echo "  DIFF [$m a $shape]: the port dropped a file the archive already had"
+      fail=$((fail + 1))
+    fi
+  done
+done
+
 # The delete command. Filespecs match on the BASE NAME by default, so "a.txt"
 # deletes every a.txt at any depth and "*" takes the directories too -- which
 # empties the archive, and an emptied archive is REMOVED rather than written.


### PR DESCRIPTION
Found while writing #154's harness, kept out of that PR as a separate defect.

`darc a x.arc b.txt` on an archive that already held `a.txt` wrote an archive holding **`b.txt` alone**. Everything `x.arc` had — the other files, the comment, the lock, an SFX stub and its autorun command — was destroyed, and it reported `All OK`.

## Cause

One condition. The input archive was read only when

```
archive_only || joining || update_type != UpdateType::Add
```

so the one update type that *is* `a` skipped it. `main_list` was empty, and `joinlist::merge`'s "if one of the lists is empty, simply return the other one" arm returned the disk list alone.

Nothing else was wrong. `merge` implements `Add` correctly — the disk file wins where names collide, the archive's is kept where they do not. **It was never reached.** The guard is now just "there is an archive to read".

## Measured

Same corpus, against the oracle: `arc-ghc a` onto an existing archive lists both files, the port listed one. With the fix the two archives are **byte-identical** — so this was a missing read, not a different merge.

## Why it survived

`arc-update-check.sh` ran `u`, `f` and `--sync` against an existing archive, and plain `a` only ever against a fresh name. The harness had a hole exactly the shape of the bug.

Six cases close it, over `-m0`/`-m1`/`-m4` and two shapes, because they reach different arms of `merge`: a name the archive does **not** have (must be kept alongside), and one it **does** (the disk copy must win — what separates `a` from `f`). The second rewrites the file on disk first, so "the disk won" and "nothing happened" cannot look alike.

Each case also asserts what the archive must **contain**, not only that the two binaries agree: byte equality would also hold if both sides destroyed the archive the same way. The reference doesn't, but this harness gates the port.

Falsified by restoring the old condition: exactly the 6 new cases fail, 6 of 54.

## Verification

`arc-update-check` 54/54, and every other reference harness re-run unchanged — create, copy, move, cli, solid, filter, list, extract, test, recovery, fit, canonize, listfile, crypt, multimedia, recover, config, unarc, sfx-autorun. golden 118/118, run-tests 24/0/0, nextest 700/700, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)